### PR TITLE
feat: Add support for the new `planned` date type in Omnifocus 4.7

### DIFF
--- a/QUERY_TOOL_EXAMPLES.md
+++ b/QUERY_TOOL_EXAMPLES.md
@@ -91,6 +91,28 @@ The `query_omnifocus` tool provides efficient, targeted queries against your Omn
 }
 ```
 
+### Get tasks planned for this week
+```json
+{
+  "entity": "tasks",
+  "filters": {
+    "plannedWithin": 7
+  },
+  "sortBy": "plannedDate"
+}
+```
+
+### Get today's planned work
+```json
+{
+  "entity": "tasks",
+  "filters": {
+    "plannedWithin": 0,
+    "status": ["Next", "Available"]
+  }
+}
+```
+
 ## Performance Optimization
 
 ### Get only specific fields (reduces response size)
@@ -256,6 +278,19 @@ Get your most important tasks for the day:
   },
   "sortBy": "dueDate",
   "limit": 15
+}
+```
+
+Or get tasks you planned to work on today:
+```json
+{
+  "entity": "tasks",
+  "filters": {
+    "plannedWithin": 0,
+    "status": ["Next", "Available"]
+  },
+  "sortBy": "plannedDate",
+  "fields": ["name", "plannedDate", "projectName", "estimatedMinutes"]
 }
 ```
 

--- a/QUERY_TOOL_REFERENCE.md
+++ b/QUERY_TOOL_REFERENCE.md
@@ -14,6 +14,10 @@ All available fields you can request for tasks:
 | `taskStatus` | string | Current status | "Next", "Available", "Blocked" |
 | `dueDate` | string | Due date in ISO format | "2024-12-25T00:00:00Z" |
 | `deferDate` | string | Defer/start date in ISO format | "2024-12-20T00:00:00Z" |
+| `plannedDate` | string | Planned date in ISO format | "2024-12-22T00:00:00Z" |
+| `effectiveDueDate` | string | Inherited or set due date | "2024-12-25T00:00:00Z" |
+| `effectiveDeferDate` | string | Inherited or set defer date | "2024-12-20T00:00:00Z" |
+| `effectivePlannedDate` | string | Inherited or set planned date | "2024-12-22T00:00:00Z" |
 | `completionDate` | string | When task was completed | "2024-12-24T14:30:00Z" |
 | `estimatedMinutes` | number | Time estimate in minutes | 30 |
 | `tagNames` | string[] | Array of tag names | ["work", "urgent"] |
@@ -92,6 +96,15 @@ All available fields you can request for folders:
 ```json
 {
   "dueWithin": 1  // Tasks due today or tomorrow
+}
+```
+
+### `plannedWithin` Filter
+- **Behavior**: Returns tasks planned from now until N days in the future (inclusive)
+- **Example**: `"plannedWithin": 7` returns tasks planned today through 7 days from now
+```json
+{
+  "plannedWithin": 7  // Tasks planned within next week
 }
 ```
 
@@ -178,7 +191,8 @@ Within array filters (`status`, `tags`), **OR** logic applies:
 Common fields you can sort by:
 - `name` - Alphabetical by item name
 - `dueDate` - By due date (null dates sort last)
-- `deferDate` - By defer date (null dates sort last)  
+- `deferDate` - By defer date (null dates sort last)
+- `plannedDate` - By planned date (null dates sort last)
 - `modificationDate` - By last modified time
 - `creationDate` - By creation time
 - `estimatedMinutes` - By time estimate (shortest first with 'asc')

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Some ways you could use it:
 
 ## Roadmap
 - ~~Enable the client to interact with perspectives~~ ✅ (Added list_perspectives and get_perspective_view)
+- ~~Add support for the new `planned` date type in Omnifocus 4.7~~ ✅ (Added plannedDate support for tasks)
 - Benefit from MCP `resource` and `prompt` features
-- Add support for the new `planned` date type in Omnifocus 4.7
 - Support manipulating notifications for projects and tasks
 
 
@@ -137,11 +137,12 @@ Parameters:
 - `note`: (Optional) Additional notes for the task
 - `dueDate`: (Optional) The due date of the task in ISO format
 - `deferDate`: (Optional) The defer date of the task in ISO format
