### PR TITLE
1 feature batch add and batch remove for omnifocus mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Some ways you could use it:
 - Translate the PDF of a syllabus into a fully specificed project with tasks, tags, defer dates, and due dates.
 - Turn a meeting transcript into a list of actions
 - Create visualizations of your tasks, projects, and tags
+- Process multiple tasks or projects in a single operation
+- Bulk manage your OmniFocus items efficiently
 
 
 ## 🚀 Quick Start
@@ -61,6 +63,13 @@ Get a summary of your current tasks and manage them conversationally:
 Extract action items from meeting transcripts, academic research articles, or notes:
 
 > "I'm pasting in the transcript from today's product meeting. Please analyze it and create tasks in OmniFocus for any action items assigned to me. Put them in my 'Product Development' project."
+
+### Batch Operations
+
+Manage multiple items efficiently:
+
+> "I have a list of 20 tasks from this meeting transcript. Please add them all to my 'Q2 Planning' project with appropriate tags and due dates."
+
 
 ## 🔧 Available Tools
 
@@ -112,6 +121,32 @@ Parameters:
 - `name`: (Optional) The name of the task or project to edit
 - `itemType`: The type of item to edit ('task' or 'project')
 - Various parameters for editing properties
+
+### `batch_add_items`
+Add multiple tasks or projects to OmniFocus in a single operation.
+
+Parameters:
+- `items`: Array of items to add, where each item can be:
+  - `type`: The type of item ('task' or 'project')
+  - `name`: The name of the item
+  - `note`: (Optional) Additional notes
+  - `dueDate`: (Optional) Due date in ISO format
+  - `deferDate`: (Optional) Defer date in ISO format
+  - `flagged`: (Optional) Whether the item is flagged
+  - `estimatedMinutes`: (Optional) Estimated completion time
+  - `tags`: (Optional) Array of tags
+  - `projectName`: (Optional) For tasks: the project to add to
+  - `folderName`: (Optional) For projects: the folder to add to
+  - `sequential`: (Optional) For projects: whether tasks are sequential
+
+### `batch_remove_items`
+Remove multiple tasks or projects from OmniFocus in a single operation.
+
+Parameters:
+- `items`: Array of items to remove, where each item can be:
+  - `id`: (Optional) The ID of the item to remove
+  - `name`: (Optional) The name of the item to remove
+  - `itemType`: The type of item ('task' or 'project')
 
 ## 🛠 Development
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,8 @@ import * as addOmniFocusTaskTool from './tools/definitions/addOmniFocusTask.js';
 import * as addProjectTool from './tools/definitions/addProject.js';
 import * as removeItemTool from './tools/definitions/removeItem.js';
 import * as editItemTool from './tools/definitions/editItem.js';
