### PR TITLE
Create a perspective rule engine to get perspective tasks

### DIFF
--- a/src/tools/primitives/getPerspectiveView.ts
+++ b/src/tools/primitives/getPerspectiveView.ts
@@ -25,7 +25,7 @@ const requestedLimit = ${limit};
 
 // Load and execute the getPerspectiveView script
 ${await import('fs').then(fs => 
-  fs.readFileSync('/Users/rjames/dev/OmniFocus-MCP/src/utils/omnifocusScripts/getPerspectiveView.js', 'utf8')
+  fs.readFileSync('../../utils/omnifocusScripts/getPerspectiveView.js', 'utf8')
 )}`;
     
     // Write temporary script and execute

--- a/src/tools/primitives/getPerspectiveView.ts
+++ b/src/tools/primitives/getPerspectiveView.ts
@@ -17,26 +17,8 @@ export async function getPerspectiveView(params: GetPerspectiveViewParams): Prom
   const { perspectiveName, limit = 100, includeMetadata = true, fields } = params;
   
   try {
-    // Create a simple script that calls the function with parameters
-    const scriptContent = `
-// Set parameters for perspective view
-const perspectiveName = "${perspectiveName}";
-const requestedLimit = ${limit};
-
-// Load and execute the getPerspectiveView script
-${await import('fs').then(fs => 
-  fs.readFileSync('../../utils/omnifocusScripts/getPerspectiveView.js', 'utf8')
-)}`;
-    
-    // Write temporary script and execute
-    const tempFile = `/tmp/perspective_view_${Date.now()}.js`;
-    const fs = await import('fs');
-    fs.writeFileSync(tempFile, scriptContent);
-    
-    const result = await executeOmniFocusScript(tempFile);
-    
-    // Clean up temp file
-    fs.unlinkSync(tempFile);
+    // Execute the script with arguments using the @ shorthand
+    const result = await executeOmniFocusScript('@getPerspectiveView.js', [perspectiveName, limit.toString()]);
     
     // The result is already parsed JSON from the script
     if (result.error) {
@@ -62,7 +44,7 @@ ${await import('fs').then(fs =>
       });
     }
     
-    // Apply limit
+    // Apply limit (script already limits, but we may filter further)
     if (limit && items.length > limit) {
       items = items.slice(0, limit);
     }

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -1,169 +1,453 @@
-// OmniJS script to get the current perspective view in OmniFocus
-(() => {
+// OmniJS script to get perspective view in OmniFocus using rule evaluation
+// Usage: Call with perspective name and limit as parameters
+// Example: getPerspectiveViewByName("Today", 100)
+
+function getPerspectiveViewByName(perspectiveName, limit = 100) {
   try {
-    // Note: We can't easily switch perspectives via OmniJS
-    // We can only report what's currently visible in the window
+    // Get the specific perspective
+    let currentPerspective = null;
     
-    // Get the current window and its perspective
-    const window = document.windows[0];
-    if (!window) {
-      return JSON.stringify({
-        success: false,
-        error: "No OmniFocus window is open"
-      });
+    // Check built-in perspectives first
+    if (perspectiveName.toLowerCase() === "inbox") {
+      currentPerspective = Perspective.BuiltIn.Inbox;
+    } else if (perspectiveName.toLowerCase() === "projects") {
+      currentPerspective = Perspective.BuiltIn.Projects;
+    } else if (perspectiveName.toLowerCase() === "tags") {
+      currentPerspective = Perspective.BuiltIn.Tags;
+    } else if (perspectiveName.toLowerCase() === "forecast") {
+      currentPerspective = Perspective.BuiltIn.Forecast;
+    } else if (perspectiveName.toLowerCase() === "flagged") {
+      currentPerspective = Perspective.BuiltIn.Flagged;
+    } else if (perspectiveName.toLowerCase() === "review") {
+      currentPerspective = Perspective.BuiltIn.Review;
+    } else {
+      // Look for custom perspective
+      currentPerspective = Perspective.Custom.byName(perspectiveName);
     }
     
-    // Get the current perspective
-    const currentPerspective = window.perspective;
-    let perspectiveName = "Unknown";
+    if (!currentPerspective) {
+      return JSON.stringify({
+        success: false,
+        error: "Could not find perspective named '" + perspectiveName + "'"
+      });
+    }
+    let perspectiveDisplayName = "Unknown";
     
     // Identify the perspective
     if (currentPerspective) {
       if (currentPerspective === Perspective.BuiltIn.Inbox) {
-        perspectiveName = "Inbox";
+        perspectiveDisplayName = "Inbox";
       } else if (currentPerspective === Perspective.BuiltIn.Projects) {
-        perspectiveName = "Projects";
+        perspectiveDisplayName = "Projects";
       } else if (currentPerspective === Perspective.BuiltIn.Tags) {
-        perspectiveName = "Tags";
+        perspectiveDisplayName = "Tags";
       } else if (currentPerspective === Perspective.BuiltIn.Forecast) {
-        perspectiveName = "Forecast";
+        perspectiveDisplayName = "Forecast";
       } else if (currentPerspective === Perspective.BuiltIn.Flagged) {
-        perspectiveName = "Flagged";
+        perspectiveDisplayName = "Flagged";
       } else if (currentPerspective === Perspective.BuiltIn.Review) {
-        perspectiveName = "Review";
+        perspectiveDisplayName = "Review";
       } else if (currentPerspective.name) {
-        // Custom perspective
-        perspectiveName = currentPerspective.name;
+        perspectiveDisplayName = currentPerspective.name;
       }
     }
+
+    // Complete rule evaluation functions based on the specification
+    var evaluateActionAvailability = (task, value) => {
+      let result;
+      if (value === "remaining") {
+        result = !task.completed && task.taskStatus !== Task.Status.Dropped;
+      } else if (value === "completed") {
+        result = task.completed;
+      } else if (value === "dropped") {
+        result = task.taskStatus === Task.Status.Dropped;
+      } else if (value === "available") {
+        // "available" per OmniFocus glossary: Active and Available (not blocked, deferred, or on hold)
+        // Active = not completed/dropped, Available = not blocked/deferred
+        const isActive = !task.completed && task.taskStatus !== Task.Status.Dropped;
+        const isAvailable = task.taskStatus !== Task.Status.Blocked && 
+                           (!task.deferDate || task.deferDate <= new Date());
+        result = isActive && isAvailable;
+      } else if (value === "firstAvailable") {
+        // "firstAvailable" specifically means the Available status
+        result = task.taskStatus === Task.Status.Available;
+      } else {
+        result = false;
+      }
+      return result;
+    };
     
-    // Get visible items based on the perspective
-    const items = [];
-    const selection = window.selection;
-    const selectedTasks = selection.tasks;
-    const selectedProjects = selection.projects;
+    var evaluateActionStatus = (task, value) => {
+      if (value === "due") return task.taskStatus === Task.Status.DueSoon || task.taskStatus === Task.Status.Overdue;
+      if (value === "flagged") return task.flagged;
+      return false;
+    };
     
-    // Helper function to format dates
+    var evaluateActionHasDueDate = (task, value) => (task.dueDate !== null) === value;
+    var evaluateActionHasDeferDate = (task, value) => (task.deferDate !== null) === value;
+    var evaluateActionHasDuration = (task, value) => (task.estimatedMinutes !== null) === value;
+    var evaluateActionWithinDuration = (task, value) => task.estimatedMinutes !== null && task.estimatedMinutes <= value;
+    var evaluateActionIsProject = (task, value) => (task.children && task.children.length > 0 && task.containingProject === null) === value;
+    var evaluateActionIsGroup = (task, value) => (task.children && task.children.length > 0 && task.containingProject !== null) === value;
+    var evaluateActionIsProjectOrGroup = (task, value) => (task.children && task.children.length > 0) === value;
+    var evaluateActionRepeats = (task, value) => (task.repetitionRule !== null) === value;
+    var evaluateActionIsUntagged = (task, value) => (task.tags.length === 0) === value;
+    var evaluateActionHasTagWithStatus = (task, value) => {
+      return task.tags.some(tag => {
+        // Map OmniFocus tag status values
+        if (value === "remaining") return !tag.effectivelyDropped;
+        if (value === "active") return tag.effectivelyActive;
+        if (value === "onHold") return tag.effectivelyOnHold;
+        if (value === "dropped") return tag.effectivelyDropped;
+        return false;
+      });
+    };
+    var evaluateActionIsLeaf = (task, value) => (!task.children || task.children.length === 0) === value;
+    var evaluateActionHasNoProject = (task, value) => (task.containingProject === null) === value;
+    var evaluateActionIsInSingleActionsList = (task, value) => {
+      // Check if task is in a single actions list (project with single action list status)
+      const project = task.containingProject;
+      return project && project.status === Project.Status.SingleActions === value;
+    };
+    var evaluateActionHasProjectWithStatus = (task, value) => {
+      const project = task.containingProject;
+      if (!project) return false;
+      const statusMap = {
+        "active": Project.Status.Active,
+        "remaining": !project.effectivelyCompleted && !project.effectivelyDropped,
+        "onHold": Project.Status.OnHold,
+        "completed": project.effectivelyCompleted,
+        "dropped": project.effectivelyDropped,
+        "stalled": Project.Status.Stalled,
+        "pending": Project.Status.Pending
+      };
+      if (value === "remaining") {
+        return !project.effectivelyCompleted && !project.effectivelyDropped;
+      }
+      return project.status === statusMap[value];
+    };
+    
+    var evaluateActionHasAnyOfTags = (task, value) => {
+      if (!Array.isArray(value) || task.tags.length === 0) return false;
+      const taskTagIds = task.tags.map(tag => tag.id.primaryKey);
+      return value.some(tagId => taskTagIds.includes(tagId));
+    };
+    
+    var evaluateActionHasAllOfTags = (task, value) => {
+      if (!Array.isArray(value) || task.tags.length === 0) return false;
+      const taskTagIds = task.tags.map(tag => tag.id.primaryKey);
+      return value.every(tagId => taskTagIds.includes(tagId));
+    };
+    
+    var evaluateActionWithinFocus = (task, value) => {
+      if (!Array.isArray(value)) return false;
+      
+      // Check if task is within any of the focus projects/folders at any depth
+      function isWithinHierarchy(item) {
+        if (!item) return false;
+        
+        // Check if this item itself is in the focus list
+        if (value.includes(item.id.primaryKey)) {
+          return true;
+        }
+        
+        // For projects, check parent folder hierarchy
+        if (item.parentFolder) {
+          return isWithinHierarchy(item.parentFolder);
+        }
+        
+        // For folders, check parent folder hierarchy  
+        if (item.parent && item.parent !== item) {
+          return isWithinHierarchy(item.parent);
+        }
+        
+        return false;
+      }
+      
+      // Start with the task's containing project
+      if (task.containingProject) {
+        return isWithinHierarchy(task.containingProject);
+      }
+      
+      // If no containing project, check if task itself is somehow in focus
+      return value.includes(task.id.primaryKey);
+    };
+    
+    var evaluateActionMatchingSearch = (task, value) => {
+      if (!Array.isArray(value)) return false;
+      const searchText = (task.name + " " + (task.note || "")).toLowerCase();
+      return value.some(term => searchText.includes(term.toLowerCase()));
+    };
+    
+    // Date evaluation functions
+    var evaluateActionDateIsToday = (task, dateField) => {
+      const fieldDate = task[dateField + 'Date']; // e.g., dueDate, deferDate
+      if (!fieldDate) return false;
+      const today = new Date();
+      return fieldDate.toDateString() === today.toDateString();
+    };
+    
+    var evaluateActionDateIsYesterday = (task, dateField) => {
+      const fieldDate = task[dateField + 'Date'];
+      if (!fieldDate) return false;
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      return fieldDate.toDateString() === yesterday.toDateString();
+    };
+    
+    var evaluateActionDateIsTomorrow = (task, dateField) => {
+      const fieldDate = task[dateField + 'Date'];
+      if (!fieldDate) return false;
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      return fieldDate.toDateString() === tomorrow.toDateString();
+    };
+
+    var possibleRuleTypes = {
+        'actionAvailability': evaluateActionAvailability,
+        'actionStatus': evaluateActionStatus,
+        'actionHasDueDate': evaluateActionHasDueDate,
+        'actionHasDeferDate': evaluateActionHasDeferDate,
+        'actionHasDuration': evaluateActionHasDuration,
+        'actionWithinDuration': evaluateActionWithinDuration,
+        'actionIsProject': evaluateActionIsProject,
+        'actionIsGroup': evaluateActionIsGroup,
+        'actionIsProjectOrGroup': evaluateActionIsProjectOrGroup,
+        'actionRepeats': evaluateActionRepeats,
+        'actionIsUntagged': evaluateActionIsUntagged,
+        'actionHasTagWithStatus': evaluateActionHasTagWithStatus,
+        'actionHasAnyOfTags': evaluateActionHasAnyOfTags,
+        'actionHasAllOfTags': evaluateActionHasAllOfTags,
+        'actionIsLeaf': evaluateActionIsLeaf,
+        'actionHasNoProject': evaluateActionHasNoProject,
+        'actionIsInSingleActionsList': evaluateActionIsInSingleActionsList,
+        'actionHasProjectWithStatus': evaluateActionHasProjectWithStatus,
+        'actionWithinFocus': evaluateActionWithinFocus,
+        'actionMatchingSearch': evaluateActionMatchingSearch,
+    };
+
+    function evaluateRule(task, rule) {
+      // Handle complex date field rules
+      if (rule.actionDateField) {
+        const dateField = rule.actionDateField;
+        
+        // Check for date-specific conditions
+        if (rule.actionDateIsToday) {
+          return evaluateActionDateIsToday(task, dateField);
+        }
+        if (rule.actionDateIsYesterday) {
+          return evaluateActionDateIsYesterday(task, dateField);
+        }
+        if (rule.actionDateIsTomorrow) {
+          return evaluateActionDateIsTomorrow(task, dateField);
+        }
+        
+        // Add other date conditions as needed
+        return false;
+      }
+      
+      // Handle standard rules
+      for (const [key, value] of Object.entries(rule)) {
+        if (possibleRuleTypes[key]) {
+          return possibleRuleTypes[key](task, value);
+        }
+      }
+      
+      return false;
+    }
+
+    function evaluateTask(task, filters, aggregationType = "all") {
+      if (!Array.isArray(filters) || filters.length === 0) return true;
+      
+      const results = filters.map(filter => {
+        if (filter.aggregateType && filter.aggregateRules) {
+          // Handle nested aggregate rules
+          return evaluateTask(task, filter.aggregateRules, filter.aggregateType);
+        } else {
+          // Handle single rule
+          return evaluateRule(task, filter);
+        }
+      });
+      
+      switch (aggregationType) {
+        case "any":
+          return results.some(result => result);
+        case "all":
+          return results.every(result => result);
+        case "none":
+          return results.every(result => !result);
+        default:
+          return results.every(result => result);
+      }
+    }
+
+    // Helper functions
     function formatDate(date) {
       if (!date) return null;
       return date.toISOString();
     }
     
-    // Helper to get task details
     function getTaskDetails(task) {
-      const details = {
-        id: task.id.primaryKey,
-        name: task.name,
-        completed: task.completed,
-        flagged: task.flagged,
-        note: task.note || '',
-        dueDate: formatDate(task.dueDate),
-        deferDate: formatDate(task.deferDate),
-        completionDate: formatDate(task.completionDate),
-        estimatedMinutes: task.estimatedMinutes
-      };
+      // Helper to safely get string values
+      function safeString(value) {
+        if (value == null) return null;
+        return String(value).replace(/[\u0000-\u001F\u007F-\u009F]/g, ''); // Remove control characters
+      }
       
-      // Task status
-      const statusMap = {
+      // Task status mapping to match queryOmnifocus.ts
+      const taskStatusMap = {
         [Task.Status.Available]: "Available",
-        [Task.Status.Blocked]: "Blocked",
+        [Task.Status.Blocked]: "Blocked", 
         [Task.Status.Completed]: "Completed",
         [Task.Status.Dropped]: "Dropped",
         [Task.Status.DueSoon]: "DueSoon",
         [Task.Status.Next]: "Next",
         [Task.Status.Overdue]: "Overdue"
       };
-      details.taskStatus = statusMap[task.taskStatus] || "Unknown";
       
-      // Project context
-      const project = task.containingProject;
-      details.projectName = project ? project.name : null;
-      
-      // Tags
-      details.tagNames = task.tags.map(tag => tag.name);
-      
-      return details;
-    }
-    
-    // Get project details
-    function getProjectDetails(project) {
       return {
-        id: project.id.primaryKey,
-        name: project.name,
-        type: 'project',
-        status: project.status,
-        note: project.note || '',
-        flagged: project.flagged || false,
-        dueDate: formatDate(project.dueDate),
-        deferDate: formatDate(project.deferDate),
-        folderName: project.parentFolder ? project.parentFolder.name : null
+        id: safeString(task.id.primaryKey),
+        name: safeString(task.name),
+        completed: Boolean(task.completed),
+        flagged: Boolean(task.flagged),
+        note: safeString(task.note) || '',
+        dueDate: formatDate(task.dueDate),
+        deferDate: formatDate(task.deferDate),
+        completionDate: formatDate(task.completionDate),
+        estimatedMinutes: task.estimatedMinutes ? Number(task.estimatedMinutes) : null,
+        taskStatus: taskStatusMap[task.taskStatus] || "Unknown",
+        projectName: task.containingProject ? safeString(task.containingProject.name) : null,
+        tagNames: (task.tags || []).map(tag => safeString(tag.name)).filter(name => name)
       };
     }
+
+    // Get perspective rules if available
+    let perspectiveRules = null;
+    let perspectiveAggregation = "all";
+    let isCustomPerspective = false;
     
-    // Try to get content based on perspective type
-    if (perspectiveName === "Inbox") {
-      // Get inbox tasks - inbox is a global in OmniJS
-      inbox.forEach(task => {
-        items.push(getTaskDetails(task));
-      });
-    } else if (perspectiveName === "Projects") {
-      // Get all projects - using flattenedProjects global
-      flattenedProjects.forEach(project => {
-        if (project.status === Project.Status.Active) {
-          items.push(getProjectDetails(project));
+    try {
+      // Check if it's a custom perspective (not a built-in one)
+      isCustomPerspective = currentPerspective && 
+                           currentPerspective !== Perspective.BuiltIn.Inbox &&
+                           currentPerspective !== Perspective.BuiltIn.Projects &&
+                           currentPerspective !== Perspective.BuiltIn.Tags &&
+                           currentPerspective !== Perspective.BuiltIn.Forecast &&
+                           currentPerspective !== Perspective.BuiltIn.Flagged &&
+                           currentPerspective !== Perspective.BuiltIn.Review;
+      
+      if (isCustomPerspective && currentPerspective.archivedFilterRules) {
+        // Check if it's already an object or needs parsing
+        if (typeof currentPerspective.archivedFilterRules === 'string') {
+          perspectiveRules = JSON.parse(currentPerspective.archivedFilterRules);
+        } else {
+          perspectiveRules = currentPerspective.archivedFilterRules;
         }
+        perspectiveAggregation = currentPerspective.archivedTopLevelFilterAggregation || "all";
+      }
+    } catch (e) {
+      // If we can't parse the rules, fall back to getting all available tasks
+    }
+
+    // Filter tasks based on perspective rules
+    let filteredTasks = [];
+    
+    // Ensure flattenedTasks is available
+    if (typeof flattenedTasks === 'undefined') {
+      return JSON.stringify({
+        success: false,
+        error: "flattenedTasks global variable is not available in OmniFocus context"
       });
-    } else if (perspectiveName === "Tags") {
-      // Get tagged tasks - using flattenedTags global
-      flattenedTags.forEach(tag => {
-        tag.remainingTasks.forEach(task => {
-          const taskDetail = getTaskDetails(task);
-          if (!items.some(item => item.id === taskDetail.id)) {
-            items.push(taskDetail);
-          }
-        });
-      });
-    } else if (perspectiveName === "Flagged") {
-      // Get flagged items - using flattenedTasks global
+    }
+    
+    if (isCustomPerspective && perspectiveRules) {
+      // Use rule-based filtering for custom perspectives
       flattenedTasks.forEach(task => {
-        if (task.flagged && !task.completed) {
-          items.push(getTaskDetails(task));
+        if (evaluateTask(task, perspectiveRules, perspectiveAggregation)) {
+          filteredTasks.push(getTaskDetails(task));
         }
       });
     } else {
-      // For other perspectives, try to get selected or visible items
-      if (selectedTasks.length > 0) {
-        selectedTasks.forEach(task => {
-          items.push(getTaskDetails(task));
+      // Use built-in perspective logic for default perspectives
+      if (perspectiveName === "Inbox") {
+        inbox.forEach(task => {
+          filteredTasks.push(getTaskDetails(task));
         });
-      }
-      if (selectedProjects.length > 0) {
-        selectedProjects.forEach(project => {
-          items.push(getProjectDetails(project));
+      } else if (perspectiveName === "Flagged") {
+        flattenedTasks.forEach(task => {
+          if (task.flagged && !task.completed) {
+            filteredTasks.push(getTaskDetails(task));
+          }
         });
-      }
-      
-      // If no selection, get some available tasks
-      if (items.length === 0) {
-        const availableTasks = flattenedTasks.filter(task => 
-          task.taskStatus === Task.Status.Available && !task.completed
-        );
-        availableTasks.slice(0, 100).forEach(task => {
-          items.push(getTaskDetails(task));
+      } else if (perspectiveName === "Projects") {
+        flattenedProjects.forEach(project => {
+          if (project.status === Project.Status.Active) {
+            const projectTask = project.task;
+            if (projectTask) {
+              filteredTasks.push(getTaskDetails(projectTask));
+            }
+          }
+        });
+      } else if (perspectiveName === "Tags") {
+        flattenedTags.forEach(tag => {
+          tag.remainingTasks.forEach(task => {
+            const taskDetail = getTaskDetails(task);
+            if (!filteredTasks.some(item => item.id === taskDetail.id)) {
+              filteredTasks.push(taskDetail);
+            }
+          });
+        });
+      } else {
+        // Default: get available tasks
+        flattenedTasks.forEach(task => {
+          if (task.taskStatus === Task.Status.Available && !task.completed) {
+            filteredTasks.push(getTaskDetails(task));
+          }
         });
       }
     }
     
-    return JSON.stringify({
+    const response = {
       success: true,
-      perspectiveName: perspectiveName,
-      items: items.slice(0, 100) // Limit to 100 items by default
-    });
+      perspectiveName: perspectiveDisplayName,
+      isCustomPerspective: isCustomPerspective,
+      rulesUsed: perspectiveRules !== null,
+      aggregationType: perspectiveAggregation,
+      items: filteredTasks.slice(0, limit) // Use the provided limit
+    };
+    
+    try {
+      return JSON.stringify(response);
+    } catch (jsonError) {
+      return JSON.stringify({
+        success: false,
+        error: "JSON serialization error: " + jsonError.toString(),
+        itemCount: filteredTasks.length
+      });
+    }
     
   } catch (error) {
     return JSON.stringify({
       success: false,
       error: error.toString()
     });
+  }
+}
+
+// Execute based on provided parameters or fallback to current window
+(() => {
+  if (typeof perspectiveName !== 'undefined' && typeof requestedLimit !== 'undefined') {
+    return getPerspectiveViewByName(perspectiveName, requestedLimit);
+  } else {
+    // Fallback to current window perspective for backwards compatibility
+    const window = document.windows[0];
+    if (window && window.perspective) {
+      return getPerspectiveViewByName(window.perspective.name || "Unknown", 100);
+    } else {
+      return JSON.stringify({
+        success: false,
+        error: "No perspective specified and no active window found"
+      });
+    }
   }
 })()

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -5,7 +5,7 @@
 function getPerspectiveViewByName(perspectiveName, limit = 100) {
   try {
     let currentPerspective = null;
-    
+
     if (perspectiveName.toLowerCase() === "inbox") {
       currentPerspective = Perspective.BuiltIn.Inbox;
     } else if (perspectiveName.toLowerCase() === "projects") {
@@ -21,15 +21,15 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     } else {
       currentPerspective = Perspective.Custom.byName(perspectiveName);
     }
-    
+
     if (!currentPerspective) {
       return JSON.stringify({
         success: false,
-        error: "Could not find perspective named '" + perspectiveName + "'"
+        error: "Could not find perspective named '" + perspectiveName + "'",
       });
     }
     let perspectiveDisplayName = "Unknown";
-    
+
     if (currentPerspective) {
       if (currentPerspective === Perspective.BuiltIn.Inbox) {
         perspectiveDisplayName = "Inbox";
@@ -58,9 +58,11 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         result = task.taskStatus === Task.Status.Dropped;
       } else if (value === "available") {
         // "available" is defined here: https://support.omnigroup.com/documentation/omnifocus/universal/4.3.3/en/glossary/#view-options
-        const isActive = !task.completed && task.taskStatus !== Task.Status.Dropped;
-        const isAvailable = task.taskStatus !== Task.Status.Blocked && 
-                           (!task.deferDate || task.deferDate <= new Date());
+        const isActive =
+          !task.completed && task.taskStatus !== Task.Status.Dropped;
+        const isAvailable =
+          task.taskStatus !== Task.Status.Blocked &&
+          (!task.deferDate || task.deferDate <= new Date());
         result = isActive && isAvailable;
       } else if (value === "firstAvailable") {
         // "firstAvailable" specifically means the Available status
@@ -70,24 +72,41 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       }
       return result;
     };
-    
+
     var evaluateActionStatus = (task, value) => {
-      if (value === "due") return task.taskStatus === Task.Status.DueSoon || task.taskStatus === Task.Status.Overdue;
+      if (value === "due")
+        return (
+          task.taskStatus === Task.Status.DueSoon ||
+          task.taskStatus === Task.Status.Overdue
+        );
       if (value === "flagged") return task.flagged;
       return false;
     };
-    
-    var evaluateActionHasDueDate = (task, value) => (task.dueDate !== null) === value;
-    var evaluateActionHasDeferDate = (task, value) => (task.deferDate !== null) === value;
-    var evaluateActionHasDuration = (task, value) => (task.estimatedMinutes !== null) === value;
-    var evaluateActionWithinDuration = (task, value) => task.estimatedMinutes !== null && task.estimatedMinutes <= value;
-    var evaluateActionIsProject = (task, value) => (task.children && task.children.length > 0 && task.containingProject === null) === value;
-    var evaluateActionIsGroup = (task, value) => (task.children && task.children.length > 0 && task.containingProject !== null) === value;
-    var evaluateActionIsProjectOrGroup = (task, value) => (task.children && task.children.length > 0) === value;
-    var evaluateActionRepeats = (task, value) => (task.repetitionRule !== null) === value;
-    var evaluateActionIsUntagged = (task, value) => (task.tags.length === 0) === value;
+
+    var evaluateActionHasDueDate = (task, value) =>
+      (task.dueDate !== null) === value;
+    var evaluateActionHasDeferDate = (task, value) =>
+      (task.deferDate !== null) === value;
+    var evaluateActionHasDuration = (task, value) =>
+      (task.estimatedMinutes !== null) === value;
+    var evaluateActionWithinDuration = (task, value) =>
+      task.estimatedMinutes !== null && task.estimatedMinutes <= value;
+    var evaluateActionIsProject = (task, value) =>
+      (task.children &&
+        task.children.length > 0 &&
+        task.containingProject === null) === value;
+    var evaluateActionIsGroup = (task, value) =>
+      (task.children &&
+        task.children.length > 0 &&
+        task.containingProject !== null) === value;
+    var evaluateActionIsProjectOrGroup = (task, value) =>
+      (task.children && task.children.length > 0) === value;
+    var evaluateActionRepeats = (task, value) =>
+      (task.repetitionRule !== null) === value;
+    var evaluateActionIsUntagged = (task, value) =>
+      (task.tags.length === 0) === value;
     var evaluateActionHasTagWithStatus = (task, value) => {
-      return task.tags.some(tag => {
+      return task.tags.some((tag) => {
         // Map OmniFocus tag status values
         if (value === "remaining") return !tag.effectivelyDropped;
         if (value === "active") return tag.effectivelyActive;
@@ -96,93 +115,97 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return false;
       });
     };
-    var evaluateActionIsLeaf = (task, value) => (!task.children || task.children.length === 0) === value;
-    var evaluateActionHasNoProject = (task, value) => (task.containingProject === null) === value;
+    var evaluateActionIsLeaf = (task, value) =>
+      (!task.children || task.children.length === 0) === value;
+    var evaluateActionHasNoProject = (task, value) =>
+      (task.containingProject === null) === value;
     var evaluateActionIsInSingleActionsList = (task, value) => {
       const project = task.containingProject;
-      return project && project.status === Project.Status.SingleActions === value;
+      return (
+        project && (project.status === Project.Status.SingleActions) === value
+      );
     };
     var evaluateActionHasProjectWithStatus = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
       const statusMap = {
-        "active": Project.Status.Active,
-        "remaining": !project.effectivelyCompleted && !project.effectivelyDropped,
-        "onHold": Project.Status.OnHold,
-        "completed": project.effectivelyCompleted,
-        "dropped": project.effectivelyDropped,
-        "stalled": Project.Status.Stalled,
-        "pending": Project.Status.Pending
+        active: Project.Status.Active,
+        remaining: !project.effectivelyCompleted && !project.effectivelyDropped,
+        onHold: Project.Status.OnHold,
+        completed: project.effectivelyCompleted,
+        dropped: project.effectivelyDropped,
+        stalled: Project.Status.Stalled,
+        pending: Project.Status.Pending,
       };
       if (value === "remaining") {
         return !project.effectivelyCompleted && !project.effectivelyDropped;
       }
       return project.status === statusMap[value];
     };
-    
+
     var evaluateActionHasAnyOfTags = (task, value) => {
       if (!Array.isArray(value) || task.tags.length === 0) return false;
-      const taskTagIds = task.tags.map(tag => tag.id.primaryKey);
-      return value.some(tagId => taskTagIds.includes(tagId));
+      const taskTagIds = task.tags.map((tag) => tag.id.primaryKey);
+      return value.some((tagId) => taskTagIds.includes(tagId));
     };
-    
+
     var evaluateActionHasAllOfTags = (task, value) => {
       if (!Array.isArray(value) || task.tags.length === 0) return false;
-      const taskTagIds = task.tags.map(tag => tag.id.primaryKey);
-      return value.every(tagId => taskTagIds.includes(tagId));
+      const taskTagIds = task.tags.map((tag) => tag.id.primaryKey);
+      return value.every((tagId) => taskTagIds.includes(tagId));
     };
-    
+
     var evaluateActionWithinFocus = (task, value) => {
       if (!Array.isArray(value)) return false;
-      
+
       function isWithinHierarchy(item) {
         if (!item) return false;
-        
+
         if (value.includes(item.id.primaryKey)) {
           return true;
         }
-        
+
         if (item.parentFolder) {
           return isWithinHierarchy(item.parentFolder);
         }
-        
+
         if (item.parent && item.parent !== item) {
           return isWithinHierarchy(item.parent);
         }
-        
+
         return false;
       }
-      
+
       if (task.containingProject) {
         return isWithinHierarchy(task.containingProject);
       }
-      
+
       return value.includes(task.id.primaryKey);
     };
-    
+
     var evaluateActionMatchingSearch = (task, value) => {
       if (!Array.isArray(value)) return false;
       const searchText = (task.name + " " + (task.note || "")).toLowerCase();
-      return value.some(term => searchText.includes(term.toLowerCase()));
+      return value.some((term) => searchText.includes(term.toLowerCase()));
     };
-    
+
     var evaluateActionDateIsToday = (task, dateField) => {
-      const fieldDate = task[dateField + 'Date']; // e.g., dueDate, deferDate
+      const fieldDate = task[dateField + "Date"]; // e.g., dueDate, deferDate
       if (!fieldDate) return false;
       const today = new Date();
       return fieldDate.toDateString() === today.toDateString();
     };
-    
+
     var evaluateActionDateIsYesterday = (task, dateField) => {
-      const fieldDate = task[dateField + 'Date'];
+      const fieldDate = task[dateField + "Date"];
       if (!fieldDate) return false;
       const yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);
       return fieldDate.toDateString() === yesterday.toDateString();
     };
-    
+
     var evaluateActionDateIsTomorrow = (task, dateField) => {
-      const fieldDate = task[dateField + 'Date'];
+      const fieldDate = task[dateField + "Date"];
       if (!fieldDate) return false;
       const tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
@@ -191,33 +214,33 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
 
     // filter rules and values are defined here: https://omni-automation.com/omnifocus/perspective.html
     var possibleRuleTypes = {
-        'actionAvailability': evaluateActionAvailability,
-        'actionStatus': evaluateActionStatus,
-        'actionHasDueDate': evaluateActionHasDueDate,
-        'actionHasDeferDate': evaluateActionHasDeferDate,
-        'actionHasDuration': evaluateActionHasDuration,
-        'actionWithinDuration': evaluateActionWithinDuration,
-        'actionIsProject': evaluateActionIsProject,
-        'actionIsGroup': evaluateActionIsGroup,
-        'actionIsProjectOrGroup': evaluateActionIsProjectOrGroup,
-        'actionRepeats': evaluateActionRepeats,
-        'actionIsUntagged': evaluateActionIsUntagged,
-        'actionHasTagWithStatus': evaluateActionHasTagWithStatus,
-        'actionHasAnyOfTags': evaluateActionHasAnyOfTags,
-        'actionHasAllOfTags': evaluateActionHasAllOfTags,
-        'actionIsLeaf': evaluateActionIsLeaf,
-        'actionHasNoProject': evaluateActionHasNoProject,
-        'actionIsInSingleActionsList': evaluateActionIsInSingleActionsList,
-        'actionHasProjectWithStatus': evaluateActionHasProjectWithStatus,
-        'actionWithinFocus': evaluateActionWithinFocus,
-        'actionMatchingSearch': evaluateActionMatchingSearch,
+      actionAvailability: evaluateActionAvailability,
+      actionStatus: evaluateActionStatus,
+      actionHasDueDate: evaluateActionHasDueDate,
+      actionHasDeferDate: evaluateActionHasDeferDate,
+      actionHasDuration: evaluateActionHasDuration,
+      actionWithinDuration: evaluateActionWithinDuration,
+      actionIsProject: evaluateActionIsProject,
+      actionIsGroup: evaluateActionIsGroup,
+      actionIsProjectOrGroup: evaluateActionIsProjectOrGroup,
+      actionRepeats: evaluateActionRepeats,
+      actionIsUntagged: evaluateActionIsUntagged,
+      actionHasTagWithStatus: evaluateActionHasTagWithStatus,
+      actionHasAnyOfTags: evaluateActionHasAnyOfTags,
+      actionHasAllOfTags: evaluateActionHasAllOfTags,
+      actionIsLeaf: evaluateActionIsLeaf,
+      actionHasNoProject: evaluateActionHasNoProject,
+      actionIsInSingleActionsList: evaluateActionIsInSingleActionsList,
+      actionHasProjectWithStatus: evaluateActionHasProjectWithStatus,
+      actionWithinFocus: evaluateActionWithinFocus,
+      actionMatchingSearch: evaluateActionMatchingSearch,
     };
 
     function evaluateRule(task, rule) {
       // Handle complex date field rules
       if (rule.actionDateField) {
         const dateField = rule.actionDateField;
-        
+
         // Check for date-specific conditions
         if (rule.actionDateIsToday) {
           return evaluateActionDateIsToday(task, dateField);
@@ -228,43 +251,47 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         if (rule.actionDateIsTomorrow) {
           return evaluateActionDateIsTomorrow(task, dateField);
         }
-        
+
         // Add other date conditions as needed
         return false;
       }
-      
+
       // Handle standard rules
       for (const [key, value] of Object.entries(rule)) {
         if (possibleRuleTypes[key]) {
           return possibleRuleTypes[key](task, value);
         }
       }
-      
+
       return false;
     }
 
     function evaluateTask(task, filters, aggregationType = "all") {
       if (!Array.isArray(filters) || filters.length === 0) return true;
-      
-      const results = filters.map(filter => {
+
+      const results = filters.map((filter) => {
         if (filter.aggregateType && filter.aggregateRules) {
           // Handle nested aggregate rules
-          return evaluateTask(task, filter.aggregateRules, filter.aggregateType);
+          return evaluateTask(
+            task,
+            filter.aggregateRules,
+            filter.aggregateType
+          );
         } else {
           // Handle single rule
           return evaluateRule(task, filter);
         }
       });
-      
+
       switch (aggregationType) {
         case "any":
-          return results.some(result => result);
+          return results.some((result) => result);
         case "all":
-          return results.every(result => result);
+          return results.every((result) => result);
         case "none":
-          return results.every(result => !result);
+          return results.every((result) => !result);
         default:
-          return results.every(result => result);
+          return results.every((result) => result);
       }
     }
 
@@ -273,65 +300,72 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       if (!date) return null;
       return date.toISOString();
     }
-    
-    function getTaskDetails(task) {      
+
+    function getTaskDetails(task) {
       // Task status mapping to match queryOmnifocus.ts
       const taskStatusMap = {
         [Task.Status.Available]: "Available",
-        [Task.Status.Blocked]: "Blocked", 
+        [Task.Status.Blocked]: "Blocked",
         [Task.Status.Completed]: "Completed",
         [Task.Status.Dropped]: "Dropped",
         [Task.Status.DueSoon]: "DueSoon",
         [Task.Status.Next]: "Next",
-        [Task.Status.Overdue]: "Overdue"
+        [Task.Status.Overdue]: "Overdue",
       };
-      
+
       return {
         id: task.id.primaryKey,
         name: task.name,
         completed: Boolean(task.completed),
         flagged: Boolean(task.flagged),
-        note: task.note || '',
+        note: task.note || "",
         dueDate: formatDate(task.dueDate),
         deferDate: formatDate(task.deferDate),
         completionDate: formatDate(task.completionDate),
-        estimatedMinutes: task.estimatedMinutes ? Number(task.estimatedMinutes) : null,
+        estimatedMinutes: task.estimatedMinutes
+          ? Number(task.estimatedMinutes)
+          : null,
         taskStatus: taskStatusMap[task.taskStatus] || "Unknown",
-        projectName: task.containingProject ? task.containingProject.name : null,
-        tagNames: (task.tags || []).map(tag => tag.name).filter(name => name)
+        projectName: task.containingProject
+          ? task.containingProject.name
+          : null,
+        tagNames: (task.tags || [])
+          .map((tag) => tag.name)
+          .filter((name) => name),
       };
     }
 
     let perspectiveRules = null;
     let perspectiveAggregation = "all";
     let isCustomPerspective = false;
-    
+
     try {
-      isCustomPerspective = currentPerspective && 
-                           currentPerspective !== Perspective.BuiltIn.Inbox &&
-                           currentPerspective !== Perspective.BuiltIn.Projects &&
-                           currentPerspective !== Perspective.BuiltIn.Tags &&
-                           currentPerspective !== Perspective.BuiltIn.Forecast &&
-                           currentPerspective !== Perspective.BuiltIn.Flagged &&
-                           currentPerspective !== Perspective.BuiltIn.Review;
-      
+      isCustomPerspective =
+        currentPerspective &&
+        currentPerspective !== Perspective.BuiltIn.Inbox &&
+        currentPerspective !== Perspective.BuiltIn.Projects &&
+        currentPerspective !== Perspective.BuiltIn.Tags &&
+        currentPerspective !== Perspective.BuiltIn.Forecast &&
+        currentPerspective !== Perspective.BuiltIn.Flagged &&
+        currentPerspective !== Perspective.BuiltIn.Review;
+
       if (isCustomPerspective && currentPerspective.archivedFilterRules) {
-        if (typeof currentPerspective.archivedFilterRules === 'string') {
+        if (typeof currentPerspective.archivedFilterRules === "string") {
           perspectiveRules = JSON.parse(currentPerspective.archivedFilterRules);
         } else {
           perspectiveRules = currentPerspective.archivedFilterRules;
         }
-        perspectiveAggregation = currentPerspective.archivedTopLevelFilterAggregation || "all";
+        perspectiveAggregation =
+          currentPerspective.archivedTopLevelFilterAggregation || "all";
       }
     } catch (e) {
       // If we can't parse the rules, fall back to getting all available tasks
     }
 
     let filteredTasks = [];
-  
-    
+
     if (isCustomPerspective && perspectiveRules) {
-      flattenedTasks.forEach(task => {
+      flattenedTasks.forEach((task) => {
         if (evaluateTask(task, perspectiveRules, perspectiveAggregation)) {
           filteredTasks.push(getTaskDetails(task));
         }
@@ -339,17 +373,17 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     } else {
       // Use built-in perspective logic for default perspectives
       if (perspectiveName === "Inbox") {
-        inbox.forEach(task => {
+        inbox.forEach((task) => {
           filteredTasks.push(getTaskDetails(task));
         });
       } else if (perspectiveName === "Flagged") {
-        flattenedTasks.forEach(task => {
+        flattenedTasks.forEach((task) => {
           if (task.flagged && !task.completed) {
             filteredTasks.push(getTaskDetails(task));
           }
         });
       } else if (perspectiveName === "Projects") {
-        flattenedProjects.forEach(project => {
+        flattenedProjects.forEach((project) => {
           if (project.status === Project.Status.Active) {
             const projectTask = project.task;
             if (projectTask) {
@@ -358,63 +392,73 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
           }
         });
       } else if (perspectiveName === "Tags") {
-        flattenedTags.forEach(tag => {
-          tag.remainingTasks.forEach(task => {
+        flattenedTags.forEach((tag) => {
+          tag.remainingTasks.forEach((task) => {
             const taskDetail = getTaskDetails(task);
-            if (!filteredTasks.some(item => item.id === taskDetail.id)) {
+            if (!filteredTasks.some((item) => item.id === taskDetail.id)) {
               filteredTasks.push(taskDetail);
             }
           });
         });
       } else {
-        flattenedTasks.forEach(task => {
+        flattenedTasks.forEach((task) => {
           if (task.taskStatus === Task.Status.Available && !task.completed) {
             filteredTasks.push(getTaskDetails(task));
           }
         });
       }
     }
-    
+
     const response = {
       success: true,
       perspectiveName: perspectiveDisplayName,
       isCustomPerspective: isCustomPerspective,
       rulesUsed: perspectiveRules !== null,
       aggregationType: perspectiveAggregation,
-      items: filteredTasks.slice(0, limit) 
+      items: filteredTasks.slice(0, limit),
     };
-    
+
     try {
       return JSON.stringify(response);
     } catch (jsonError) {
       return JSON.stringify({
         success: false,
         error: "JSON serialization error: " + jsonError.toString(),
-        itemCount: filteredTasks.length
+        itemCount: filteredTasks.length,
       });
     }
-    
   } catch (error) {
     return JSON.stringify({
       success: false,
-      error: error.toString()
+      error: error.toString(),
     });
   }
 }
 
 (() => {
-  if (typeof perspectiveName !== 'undefined' && typeof requestedLimit !== 'undefined') {
+  // Check for command-line arguments passed via the wrapper
+  if (
+    typeof perspectiveName !== "undefined" &&
+    typeof requestedLimit !== "undefined"
+  ) {
     return getPerspectiveViewByName(perspectiveName, requestedLimit);
-  } else {
-    // Fallback to current window perspective for backwards compatibility
-    const window = document.windows[0];
-    if (window && window.perspective) {
-      return getPerspectiveViewByName(window.perspective.name || "Unknown", 100);
-    } else {
-      return JSON.stringify({
-        success: false,
-        error: "No perspective specified and no active window found"
-      });
-    }
   }
-})()
+
+  // Check for arguments passed via osascript
+  if (typeof argv !== "undefined" && argv.length >= 2) {
+    const argPerspectiveName = argv[0];
+    const argLimit = parseInt(argv[1]) || 100;
+    return getPerspectiveViewByName(argPerspectiveName, argLimit);
+  }
+
+  // Fallback to current window perspective for backwards compatibility
+  const window = document.windows[0];
+  if (window && window.perspective) {
+    return getPerspectiveViewByName(window.perspective.name || "Unknown", 100);
+  } else {
+    return JSON.stringify({
+      success: false,
+      error: "No perspective specified and no active window found",
+    });
+  }
+})();

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -99,7 +99,6 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     var evaluateActionIsLeaf = (task, value) => (!task.children || task.children.length === 0) === value;
     var evaluateActionHasNoProject = (task, value) => (task.containingProject === null) === value;
     var evaluateActionIsInSingleActionsList = (task, value) => {
-      // Check if task is in a single actions list (project with single action list status)
       const project = task.containingProject;
       return project && project.status === Project.Status.SingleActions === value;
     };
@@ -136,21 +135,17 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     var evaluateActionWithinFocus = (task, value) => {
       if (!Array.isArray(value)) return false;
       
-      // Check if task is within any of the focus projects/folders at any depth
       function isWithinHierarchy(item) {
         if (!item) return false;
         
-        // Check if this item itself is in the focus list
         if (value.includes(item.id.primaryKey)) {
           return true;
         }
         
-        // For projects, check parent folder hierarchy
         if (item.parentFolder) {
           return isWithinHierarchy(item.parentFolder);
         }
         
-        // For folders, check parent folder hierarchy  
         if (item.parent && item.parent !== item) {
           return isWithinHierarchy(item.parent);
         }
@@ -158,12 +153,10 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return false;
       }
       
-      // Start with the task's containing project
       if (task.containingProject) {
         return isWithinHierarchy(task.containingProject);
       }
       
-      // If no containing project, check if task itself is somehow in focus
       return value.includes(task.id.primaryKey);
     };
     
@@ -173,7 +166,6 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       return value.some(term => searchText.includes(term.toLowerCase()));
     };
     
-    // Date evaluation functions
     var evaluateActionDateIsToday = (task, dateField) => {
       const fieldDate = task[dateField + 'Date']; // e.g., dueDate, deferDate
       if (!fieldDate) return false;

--- a/src/utils/scriptExecution.ts
+++ b/src/utils/scriptExecution.ts
@@ -106,10 +106,12 @@ export async function executeOmniFocusScript(
     let wrappedScript = scriptContent;
 
     if (args && args.length > 0) {
-      const escapedArgs = args.map(escapeContent).join(", ");
+      const quotedArgs = args
+        .map((arg) => `"${escapeContent(arg)}"`)
+        .join(", ");
       wrappedScript = `
 // Set up arguments
