### PR TITLE
fix: Add missing note field support in query results and formatting

### DIFF
--- a/QUERY_TOOL_EXAMPLES.md
+++ b/QUERY_TOOL_EXAMPLES.md
@@ -91,6 +91,29 @@ The `query_omnifocus` tool provides efficient, targeted queries against your Omn
 }
 ```
 
+### Get tasks with notes
+```json
+{
+  "entity": "tasks",
+  "filters": {
+    "hasNote": true
+  },
+  "fields": ["name", "note", "projectName"]
+}
+```
+
+### Get tasks without notes (for review)
+```json
+{
+  "entity": "tasks",
+  "filters": {
+    "hasNote": false,
+    "status": ["Available", "Next"]
+  },
+  "sortBy": "modificationDate"
+}
+```
+
 ## Performance Optimization
 
 ### Get only specific fields (reduces response size)
@@ -100,7 +123,7 @@ The `query_omnifocus` tool provides efficient, targeted queries against your Omn
   "filters": {
     "flagged": true
   },
-  "fields": ["name", "dueDate", "projectName"],
+  "fields": ["name", "note", "dueDate", "projectName"],
   "limit": 10
 }
 ```
@@ -279,7 +302,7 @@ See what's in your inbox:
   "filters": {
     "projectName": "inbox"
   },
-  "fields": ["name", "flagged", "dueDate", "tagNames"]
+  "fields": ["name", "note", "flagged", "dueDate", "tagNames"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The server currently provides these tools:
 Efficiently query your OmniFocus database with powerful filters. Get specific tasks, projects, or folders without loading the entire database.
 
 Key Features:
-- **Filter by multiple criteria**: project, tags, status, due dates, flags, and more
+- **Filter by multiple criteria**: project, tags, status, due dates, flags, notes, and more
 - **Request specific fields**: Reduce response size by only getting the data you need
 - **Sort and limit results**: Control the output format
 - **Much faster than dump_database** for targeted queries
@@ -115,7 +115,7 @@ Common Uses:
 Parameters:
 - `entity`: Type to query ('tasks', 'projects', or 'folders')
 - `filters`: (Optional) Narrow results by project, tags, status, dates, etc.
-- `fields`: (Optional) Specific fields to return (id, name, dueDate, etc.)
+- `fields`: (Optional) Specific fields to return (id, name, note, dueDate, etc.)
 - `limit`: (Optional) Maximum items to return
 - `sortBy`: (Optional) Field to sort by
 - `includeCompleted`: (Optional) Include completed items (default: false)

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -180,8 +180,15 @@ function formatTasks(tasks: any[]): string {
     if (task.completionDate) {
       parts.push(`[completed: ${formatDate(task.completionDate)}]`);
     }
-    
-    return parts.join(' ');
+
+    let result = parts.join(' ');
+
+    // Add note on a new line if present
+    if (task.note) {
+      result += `\n  Note: ${task.note}`;
+    }
+
+    return result;
   }).join('\n');
 }
 
@@ -192,8 +199,15 @@ function formatProjects(projects: any[]): string {
     const taskCount = project.taskCount !== undefined && project.taskCount !== null ? ` (${project.taskCount} tasks)` : '';
     const flagged = project.flagged ? '🚩 ' : '';
     const due = project.dueDate ? ` [due: ${formatDate(project.dueDate)}]` : '';
-    
-    return `P: ${flagged}${project.name}${status}${due}${folder}${taskCount}`;
+
+    let result = `P: ${flagged}${project.name}${status}${due}${folder}${taskCount}`;
+
+    // Add note on a new line if present
+    if (project.note) {
+      result += `\n  Note: ${project.note}`;
+    }
+
+    return result;
   }).join('\n');
 }
 

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -293,9 +293,9 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
           deferDate: formatDate(item.deferDate),
           tagNames: item.tags ? item.tags.map(t => t.name) : [],
           projectName: item.containingProject ? item.containingProject.name : (item.inInbox ? "Inbox" : null),
-          estimatedMinutes: item.estimatedMinutes || null
+          estimatedMinutes: item.estimatedMinutes || null,
+          note: item.note || ""
         };
-        if (item.note && item.note.trim()) obj.note = item.note;
         return obj;
       `;
     } else if (entity === 'projects') {
@@ -309,7 +309,8 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
           taskCount: taskArray.length,
           flagged: item.flagged || false,
           dueDate: formatDate(item.dueDate),
-          deferDate: formatDate(item.deferDate)
+          deferDate: formatDate(item.deferDate),
+          note: item.note || ""
         };
       `;
     } else if (entity === 'folders') {
@@ -380,6 +381,8 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
       return `path: item.container ? item.container.name + "/" + item.name : item.name`;
     } else if (field === 'estimatedMinutes') {
       return `estimatedMinutes: item.estimatedMinutes || null`;
+    } else if (field === 'note') {
+      return `note: item.note || ""`;
     } else {
       // Default: try to access the field directly
       return `${field}: item.${field} !== undefined ? item.${field} : null`;


### PR DESCRIPTION
## Problem
The query_omnifocus tool was not returning note fields even when explicitly requested via the fields parameter. Notes could be created and edited successfully, but were never visible in query results or database dumps.

## Root Cause
Two separate bugs in the query pipeline:

1. **Primitive Layer** (queryOmnifocus.ts): The generateFieldMapping function had no explicit handler for the 'note' field, causing it to fall through to a default handler that didn't work correctly with OmniFocus's object model.

2. **Formatting Layer** (definitions/queryOmnifocus.ts): The formatTasks and formatProjects functions never included notes in their output, stripping them from results before display.

## Changes Made

### Code Fixes
- Added explicit 'note' field handler using `item.note || ""` pattern
- Updated default field mappings for tasks to always include notes
- Updated default field mappings for projects to include notes
- Modified formatTasks() to display notes on indented new lines
- Modified formatProjects() to display notes on indented new lines

### Documentation Updates
- Updated README.md to include 'note' in example fields lists
- Added practical examples to QUERY_TOOL_EXAMPLES.md showing:
  - How to query tasks with notes (hasNote: true)
  - How to find tasks without notes for review workflow
  - Including notes in field requests

## Testing
Verified that notes now appear correctly in:
- query_omnifocus results when 'note' field is requested
- query_omnifocus results with default fields (no fields specified)
- dump_database output for both tasks and projects

Notes are displayed indented on a new line after task/project info for readability while maintaining the compact format.