+import * as batchAddItemsTool from './tools/definitions/batchAddItems.js';
+import * as batchRemoveItemsTool from './tools/definitions/batchRemoveItems.js';
 
 // Create an MCP server
 const server = new McpServer({
@@ -50,6 +52,20 @@ server.tool(
   "Edit a task or project in OmniFocus",
   editItemTool.schema.shape,
   editItemTool.handler
+);
+
+server.tool(
+  "batch_add_items",
+  "Add multiple tasks or projects to OmniFocus in a single operation",
+  batchAddItemsTool.schema.shape,
+  batchAddItemsTool.handler
+);
+
+server.tool(
+  "batch_remove_items",
+  "Remove multiple tasks or projects from OmniFocus in a single operation",
+  batchRemoveItemsTool.schema.shape,
+  batchRemoveItemsTool.handler
 );
 
 // Start the MCP server

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import { batchAddItems, BatchAddItemsParams } from '../primitives/batchAddItems.js';
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+
+export const schema = z.object({
+  items: z.array(z.object({
+    type: z.enum(['task', 'project']).describe("Type of item to add ('task' or 'project')"),
+    name: z.string().describe("The name of the item"),
+    note: z.string().optional().describe("Additional notes for the item"),
+    dueDate: z.string().optional().describe("The due date in ISO format (YYYY-MM-DD or full ISO date)"),
+    deferDate: z.string().optional().describe("The defer date in ISO format (YYYY-MM-DD or full ISO date)"),
+    flagged: z.boolean().optional().describe("Whether the item is flagged or not"),
+    estimatedMinutes: z.number().optional().describe("Estimated time to complete the item, in minutes"),
+    tags: z.array(z.string()).optional().describe("Tags to assign to the item"),
+    
+    // Task-specific properties
+    projectName: z.string().optional().describe("For tasks: The name of the project to add the task to"),
+    
+    // Project-specific properties
+    folderName: z.string().optional().describe("For projects: The name of the folder to add the project to"),
+    sequential: z.boolean().optional().describe("For projects: Whether tasks in the project should be sequential")
+  })).describe("Array of items (tasks or projects) to add")
+});
+
+export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {
+  try {
+    // Call the batchAddItems function
+    const result = await batchAddItems(args.items as BatchAddItemsParams[]);
+    
+    if (result.success) {
+      const successCount = result.results.filter(r => r.success).length;
+      const failureCount = result.results.filter(r => !r.success).length;
+      
+      let message = `✅ Successfully added ${successCount} items.`;
+      
+      if (failureCount > 0) {
+        message += ` ⚠️ Failed to add ${failureCount} items.`;
+      }
+      
+      // Include details about added items
+      const details = result.results.map((item, index) => {
+        if (item.success) {
+          const itemType = args.items[index].type;
+          const itemName = args.items[index].name;
+          return `- ✅ ${itemType}: "${itemName}"`;
+        } else {
+          const itemType = args.items[index].type;
+          const itemName = args.items[index].name;
+          return `- ❌ ${itemType}: "${itemName}" - Error: ${item.error}`;
+        }
+      }).join('\n');
+      
+      return {
+        content: [{
+          type: "text" as const,
+          text: `${message}\n\n${details}`
+        }]
+      };
+    } else {
+      // Batch operation failed completely
+      return {
+        content: [{
+          type: "text" as const,
+          text: `Failed to process batch operation: ${result.error}`
+        }],
+        isError: true
+      };
+    }
+  } catch (err: unknown) {
+    const error = err as Error;
+    console.error(`Tool execution error: ${error.message}`);
+    return {
+      content: [{
+        type: "text" as const,
+        text: `Error processing batch operation: ${error.message}`
+      }],
+      isError: true
+    };
+  }
+} 

--- a/src/tools/definitions/batchRemoveItems.ts
+++ b/src/tools/definitions/batchRemoveItems.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import { batchRemoveItems, BatchRemoveItemsParams } from '../primitives/batchRemoveItems.js';
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+
+export const schema = z.object({
+  items: z.array(z.object({
+    id: z.string().optional().describe("The ID of the task or project to remove"),
+    name: z.string().optional().describe("The name of the task or project to remove (as fallback if ID not provided)"),
+    itemType: z.enum(['task', 'project']).describe("Type of item to remove ('task' or 'project')")
+  })).describe("Array of items (tasks or projects) to remove")
+});
+
+export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {
+  try {
+    // Validate that each item has at least an ID or name
+    for (const item of args.items) {
+      if (!item.id && !item.name) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: "Each item must have either id or name provided to remove it."
+          }],
+          isError: true
+        };
+      }
+    }
+    
+    // Call the batchRemoveItems function
+    const result = await batchRemoveItems(args.items as BatchRemoveItemsParams[]);
+    
+    if (result.success) {
+      const successCount = result.results.filter(r => r.success).length;
+      const failureCount = result.results.filter(r => !r.success).length;
+      
+      let message = `✅ Successfully removed ${successCount} items.`;
+      
+      if (failureCount > 0) {
+        message += ` ⚠️ Failed to remove ${failureCount} items.`;
+      }
+      
+      // Include details about removed items
+      const details = result.results.map((item, index) => {
+        if (item.success) {
+          const itemType = args.items[index].itemType;
+          return `- ✅ ${itemType}: "${item.name}"`;
+        } else {
+          const itemType = args.items[index].itemType;
+          const identifier = args.items[index].id || args.items[index].name;
+          return `- ❌ ${itemType}: ${identifier} - Error: ${item.error}`;
+        }
+      }).join('\n');
+      
+      return {
+        content: [{
+          type: "text" as const,
+          text: `${message}\n\n${details}`
+        }]
+      };
+    } else {
+      // Batch operation failed completely
+      return {
+        content: [{
+          type: "text" as const,
+          text: `Failed to process batch removal: ${result.error}`
+        }],
+        isError: true
+      };
+    }
+  } catch (err: unknown) {
+    const error = err as Error;
+    console.error(`Tool execution error: ${error.message}`);
+    return {
+      content: [{
+        type: "text" as const,
+        text: `Error processing batch removal: ${error.message}`
+      }],
+      isError: true
+    };
+  }
+} 

