### PR TITLE
feat: Implement hierarchical task creation with parent-child relationships in OmniFocus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ exampleDump.txt
 MCP_OPTIMIZATION_STRATEGY.md
 DEPLOYMENT_GUIDE.md
 Roadmap.md
+AGENTS.md
+GEMINI.md

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Parameters:
 - `flagged`: (Optional) Whether the task is flagged or not
 - `estimatedMinutes`: (Optional) Estimated time to complete the task
 - `tags`: (Optional) Tags to assign to the task
+ - `parentTaskId`: (Optional) Create under an existing parent task by ID
+ - `parentTaskName`: (Optional) Create under first matching parent task by name (fallback)
 
 ### `add_project`
 Add a new project to OmniFocus.
@@ -188,6 +190,22 @@ Parameters:
   - `projectName`: (Optional) For tasks: the project to add to
   - `folderName`: (Optional) For projects: the folder to add to
   - `sequential`: (Optional) For projects: whether tasks are sequential
+  - `parentTaskId`: (Optional, tasks): Parent task by ID
+  - `parentTaskName`: (Optional, tasks): Parent task by name (fallback)
+  - `tempId`: (Optional, tasks): Temporary ID for within-batch references
+  - `parentTempId`: (Optional, tasks): Reference to another item's `tempId` to establish hierarchy
+  - `hierarchyLevel`: (Optional, tasks): Ordering hint (0 for root, 1 for child, ...)
+
+Examples:
+```
+{
+  "items": [
+    { "type": "task", "name": "Parent", "projectName": "My Project", "tempId": "p1" },
+    { "type": "task", "name": "Child A", "parentTempId": "p1" },
+    { "type": "task", "name": "Child B", "parentTempId": "p1" }
+  ]
+}
+```
 
 ### `batch_remove_items`
 Remove multiple tasks or projects from OmniFocus in a single operation.

--- a/docs/hierarchy-testing.md
+++ b/docs/hierarchy-testing.md
@@ -1,0 +1,17 @@
+# Hierarchical Task Creation – Manual Test Checklist
+
+- Single add under parent by ID:
+  - Create a parent task; capture its ID (via `query_omnifocus` or UI).
+  - Call `add_omnifocus_task` with `parentTaskId` and verify child appears under parent.
+- Single add under parent by name (fallback):
+  - Ensure a unique parent task name in the target project.
+  - Call `add_omnifocus_task` with `projectName` + `parentTaskName`; verify placement.
+- Batch hierarchy with tempId/parentTempId:
+  - Send three items: parent (with `tempId`), two children using `parentTempId`.
+  - Verify ordering and parent-child relationship in OmniFocus.
+- Mixed batch with existing parent:
+  - Use `parentTaskId` for one child and `parentTempId` for another referencing a new parent in the same batch.
+- Error cases:
+  - Unknown `parentTempId` → item reports `Unknown parentTempId`.
+  - Cyclic references (A->B, B->A) → items report cycle detection.
+  - Missing `projectName` + missing parent → item is created in Inbox.