-const argv = [${escapedArgs}];
+const argv = [${quotedArgs}];
 
 ${scriptContent}`;
     }

--- a/src/utils/scriptExecution.ts
+++ b/src/utils/scriptExecution.ts
@@ -1,11 +1,11 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
-import { writeFileSync, unlinkSync, readFileSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
-import { existsSync } from 'fs';
+import { exec } from "child_process";
+import { promisify } from "util";
+import { writeFileSync, unlinkSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+import { existsSync } from "fs";
 
 const execAsync = promisify(exec);
 
@@ -14,32 +14,34 @@ export async function executeJXA(script: string): Promise<any[]> {
   try {
     // Write the script to a temporary file in the system temp directory
     const tempFile = join(tmpdir(), `jxa_script_${Date.now()}.js`);
-    
+
     // Write the script to the temporary file
     writeFileSync(tempFile, script);
-    
+
     // Execute the script using osascript
-    const { stdout, stderr } = await execAsync(`osascript -l JavaScript ${tempFile}`);
-    
+    const { stdout, stderr } = await execAsync(
+      `osascript -l JavaScript ${tempFile}`
+    );
+
     if (stderr) {
       console.error("Script stderr output:", stderr);
     }
-    
+
     // Clean up the temporary file
     unlinkSync(tempFile);
-    
+
     // Parse the output as JSON
     try {
       const result = JSON.parse(stdout);
       return result;
     } catch (e) {
       console.error("Failed to parse script output as JSON:", e);
-      
+
       // If this contains a "Found X tasks" message, treat it as a successful non-JSON response
       if (stdout.includes("Found") && stdout.includes("tasks")) {
         return [];
       }
-      
+
       return [];
     }
   } catch (error) {
@@ -48,40 +50,76 @@ export async function executeJXA(script: string): Promise<any[]> {
   }
 }
 
+const escapeContent = (content: string) => {
+  return content
+    .replace(/\\/g, "\\\\") // Escape backslashes
+    .replace(/`/g, "\\`") // Escape backticks
+    .replace(/\$/g, "\\$"); // Escape dollar signs
+};
+
 // Function to execute scripts in OmniFocus using the URL scheme
 // Update src/utils/scriptExecution.ts