--- a/src/tools/primitives/batchAddItems.ts
+++ b/src/tools/primitives/batchAddItems.ts
@@ -1,0 +1,116 @@
+import { addOmniFocusTask, AddOmniFocusTaskParams } from './addOmniFocusTask.js';
+import { addProject, AddProjectParams } from './addProject.js';
+
+// Define the parameters for the batch operation
+export type BatchAddItemsParams = {
+  type: 'task' | 'project';
+  name: string;
+  note?: string;
+  dueDate?: string;
+  deferDate?: string;
+  flagged?: boolean;
+  estimatedMinutes?: number;
+  tags?: string[];
+  projectName?: string; // For tasks
+  folderName?: string; // For projects
+  sequential?: boolean; // For projects
+};
+
+// Define the result type for individual operations
+type ItemResult = {
+  success: boolean;
+  id?: string;
+  error?: string;
+};
+
+// Define the result type for the batch operation
+type BatchResult = {
+  success: boolean;
+  results: ItemResult[];
+  error?: string;
+};
+
+/**
+ * Add multiple items (tasks or projects) to OmniFocus
+ */
+export async function batchAddItems(items: BatchAddItemsParams[]): Promise<BatchResult> {
+  try {
+    // Results array to track individual operation outcomes
+    const results: ItemResult[] = [];
+    
+    // Process each item in sequence
+    for (const item of items) {
+      try {
+        if (item.type === 'task') {
+          // Extract task-specific params
+          const taskParams: AddOmniFocusTaskParams = {
+            name: item.name,
+            note: item.note,
+            dueDate: item.dueDate,
+            deferDate: item.deferDate,
+            flagged: item.flagged,
+            estimatedMinutes: item.estimatedMinutes,
+            tags: item.tags,
+            projectName: item.projectName
+          };
+          
+          // Add task
+          const taskResult = await addOmniFocusTask(taskParams);
+          results.push({
+            success: taskResult.success,
+            id: taskResult.taskId,
+            error: taskResult.error
+          });
+        } else if (item.type === 'project') {
+          // Extract project-specific params
+          const projectParams: AddProjectParams = {
+            name: item.name,
+            note: item.note,
+            dueDate: item.dueDate,
+            deferDate: item.deferDate,
+            flagged: item.flagged,
+            estimatedMinutes: item.estimatedMinutes,
+            tags: item.tags,
+            folderName: item.folderName,
+            sequential: item.sequential
+          };
+          
+          // Add project
+          const projectResult = await addProject(projectParams);
+          results.push({
+            success: projectResult.success,
+            id: projectResult.projectId,
+            error: projectResult.error
+          });
+        } else {
+          // Invalid type
+          results.push({
+            success: false,
+            error: `Invalid item type: ${(item as any).type}`
+          });
+        }
+      } catch (itemError: any) {
+        // Handle individual item errors
+        results.push({
+          success: false,
+          error: itemError.message || "Unknown error processing item"
+        });
+      }
+    }
+    
+    // Determine overall success (true if at least one item was added successfully)
+    const overallSuccess = results.some(result => result.success);
+    
+    return {
+      success: overallSuccess,
+      results: results
+    };
+  } catch (error: any) {
+    console.error("Error in batchAddItems:", error);
+    return {
+      success: false,
+      results: [],
+      error: error.message || "Unknown error in batchAddItems"
+    };
+  }
+} 

--- a/src/tools/primitives/batchRemoveItems.ts
+++ b/src/tools/primitives/batchRemoveItems.ts
@@ -1,0 +1,64 @@
+import { removeItem, RemoveItemParams } from './removeItem.js';
+
+// Define the parameters for the batch removal operation
+export type BatchRemoveItemsParams = RemoveItemParams;
+
+// Define the result type for individual operations
+type ItemResult = {
+  success: boolean;
+  id?: string;
+  name?: string;
+  error?: string;
+};
+
+// Define the result type for the batch operation
+type BatchResult = {
+  success: boolean;
+  results: ItemResult[];
+  error?: string;
+};
+
+/**
+ * Remove multiple items (tasks or projects) from OmniFocus
+ */
+export async function batchRemoveItems(items: BatchRemoveItemsParams[]): Promise<BatchResult> {
+  try {
+    // Results array to track individual operation outcomes
+    const results: ItemResult[] = [];
+    
+    // Process each item in sequence
+    for (const item of items) {
+      try {
+        // Remove item
+        const itemResult = await removeItem(item);
+        results.push({
+          success: itemResult.success,
+          id: itemResult.id,
+          name: itemResult.name,
+          error: itemResult.error
+        });
+      } catch (itemError: any) {
+        // Handle individual item errors
+        results.push({
+          success: false,
+          error: itemError.message || "Unknown error processing item"
+        });
+      }
+    }
+    
+    // Determine overall success (true if at least one item was removed successfully)
+    const overallSuccess = results.some(result => result.success);
+    
+    return {
+      success: overallSuccess,
+      results: results
+    };
+  } catch (error: any) {
+    console.error("Error in batchRemoveItems:", error);
+    return {
+      success: false,
+      results: [],
+      error: error.message || "Unknown error in batchRemoveItems"
+    };
+  }
+} 


### PR DESCRIPTION
This pull request introduces batch operations for adding and removing multiple OmniFocus items in a single operation, enhancing the efficiency of managing tasks and projects. The changes include updates to the documentation, server configuration, and the implementation of new batch operation tools.

### Documentation Updates:
* Added descriptions for batch operations and their parameters in the `README.md` file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R73) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125-R150)

### Server Configuration:
* Imported and registered new tools for batch adding and removing items in `src/server.ts`. [[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R12-R13) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R57-R70)

### New Tools:
* Implemented `batchAddItems` tool in `src/tools/definitions/batchAddItems.ts` to handle adding multiple tasks or projects.
* Implemented `batchRemoveItems` tool in `src/tools/definitions/batchRemoveItems.ts` to handle removing multiple tasks or projects.

### Primitives:
* Created `batchAddItems` function in `src/tools/primitives/batchAddItems.ts` to process adding items.
* Created `batchRemoveItems` function in `src/tools/primitives/batchRemoveItems.ts` to process removing items.