--- a/docs/pr-notes.md
+++ b/docs/pr-notes.md
@@ -1,0 +1,59 @@
+# PR: Hierarchical Task Creation and Batch Hierarchy Support
+
+## Summary
+- Adds first-class support for creating parent–child task hierarchies in OmniFocus via MCP.
+- Extends single-task and batch APIs with parent-reference fields, dependency-aware ordering, and clear error reporting.
+
+## Motivation
+- Fills a major gap: previously only flat tasks were created, forcing manual re-organization.
+- Enables assistants to preserve structure from transcripts, plans, and documents.
+
+## What’s Included
+- Single add (`add_omnifocus_task`)
+  - New fields: `parentTaskId`, `parentTaskName`, `hierarchyLevel` (ignored for single adds).
+  - Accurate placement messages derived from the created task’s actual container.
+  - Warning appended when a requested parent isn’t found.
+- Batch add (`batch_add_items`)
+  - New fields: `tempId`, `parentTempId`, `parentTaskId`, `parentTaskName`, `hierarchyLevel`.
+  - Dependency-aware ordering with `tempId` → real ID mapping.
+  - Cycle detection with human-readable paths (e.g., `A -> B -> A`).
+  - Specific errors for `Unknown parentTempId`.
+- Robust AppleScript execution
+  - Scripts are written to a temp file and executed with `osascript <file>` to avoid quoting/escaping issues.
+
+## Usage Examples
+- Single child by ID:
+  ```json
+  { "name": "Child", "projectName": "Project", "parentTaskId": "<ID>" }
+  ```
+- Batch with temp mapping:
+  ```json
+  { "items": [
+    { "type": "task", "name": "Parent", "projectName": "P", "tempId": "p1" },
+    { "type": "task", "name": "Child A", "parentTempId": "p1" }
+  ] }
+  ```
+
+## Testing & QA
+- Parent by ID: PASS (message: “under the parent task”).
+- Parent by Name (valid): PASS.
+- Parent by Name (invalid): PASS (project placement + warning).
+- Cycle detection: PASS (clear path message).
+- Unknown parentTempId: PASS (specific error; others proceed).
+- Inbox creation and flat adds: PASS.
+- Mixed batch with projects/tasks: PASS.
+
+## Backward Compatibility
+- Flat creation continues to work.
+- Name-based parent lookup is constrained to the specified `projectName` when provided; otherwise uses global first match.
+
+## Files Changed (high level)
+- `src/tools/definitions/addOmniFocusTask.ts`: zod schema additions, improved handler messaging.
+- `src/tools/definitions/batchAddItems.ts`: zod schema additions, clearer failure reporting.
+- `src/tools/primitives/addOmniFocusTask.ts`: parent resolution, container-based placement, temp-file AppleScript execution.
+- `src/tools/primitives/batchAddItems.ts`: ordering, `tempId` mapping, cycle/unknown-parent validation.
+- `README.md`, `docs/hierarchy-testing.md`.
+
+## Notes
+- Prefer `parentTaskId` for precision; name-based matches can be ambiguous.
+- Inbox fallback preserved when neither project nor parent is resolved.