-export async function executeOmniFocusScript(scriptPath: string, args?: any): Promise<any> {
+export async function executeOmniFocusScript(
+  scriptPath: string,
+  args?: string[]
+): Promise<any> {
   try {
     // Get the actual script path (existing code remains the same)
     let actualPath;
-    if (scriptPath.startsWith('@')) {
+    if (scriptPath.startsWith("@")) {
       const scriptName = scriptPath.substring(1);
       const __filename = fileURLToPath(import.meta.url);
       const __dirname = dirname(__filename);
-      
-      const distPath = join(__dirname, '..', 'utils', 'omnifocusScripts', scriptName);
-      const srcPath = join(__dirname, '..', '..', 'src', 'utils', 'omnifocusScripts', scriptName);
-      
+
+      const distPath = join(
+        __dirname,
+        "..",
+        "utils",
+        "omnifocusScripts",
+        scriptName
+      );
+      const srcPath = join(
+        __dirname,
+        "..",
+        "..",
+        "src",
+        "utils",
+        "omnifocusScripts",
+        scriptName
+      );
+
       if (existsSync(distPath)) {
         actualPath = distPath;
       } else if (existsSync(srcPath)) {
         actualPath = srcPath;
       } else {
-        actualPath = join(__dirname, '..', 'omnifocusScripts', scriptName);
+        actualPath = join(__dirname, "..", "omnifocusScripts", scriptName);
       }
     } else {
       actualPath = scriptPath;
     }
-    
+
     // Read the script file
-    const scriptContent = readFileSync(actualPath, 'utf8');
-    
+    const scriptContent = readFileSync(actualPath, "utf8");
+
+    // Create a wrapper script that sets up arguments and executes the original script
+    let wrappedScript = scriptContent;
+
+    if (args && args.length > 0) {
+      const escapedArgs = args.map(escapeContent).join(", ");
+      wrappedScript = `
+// Set up arguments
+const argv = [${escapedArgs}];
+
+${scriptContent}`;
+    }
+
     // Create a temporary file for our JXA wrapper script
     const tempFile = join(tmpdir(), `jxa_wrapper_${Date.now()}.js`);
-    
+
     // Escape the script content properly for use in JXA
-    const escapedScript = scriptContent.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
-    
+    const escapedScript = escapeContent(wrappedScript);
+
     // Create a JXA script that will execute our OmniJS script in OmniFocus
     const jxaScript = `
     function run() {
@@ -99,20 +137,22 @@ export async function executeOmniFocusScript(scriptPath: string, args?: any): Pr
       }
     }
     `;
-    
+
     // Write the JXA script to the temporary file
     writeFileSync(tempFile, jxaScript);
-    
+
     // Execute the JXA script using osascript
-    const { stdout, stderr } = await execAsync(`osascript -l JavaScript ${tempFile}`);
-    
+    const { stdout, stderr } = await execAsync(
+      `osascript -l JavaScript ${tempFile}`
+    );
+
     // Clean up the temporary file
     unlinkSync(tempFile);
-    
+
     if (stderr) {
       console.error("Script stderr output:", stderr);
     }
-    
+
     // Parse the output as JSON
     try {
       return JSON.parse(stdout);
@@ -125,4 +165,3 @@ export async function executeOmniFocusScript(scriptPath: string, args?: any): Pr
     throw error;
   }
 }
-    


### PR DESCRIPTION
Bit of a wild idea. Getting a list of tasks for a named custom perspective wasn't working for me. This is an attempt to recreate the rules engine for perspectives using `archivedFilterRules`. 

All of the rules may not be perfect or complete, but they're so far working with all of my perspectives. 

Some of the references I used for creating this:

- https://omni-automation.com/omnifocus/perspective.html
    -  this lists all the different rules and their options
- https://support.omnigroup.com/documentation/omnifocus/universal/4.3.3/en/glossary/#view-options
    - needed this for defining what "available" means