+- `plannedDate`: (Optional) The planned date of the task in ISO format - indicates intention to work on this task on this date
 - `flagged`: (Optional) Whether the task is flagged or not
 - `estimatedMinutes`: (Optional) Estimated time to complete the task
 - `tags`: (Optional) Tags to assign to the task
- - `parentTaskId`: (Optional) Create under an existing parent task by ID
- - `parentTaskName`: (Optional) Create under first matching parent task by name (fallback)
+- `parentTaskId`: (Optional) Create under an existing parent task by ID
+- `parentTaskName`: (Optional) Create under first matching parent task by name (fallback)
 
 ### `add_project`
 Add a new project to OmniFocus.
@@ -184,6 +185,7 @@ Parameters:
   - `note`: (Optional) Additional notes
   - `dueDate`: (Optional) Due date in ISO format
   - `deferDate`: (Optional) Defer date in ISO format
+  - `plannedDate`: (Optional) Planned date in ISO format (tasks only)
   - `flagged`: (Optional) Whether the item is flagged
   - `estimatedMinutes`: (Optional) Estimated completion time
   - `tags`: (Optional) Array of tags

--- a/src/omnifocustypes.ts
+++ b/src/omnifocustypes.ts
@@ -50,8 +50,10 @@ export interface TaskMinimal extends DatabaseObject {
   taskStatus: Task.Status;
   dueDate: Date | null;
   deferDate: Date | null;
+  plannedDate: Date | null;
   effectiveDueDate: Date | null;
   effectiveDeferDate: Date | null;
+  effectivePlannedDate: Date | null;
   estimatedMinutes: number | null;
   completedByChildren: boolean;
   sequential: boolean;

--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -7,6 +7,7 @@ export const schema = z.object({
   note: z.string().optional().describe("Additional notes for the task"),
   dueDate: z.string().optional().describe("The due date of the task in ISO format (YYYY-MM-DD or full ISO date)"),
   deferDate: z.string().optional().describe("The defer date of the task in ISO format (YYYY-MM-DD or full ISO date)"),
+  plannedDate: z.string().optional().describe("The planned date of the task in ISO format (YYYY-MM-DD or full ISO date) - indicates intention to work on this task on this date"),
   flagged: z.boolean().optional().describe("Whether the task is flagged or not"),
   estimatedMinutes: z.number().optional().describe("Estimated time to complete the task, in minutes"),
   tags: z.array(z.string()).optional().describe("Tags to assign to the task"),

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -9,10 +9,11 @@ export const schema = z.object({
     note: z.string().optional().describe("Additional notes for the item"),
     dueDate: z.string().optional().describe("The due date in ISO format (YYYY-MM-DD or full ISO date)"),
     deferDate: z.string().optional().describe("The defer date in ISO format (YYYY-MM-DD or full ISO date)"),
+    plannedDate: z.string().optional().describe("The planned date in ISO format (YYYY-MM-DD or full ISO date) - tasks only"),
     flagged: z.boolean().optional().describe("Whether the item is flagged or not"),
     estimatedMinutes: z.number().optional().describe("Estimated time to complete the item, in minutes"),
     tags: z.array(z.string()).optional().describe("Tags to assign to the item"),
-    
+
     // Task-specific properties
     projectName: z.string().optional().describe("For tasks: The name of the project to add the task to"),
     parentTaskId: z.string().optional().describe("For tasks: ID of the parent task"),

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -12,9 +12,10 @@ export const schema = z.object({
   newNote: z.string().optional().describe("New note for the item"),
   newDueDate: z.string().optional().describe("New due date in ISO format (YYYY-MM-DD or full ISO date); set to empty string to clear"),
   newDeferDate: z.string().optional().describe("New defer date in ISO format (YYYY-MM-DD or full ISO date); set to empty string to clear"),
+  newPlannedDate: z.string().optional().describe("New planned date in ISO format (YYYY-MM-DD or full ISO date); set to empty string to clear (tasks only)"),
   newFlagged: z.boolean().optional().describe("Set flagged status (set to false for no flag, true for flag)"),
   newEstimatedMinutes: z.number().optional().describe("New estimated minutes"),
-  
+
   // Task-specific fields
   newStatus: z.enum(['incomplete', 'completed', 'dropped']).optional().describe("New status for tasks (incomplete, completed, dropped)"),
   addTags: z.array(z.string()).optional().describe("Tags to add to the task"),

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -14,10 +14,11 @@ export const schema = z.object({
     flagged: z.boolean().optional().describe("Filter by flagged status. true = only flagged items, false = only unflagged items"),
     dueWithin: z.number().optional().describe("Returns items due from TODAY through N days in future. Example: 7 = items due within next week (today + 6 days)"),
     deferredUntil: z.number().optional().describe("Returns items CURRENTLY DEFERRED that will become available within N days. Example: 3 = items becoming available in next 3 days"),
+    plannedWithin: z.number().optional().describe("Returns tasks planned from TODAY through N days in future. Example: 7 = tasks planned within next week (today + 6 days)"),
     hasNote: z.boolean().optional().describe("Filter by note presence. true = items with non-empty notes (whitespace ignored), false = items with no notes or only whitespace")
   }).optional().describe("Optional filters to narrow results. ALL filters combine with AND logic (must match all). Within array filters (tags, status) OR logic applies"),
   
-  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
+  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
   
   limit: z.number().optional().describe("Maximum number of items to return. Useful for large result sets. Default: no limit"),
   
@@ -150,6 +151,9 @@ function formatTasks(tasks: any[]): string {
     }
     if (task.deferDate) {
       parts.push(`[defer: ${formatDate(task.deferDate)}]`);
+    }
+    if (task.plannedDate) {
+      parts.push(`[planned: ${formatDate(task.plannedDate)}]`);
     }
     
     // Time estimate

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -12,6 +12,7 @@ export interface AddOmniFocusTaskParams {
   note?: string;
   dueDate?: string; // ISO date string
   deferDate?: string; // ISO date string
+  plannedDate?: string; // ISO date string
   flagged?: boolean;
   estimatedMinutes?: number;
   tags?: string[]; // Tag names
@@ -31,26 +32,33 @@ function generateAppleScript(params: AddOmniFocusTaskParams): string {
   const note = params.note?.replace(/['"\\]/g, '\\$&') || '';
   const dueDate = params.dueDate || '';
   const deferDate = params.deferDate || '';
+  const plannedDate = params.plannedDate || '';
   const flagged = params.flagged === true;
   const estimatedMinutes = params.estimatedMinutes?.toString() || '';
   const tags = params.tags || [];
   const projectName = params.projectName?.replace(/['"\\]/g, '\\$&') || '';
   const parentTaskId = params.parentTaskId?.replace(/['"\\]/g, '\\$&') || '';
   const parentTaskName = params.parentTaskName?.replace(/['"\\]/g, '\\$&') || '';
-  
+
   // Generate date constructions outside tell blocks
   let datePreScript = '';
   let dueDateVar = '';
   let deferDateVar = '';
-  
+  let plannedDateVar = '';
+
   if (dueDate) {
     dueDateVar = `dueDate${Math.random().toString(36).substr(2, 9)}`;
     datePreScript += createDateOutsideTellBlock(dueDate, dueDateVar) + '\n\n';
   }
-  
+
   if (deferDate) {
     deferDateVar = `deferDate${Math.random().toString(36).substr(2, 9)}`;
     datePreScript += createDateOutsideTellBlock(deferDate, deferDateVar) + '\n\n';
+  }
+
+  if (plannedDate) {
+    plannedDateVar = `plannedDate${Math.random().toString(36).substr(2, 9)}`;
+    datePreScript += createDateOutsideTellBlock(plannedDate, plannedDateVar) + '\n\n';
   }
   
   // Construct AppleScript with error handling
@@ -130,6 +138,9 @@ function generateAppleScript(params: AddOmniFocusTaskParams): string {
         ${deferDate ? `
           -- Set defer date
           set defer date of newTask to ` + deferDateVar : ''}
+        ${plannedDate ? `
+          -- Set planned date
+          set planned date of newTask to ` + plannedDateVar : ''}
         ${flagged ? `set flagged of newTask to true` : ''}
         ${estimatedMinutes ? `set estimated minutes of newTask to ${estimatedMinutes}` : ''}
         

--- a/src/tools/primitives/batchAddItems.ts
+++ b/src/tools/primitives/batchAddItems.ts
@@ -8,6 +8,7 @@ export type BatchAddItemsParams = {
   note?: string;
   dueDate?: string;
   deferDate?: string;
+  plannedDate?: string; // For tasks
   flagged?: boolean;
   estimatedMinutes?: number;
   tags?: string[];
@@ -155,6 +156,7 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
             note: item.note,
             dueDate: item.dueDate,
             deferDate: item.deferDate,
+            plannedDate: item.plannedDate,
             flagged: item.flagged,
             estimatedMinutes: item.estimatedMinutes,
             tags: item.tags,

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -21,6 +21,7 @@ export interface EditItemParams {
   newNote?: string;             // New note for the item
   newDueDate?: string;          // New due date in ISO format (empty string to clear)
   newDeferDate?: string;        // New defer date in ISO format (empty string to clear)
+  newPlannedDate?: string;      // New planned date in ISO format (empty string to clear, tasks only)
   newFlagged?: boolean;         // New flagged status (false to remove flag, true to add flag)
   newEstimatedMinutes?: number; // New estimated minutes
   
@@ -70,6 +71,15 @@ function generateAppleScript(params: EditItemParams): string {
       datePreScripts.push(deferDateParts.preScript);
     }
     dateAssignments['defer date'] = deferDateParts.assignmentScript;
+  }
+
+  // Process planned date if provided (tasks only)
+  const plannedDateParts = generateDateAssignmentV2('foundItem', 'planned date', params.newPlannedDate);
+  if (plannedDateParts) {
+    if (plannedDateParts.preScript) {
+      datePreScripts.push(plannedDateParts.preScript);
+    }
+    dateAssignments['planned date'] = plannedDateParts.assignmentScript;
   }
   
   // Build the complete script
@@ -236,7 +246,15 @@ function generateAppleScript(params: EditItemParams): string {
         set end of changedProperties to "defer date"
 `;
   }
-  
+
+  if (dateAssignments['planned date']) {
+    script += `
+        -- Update planned date
+        ${dateAssignments['planned date']}
+        set end of changedProperties to "planned date"
+`;
+  }
+
   if (params.newFlagged !== undefined) {
     script += `
         -- Update flagged status

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -11,6 +11,7 @@ export interface QueryOmnifocusParams {
     flagged?: boolean;
     dueWithin?: number;
     deferredUntil?: number;
+    plannedWithin?: number;
     hasNote?: boolean;
   };
   fields?: string[];
@@ -224,7 +225,15 @@ function generateFilterConditions(entity: string, filters: any): string {
         }
       `);
     }
-    
+
+    if (filters.plannedWithin !== undefined) {
+      conditions.push(`
+        if (!item.plannedDate || !checkDateFilter(item.plannedDate, ${filters.plannedWithin})) {
+          return false;
+        }
+      `);
+    }
+
     if (filters.hasNote !== undefined) {
       conditions.push(`
         const hasNote = item.note && item.note.trim().length > 0;
@@ -291,6 +300,7 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
           taskStatus: taskStatusMap[item.taskStatus] || "Unknown",
           dueDate: formatDate(item.dueDate),
           deferDate: formatDate(item.deferDate),
+          plannedDate: formatDate(item.plannedDate),
           tagNames: item.tags ? item.tags.map(t => t.name) : [],
           projectName: item.containingProject ? item.containingProject.name : (item.inInbox ? "Inbox" : null),
           estimatedMinutes: item.estimatedMinutes || null
@@ -344,10 +354,14 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
       return `dueDate: formatDate(item.dueDate)`;
     } else if (field === 'deferDate') {
       return `deferDate: formatDate(item.deferDate)`;
+    } else if (field === 'plannedDate') {
+      return `plannedDate: formatDate(item.plannedDate)`;
     } else if (field === 'effectiveDueDate') {
       return `effectiveDueDate: formatDate(item.effectiveDueDate)`;
     } else if (field === 'effectiveDeferDate') {
       return `effectiveDeferDate: formatDate(item.effectiveDeferDate)`;
+    } else if (field === 'effectivePlannedDate') {
+      return `effectivePlannedDate: formatDate(item.effectivePlannedDate)`;
     } else if (field === 'tagNames') {
       return `tagNames: item.tags ? item.tags.map(t => t.name) : []`;
     } else if (field === 'tags') {


### PR DESCRIPTION
Added planned date support for OmniFocus 4.7+ as per: https://omni-automation.com/omnifocus/task.html

Tested against OmniFocus 4.8.3 but unable to regression test with versions prior to 4.7.