--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -10,32 +10,50 @@ export const schema = z.object({
   flagged: z.boolean().optional().describe("Whether the task is flagged or not"),
   estimatedMinutes: z.number().optional().describe("Estimated time to complete the task, in minutes"),
   tags: z.array(z.string()).optional().describe("Tags to assign to the task"),
-  projectName: z.string().optional().describe("The name of the project to add the task to (will add to inbox if not specified)")
+  projectName: z.string().optional().describe("The name of the project to add the task to (will add to inbox if not specified)"),
+  // Hierarchy support
+  parentTaskId: z.string().optional().describe("ID of the parent task (preferred for accuracy)"),
+  parentTaskName: z.string().optional().describe("Name of the parent task (used if ID not provided; matched within project or globally if no project)"),
+  hierarchyLevel: z.number().int().min(0).optional().describe("Explicit level indicator for ordering in batch workflows (0=root) - ignored in single add")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {
   try {
     // Call the addOmniFocusTask function 
     const result = await addOmniFocusTask(args as AddOmniFocusTaskParams);
+    console.error('[add_omnifocus_task] args:', JSON.stringify(args));
+    console.error('[add_omnifocus_task] result:', JSON.stringify(result));
     
     if (result.success) {
-      // Task was added successfully
-      let locationText = args.projectName 
-        ? `in project "${args.projectName}"` 
-        : "in your inbox";
-        
-      let tagText = args.tags && args.tags.length > 0
+      // Determine actual placement
+      const placement = (result as any).placement as 'parent' | 'project' | 'inbox' | undefined;
+      let locationText = '';
+      if (placement === 'parent') {
+        locationText = 'under the parent task';
+      } else if (placement === 'project') {
+        locationText = args.projectName ? `in project "${args.projectName}"` : 'in a project';
+      } else {
+        locationText = 'in your inbox';
+      }
+
+      const tagText = args.tags && args.tags.length > 0
         ? ` with tags: ${args.tags.join(', ')}`
-        : "";
-        
-      let dueDateText = args.dueDate
+        : '';
+
+      const dueDateText = args.dueDate
         ? ` due on ${new Date(args.dueDate).toLocaleDateString()}`
-        : "";
-        
+        : '';
+
+      // Warning if parent requested but not used
+      let placementWarning = '';
+      if ((args.parentTaskId || args.parentTaskName) && placement && placement !== 'parent') {
+        placementWarning = `\n⚠️ Parent not found; task created ${placement === 'project' ? 'in project' : 'in inbox'}.`;
+      }
+
       return {
         content: [{
           type: "text" as const,
-          text: `✅ Task "${args.name}" created successfully ${locationText}${dueDateText}${tagText}.`
+          text: `✅ Task "${args.name}" created successfully ${locationText}${dueDateText}${tagText}.${placementWarning}`
         }]
       };
     } else {

--- a/src/tools/primitives/batchAddItems.ts
+++ b/src/tools/primitives/batchAddItems.ts
@@ -12,6 +12,12 @@ export type BatchAddItemsParams = {
   estimatedMinutes?: number;
   tags?: string[];
   projectName?: string; // For tasks
+  // Hierarchy for tasks
+  parentTaskId?: string;
+  parentTaskName?: string;
+  tempId?: string;
+  parentTempId?: string;
+  hierarchyLevel?: number;
   folderName?: string; // For projects
   sequential?: boolean; // For projects
 };
@@ -35,14 +41,115 @@ type BatchResult = {
  */
 export async function batchAddItems(items: BatchAddItemsParams[]): Promise<BatchResult> {
   try {
-    // Results array to track individual operation outcomes
-    const results: ItemResult[] = [];
-    
-    // Process each item in sequence
-    for (const item of items) {
-      try {
-        if (item.type === 'task') {
-          // Extract task-specific params
+    const results: ItemResult[] = new Array(items.length);
+    const processed: boolean[] = new Array(items.length).fill(false);
+    const tempToRealId = new Map<string, string>();
+
+    // Pre-validate cycles in tempId -> parentTempId references
+    const tempIndex = new Map<string, number>();
+    items.forEach((it, idx) => { if (it.tempId) tempIndex.set(it.tempId, idx); });
+
+    // Detect cycles using DFS and capture cycle paths
+    const visiting = new Set<string>();
+    const visited = new Set<string>();
+    const inCycle = new Set<string>();
+    const cycleMessageByTempId = new Map<string, string>();
+    const stack: string[] = [];
+
+    function dfs(tempId: string) {
+      if (visited.has(tempId) || inCycle.has(tempId)) return;
+      if (visiting.has(tempId)) return; // already on stack, handled by caller
+      visiting.add(tempId);
+      stack.push(tempId);
+      const idx = tempIndex.get(tempId)!;
+      const parentTemp = items[idx].parentTempId;
+      if (parentTemp && tempIndex.has(parentTemp)) {
+        if (visiting.has(parentTemp)) {
+          // Found a cycle; construct path
+          const startIdx = stack.indexOf(parentTemp);
+          const cycleIds = stack.slice(startIdx).concat(parentTemp);
+          const cycleNames = cycleIds.map(tid => {
+            const i = tempIndex.get(tid)!;
+            return items[i].name || tid;
+          });
+          const pathText = `${cycleNames.join(' -> ')}`;
+          for (const tid of cycleIds) {
+            inCycle.add(tid);
+            cycleMessageByTempId.set(tid, `Cycle detected: ${pathText}`);
+          }
+        } else {
+          dfs(parentTemp);
+        }
+      }
+      stack.pop();
+      visiting.delete(tempId);
+      visited.add(tempId);
+    }
+
+    for (const tid of tempIndex.keys()) dfs(tid);
+
+    // Mark items that participate in cycles as failed early
+    for (const tid of inCycle) {
+      const idx = tempIndex.get(tid)!;
+      const msg = cycleMessageByTempId.get(tid) || `Cycle detected involving tempId: ${tid}`;
+      results[idx] = { success: false, error: msg };
+      processed[idx] = true;
+    }
+
+    // Mark items with unknown parentTempId (and no explicit parentTaskId) as invalid early
+    items.forEach((it, idx) => {
+      if (processed[idx]) return;
+      if (it.parentTempId && !tempIndex.has(it.parentTempId) && !it.parentTaskId) {
+        results[idx] = { success: false, error: `Unknown parentTempId: ${it.parentTempId}` };
+        processed[idx] = true;
+      }
+    });
+
+    // Stable order: sort by hierarchyLevel (undefined -> 0), then original index
+    const indexed = items.map((it, idx) => ({ ...it, __index: idx }));
+    indexed.sort((a, b) => (a.hierarchyLevel ?? 0) - (b.hierarchyLevel ?? 0) || a.__index - b.__index);
+
+    let madeProgress = true;
+    while (processed.some(p => !p) && madeProgress) {
+      madeProgress = false;
+      for (const item of indexed) {
+        const i = item.__index;
+        if (processed[i]) continue;
+        try {
+          if (item.type === 'project') {
+            const projectParams: AddProjectParams = {
+              name: item.name,
+              note: item.note,
+              dueDate: item.dueDate,
+              deferDate: item.deferDate,
+              flagged: item.flagged,
+              estimatedMinutes: item.estimatedMinutes,
+              tags: item.tags,
+              folderName: item.folderName,
+              sequential: item.sequential
+            };
+
+            const projectResult = await addProject(projectParams);
+            results[i] = {
+              success: projectResult.success,
+              id: projectResult.projectId,
+              error: projectResult.error
+            };
+            processed[i] = true;
+            madeProgress = true;
+            continue;
+          }
+
+          // task
+          let parentTaskId = item.parentTaskId;
+          if (!parentTaskId && item.parentTempId) {
+            parentTaskId = tempToRealId.get(item.parentTempId);
+            if (!parentTaskId) {
+              // Parent not created yet; skip this round
+              continue;
+            }
+          }
+
           const taskParams: AddOmniFocusTaskParams = {
             name: item.name,
             note: item.note,
@@ -51,66 +158,50 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
             flagged: item.flagged,
             estimatedMinutes: item.estimatedMinutes,
             tags: item.tags,
-            projectName: item.projectName
+            projectName: item.projectName,
+            parentTaskId,
+            parentTaskName: item.parentTaskName,
+            hierarchyLevel: item.hierarchyLevel
           };
-          
-          // Add task
+
           const taskResult = await addOmniFocusTask(taskParams);
-          results.push({
+          results[i] = {
             success: taskResult.success,
             id: taskResult.taskId,
             error: taskResult.error
-          });
-        } else if (item.type === 'project') {
-          // Extract project-specific params
-          const projectParams: AddProjectParams = {
-            name: item.name,
-            note: item.note,
-            dueDate: item.dueDate,
-            deferDate: item.deferDate,
-            flagged: item.flagged,
-            estimatedMinutes: item.estimatedMinutes,
-            tags: item.tags,
-            folderName: item.folderName,
-            sequential: item.sequential
           };
-          
-          // Add project
-          const projectResult = await addProject(projectParams);
-          results.push({
-            success: projectResult.success,
-            id: projectResult.projectId,
-            error: projectResult.error
-          });
-        } else {
-          // Invalid type
-          results.push({
+          if (item.tempId && taskResult.taskId && taskResult.success) {
+            tempToRealId.set(item.tempId, taskResult.taskId);
+          }
+          processed[i] = true;
+          madeProgress = true;
+        } catch (itemError: any) {
+          results[i] = {
             success: false,
-            error: `Invalid item type: ${(item as any).type}`
-          });
+            error: itemError?.message || 'Unknown error processing item'
+          };
+          processed[i] = true; // avoid infinite loop on thrown errors
+          madeProgress = true;
         }
-      } catch (itemError: any) {
-        // Handle individual item errors
-        results.push({
-          success: false,
-          error: itemError.message || "Unknown error processing item"
-        });
       }
     }
-    
-    // Determine overall success (true if at least one item was added successfully)
-    const overallSuccess = results.some(result => result.success);
-    
-    return {
-      success: overallSuccess,
-      results: results
-    };
+
+    // Any unprocessed due to dependencies/cycles -> fail with message
+    for (const item of indexed) {
+      const i = item.__index;
+      if (!processed[i]) {
+        const reason = item.parentTempId && !tempToRealId.has(item.parentTempId)
+          ? `Unresolved parentTempId: ${item.parentTempId}`
+          : 'Unresolved dependency or cycle';
+        results[i] = { success: false, error: reason };
+        processed[i] = true;
+      }
+    }
+
+    const overallSuccess = results.some(r => r?.success);
+    return { success: overallSuccess, results };
   } catch (error: any) {
-    console.error("Error in batchAddItems:", error);
-    return {
-      success: false,
-      results: [],
-      error: error.message || "Unknown error in batchAddItems"
-    };
+    console.error('Error in batchAddItems:', error);
+    return { success: false, results: [], error: error?.message || 'Unknown error in batchAddItems' };
   }
-} 
+}


### PR DESCRIPTION
# PR: Hierarchical Task Creation and Batch Hierarchy Support

## Summary
- Adds first-class support for creating parent–child task hierarchies in OmniFocus via MCP.
- Extends single-task and batch APIs with parent-reference fields, dependency-aware ordering, and clear error reporting.

## Motivation
- Fills a major gap: previously only flat tasks were created, forcing manual re-organization.
- Enables assistants to preserve structure from transcripts, plans, and documents.

## What’s Included
- Single add (`add_omnifocus_task`)
  - New fields: `parentTaskId`, `parentTaskName`, `hierarchyLevel` (ignored for single adds).
  - Accurate placement messages derived from the created task’s actual container.
  - Warning appended when a requested parent isn’t found.
- Batch add (`batch_add_items`)
  - New fields: `tempId`, `parentTempId`, `parentTaskId`, `parentTaskName`, `hierarchyLevel`.
  - Dependency-aware ordering with `tempId` → real ID mapping.
  - Cycle detection with human-readable paths (e.g., `A -> B -> A`).
  - Specific errors for `Unknown parentTempId`.
- Robust AppleScript execution
  - Scripts are written to a temp file and executed with `osascript <file>` to avoid quoting/escaping issues.

## Usage Examples
- Single child by ID:
  ```json
  { "name": "Child", "projectName": "Project", "parentTaskId": "<ID>" }
  ```
- Batch with temp mapping:
  ```json
  { "items": [
    { "type": "task", "name": "Parent", "projectName": "P", "tempId": "p1" },
    { "type": "task", "name": "Child A", "parentTempId": "p1" }
  ] }
  ```

## Testing & QA
- Parent by ID: PASS (message: “under the parent task”).
- Parent by Name (valid): PASS.
- Parent by Name (invalid): PASS (project placement + warning).
- Cycle detection: PASS (clear path message).
- Unknown parentTempId: PASS (specific error; others proceed).
- Inbox creation and flat adds: PASS.
- Mixed batch with projects/tasks: PASS.

## Backward Compatibility
- Flat creation continues to work.
- Name-based parent lookup is constrained to the specified `projectName` when provided; otherwise uses global first match.

## Files Changed (high level)
- `src/tools/definitions/addOmniFocusTask.ts`: zod schema additions, improved handler messaging.
- `src/tools/definitions/batchAddItems.ts`: zod schema additions, clearer failure reporting.
- `src/tools/primitives/addOmniFocusTask.ts`: parent resolution, container-based placement, temp-file AppleScript execution.
- `src/tools/primitives/batchAddItems.ts`: ordering, `tempId` mapping, cycle/unknown-parent validation.
- `README.md`, `docs/hierarchy-testing.md`.

## Notes
- Prefer `parentTaskId` for precision; name-based matches can be ambiguous.
- Inbox fallback preserved when neither project nor parent is resolved.
