### PR TITLE
Add task moves, fix AppleScript bugs, add test infrastructure

### DIFF
--- a/docs/superpowers/plans/2026-03-16-integration-tests.md
+++ b/docs/superpowers/plans/2026-03-16-integration-tests.md
@@ -1,0 +1,793 @@
+# Integration Test Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add integration tests that execute real AppleScript against OmniFocus with run-scoped containment for safety.
+
+**Architecture:** Each test run creates a unique `TEST:<timestamp>` folder in OmniFocus. A `TestRegistry` tracks every item created by ID. Cleanup deletes only tracked items. Tests use vitest with a separate config so `npm test` never touches OmniFocus.
+
+**Tech Stack:** TypeScript, vitest, AppleScript (via osascript temp files), OmniFocus
+
+**Spec:** `docs/superpowers/specs/2026-03-16-integration-tests-design.md`
+
+---
+
+## File Structure
+
+```
+vitest.config.ts                          — MODIFY: add exclude for integration tests
+vitest.integration.config.ts              — CREATE: separate config for integration tests
+package.json                              — MODIFY: add test:integration and test:integration:cleanup scripts
+src/tests/integration/
+  registry.ts                             — CREATE: TestRegistry class (ID tracking, ordered cleanup)
+  helpers.ts                              — CREATE: AppleScript helpers (createFolder, deleteById, resolveItemName, etc.)
+  setup.ts                                — CREATE: shared beforeAll/afterAll (pre-flight, run folder, cleanup)
+  cleanup.ts                              — CREATE: standalone cleanup script for crashed runs
+  task-lifecycle.test.ts                  — CREATE: task CRUD lifecycle tests
+  project-lifecycle.test.ts               — CREATE: project CRUD lifecycle tests
+```
+
+---
+
+## Chunk 1: Infrastructure (registry, helpers, config)
+
+### Task 1: Vitest Config and Package Scripts
+
+**Files:**
+- Modify: `vitest.config.ts`
+- Create: `vitest.integration.config.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Update vitest.config.ts to exclude integration tests**
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['src/tests/integration/**'],
+  },
+});
+```
+
+- [ ] **Step 2: Create vitest.integration.config.ts**
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/tests/integration/**/*.test.ts'],
+    testTimeout: 30000,
+    sequence: { concurrent: false, shuffle: false },
+  },
+});
+```
+
+- [ ] **Step 3: Add scripts to package.json**
+
+Add to the `"scripts"` section:
+```json
+"test:integration": "vitest run --config vitest.integration.config.ts",
+"test:integration:cleanup": "npx tsx src/tests/integration/cleanup.ts"
+```
+
+- [ ] **Step 4: Run existing unit tests to verify no breakage**
+
+Run: `npm test`
+Expected: All 68 tests pass. Integration directory exclusion has no effect yet (no files there).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vitest.config.ts vitest.integration.config.ts package.json
+git commit -m "Add integration test vitest config and npm scripts"
+```
+
+---
+
+### Task 2: AppleScript Helpers
+
+**Files:**
+- Create: `src/tests/integration/helpers.ts`
+
+These are raw AppleScript execution helpers for test infrastructure. They follow the same temp-file pattern used by the primitives (`writeFileSync` + `osascript` + `unlinkSync`).
+
+- [ ] **Step 1: Create helpers.ts with execAppleScript utility**
+
+The core utility that all helpers use — writes AppleScript to a temp file and executes it:
+
+```typescript
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const execAsync = promisify(exec);
+
+export const TEST_PREFIX = 'TEST:';
+
+/**
+ * Execute raw AppleScript via temp file. Returns stdout.
+ */
+export async function execAppleScript(script: string): Promise<string> {
+  const tempFile = join(tmpdir(), `test_omnifocus_${Date.now()}.applescript`);
+  try {
+    writeFileSync(tempFile, script);
+    const { stdout } = await execAsync(`osascript ${tempFile}`);
+    return stdout.trim();
+  } finally {
+    try { unlinkSync(tempFile); } catch { /* ignore */ }
+  }
+}
+```
+
+- [ ] **Step 2: Add assertOmniFocusRunning**
+
+```typescript
+/**
+ * Pre-flight check. Throws if OmniFocus is not running/accessible.
+ */
+export async function assertOmniFocusRunning(): Promise<void> {
+  try {
+    const result = await execAppleScript(`
+      tell application "OmniFocus" to return "ok"
+    `);
+    if (!result.includes('ok')) {
+      throw new Error('Unexpected response from OmniFocus');
+    }
+  } catch (error: any) {
+    throw new Error(
+      `OmniFocus is not running or not accessible. Integration tests require OmniFocus.\n${error.message}`
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Add createFolder**
+
+```typescript
+/**
+ * Create a folder in OmniFocus. Returns the folder's ID.
+ * Name must start with TEST_PREFIX.
+ */
+export async function createFolder(name: string): Promise<string> {
+  assertTestPrefix(name);
+  const escapedName = name.replace(/["\\]/g, '\\$&');
+  const result = await execAppleScript(`
+    tell application "OmniFocus"
+      tell front document
+        set newFolder to make new folder with properties {name:"${escapedName}"}
+        return id of newFolder as string
+      end tell
+    end tell
+  `);
+  return result;
+}
+
+/**
+ * Throws if name doesn't start with TEST_PREFIX.
+ */
+export function assertTestPrefix(name: string): void {
+  if (!name.startsWith(TEST_PREFIX)) {
+    throw new Error(`Safety check failed: "${name}" does not start with "${TEST_PREFIX}"`);
+  }
+}
+```
+
+- [ ] **Step 4: Add resolveItemName**
+
+```typescript
+/**
+ * Look up an item's current name by ID and type.
+ * Returns the name, or null if not found.
+ */
+export async function resolveItemName(
+  id: string,
+  type: 'task' | 'project' | 'tag' | 'folder'
+): Promise<string | null> {
+  const escapedId = id.replace(/["\\]/g, '\\$&');
+  const collection =
+    type === 'task' ? 'flattened tasks' :
+    type === 'project' ? 'flattened projects' :
+    type === 'tag' ? 'flattened tags' :
+    'flattened folders';
+  try {
+    const result = await execAppleScript(`
+      tell application "OmniFocus"
+        tell front document
+          set foundItem to first ${type === 'task' ? 'flattened task' : type === 'project' ? 'flattened project' : type === 'tag' ? 'flattened tag' : 'flattened folder'} whose id is "${escapedId}"
+          return name of foundItem
+        end tell
+      end tell
+    `);
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 5: Add deleteById helpers**
+
+```typescript
+/**
+ * Delete an item by ID after verifying its name starts with TEST_PREFIX.
+ * This is the core safe-delete mechanism.
+ */
+export async function safeDeleteById(
+  id: string,
+  type: 'task' | 'project' | 'tag' | 'folder'
+): Promise<boolean> {
+  // Resolve actual name from OmniFocus
+  const name = await resolveItemName(id, type);
+  if (name === null) {
+    // Item already gone — that's fine
+    return false;
+  }
+  assertTestPrefix(name);
+
+  const escapedId = id.replace(/["\\]/g, '\\$&');
+  const singular =
+    type === 'task' ? 'flattened task' :
+    type === 'project' ? 'flattened project' :
+    type === 'tag' ? 'flattened tag' :
+    'flattened folder';
+
+  await execAppleScript(`
+    tell application "OmniFocus"
+      tell front document
+        delete (first ${singular} whose id is "${escapedId}")
+      end tell
+    end tell
+  `);
+  return true;
+}
+```
+
+- [ ] **Step 6: Add findItemsByPrefix (for standalone cleanup)**
+
+```typescript
+/**
+ * Find all items of a type whose name starts with a prefix.
+ * Used by standalone cleanup script only.
+ */
+export async function findItemsByPrefix(
+  prefix: string,
+  type: 'task' | 'project' | 'tag' | 'folder'
+): Promise<Array<{ id: string; name: string }>> {
+  const escapedPrefix = prefix.replace(/["\\]/g, '\\$&');
+  const collection =
+    type === 'task' ? 'flattened tasks' :
+    type === 'project' ? 'flattened projects' :
+    type === 'tag' ? 'flattened tags' :
+    'flattened folders';
+
+  const result = await execAppleScript(`
+    tell application "OmniFocus"
+      tell front document
+        set matches to {}
+        repeat with anItem in ${collection}
+          if name of anItem starts with "${escapedPrefix}" then
+            set end of matches to (id of anItem as string) & "|||" & name of anItem
+          end if
+        end repeat
+        set AppleScript's text item delimiters to "\\n"
+        return matches as text
+      end tell
+    end tell
+  `);
+
+  if (!result) return [];
+  return result.split('\n').filter(Boolean).map(line => {
+    const [id, name] = line.split('|||');
+    return { id, name };
+  });
+}
+```
+
+- [ ] **Step 7: Verify helpers compile**
+
+Run: `npx tsc --noEmit src/tests/integration/helpers.ts`
+Expected: No errors (or run full build and check).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/tests/integration/helpers.ts
+git commit -m "Add AppleScript test helpers with safety checks"
+```
+
+---
+
+### Task 3: TestRegistry
+
+**Files:**
+- Create: `src/tests/integration/registry.ts`
+
+- [ ] **Step 1: Create registry.ts**
+
+```typescript
+import { safeDeleteById } from './helpers.js';
+
+type ItemType = 'task' | 'project' | 'tag' | 'folder';
+
+interface TrackedItem {
+  id: string;
+  name: string;
+  type: ItemType;
+}
+
+/**
+ * Tracks all OmniFocus items created during a test run.
+ * Cleanup deletes only tracked items in safe dependency order.
+ */
+export class TestRegistry {
+  private items = new Map<string, TrackedItem>();
+
+  /** The unique run folder name, e.g. "TEST:1710612345678" */
+  readonly runFolder: string;
+
+  /** The run folder's OmniFocus ID (set after creation) */
+  runFolderId: string = '';
+
+  /** The test project name inside the run folder */
+  readonly testProject: string;
+
+  /** The test project's OmniFocus ID (set after creation) */
+  testProjectId: string = '';
+
+  constructor() {
+    this.runFolder = `TEST:${Date.now()}`;
+    this.testProject = `TEST:Sample Project`;
+  }
+
+  /** Record an item created during this run */
+  track(id: string, name: string, type: ItemType): void {
+    this.items.set(id, { id, name, type });
+  }
+
+  /** Get all tracked items of a given type */
+  getByType(type: ItemType): TrackedItem[] {
+    return [...this.items.values()].filter(item => item.type === type);
+  }
+
+  /** Remove an item from tracking (after successful deletion) */
+  untrack(id: string): void {
+    this.items.delete(id);
+  }
+
+  /**
+   * Clean up all tracked items in safe dependency order:
+   * tasks → projects → tags → run folder
+   */
+  async cleanupAll(): Promise<void> {
+    const order: ItemType[] = ['task', 'project', 'tag', 'folder'];
+    for (const type of order) {
+      for (const item of this.getByType(type)) {
+        try {
+          await safeDeleteById(item.id, item.type);
+          this.untrack(item.id);
+        } catch (error) {
+          console.warn(`Cleanup warning: failed to delete ${item.type} "${item.name}" (${item.id}):`, error);
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit src/tests/integration/registry.ts`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tests/integration/registry.ts
+git commit -m "Add TestRegistry for run-scoped item tracking"
+```
+
+---
+
+### Task 4: Setup/Teardown
+
+**Files:**
+- Create: `src/tests/integration/setup.ts`
+
+This exports a shared `beforeAll`/`afterAll` for test files to import, plus the registry instance and tracked-create wrappers.
+
+- [ ] **Step 1: Create setup.ts**
+
+```typescript
+import { beforeAll, afterAll } from 'vitest';
+import { TestRegistry } from './registry.js';
+import {
+  assertOmniFocusRunning,
+  createFolder,
+  TEST_PREFIX,
+} from './helpers.js';
+import { addOmniFocusTask } from '../../tools/primitives/addOmniFocusTask.js';
+import { addProject } from '../../tools/primitives/addProject.js';
+import { editItem } from '../../tools/primitives/editItem.js';
+import { removeItem } from '../../tools/primitives/removeItem.js';
+import { batchAddItems } from '../../tools/primitives/batchAddItems.js';
+import { batchRemoveItems } from '../../tools/primitives/batchRemoveItems.js';
+
+export const registry = new TestRegistry();
+
+/**
+ * Create a task and track it in the registry. Returns the parsed result.
+ */
+export async function createTrackedTask(
+  params: Parameters<typeof addOmniFocusTask>[0]
+): Promise<{ success: boolean; taskId?: string; error?: string }> {
+  const result = await addOmniFocusTask(params);
+  if (result.success && result.taskId) {
+    registry.track(result.taskId, params.name, 'task');
+  }
+  return result;
+}
+
+/**
+ * Create a project and track it in the registry. Returns the parsed result.
+ */
+export async function createTrackedProject(
+  params: Parameters<typeof addProject>[0]
+): Promise<{ success: boolean; projectId?: string; error?: string }> {
+  const result = await addProject(params);
+  if (result.success && result.projectId) {
+    registry.track(result.projectId, params.name, 'project');
+  }
+  return result;
+}
+
+/**
+ * Remove an item by ID, untrack from registry.
+ */
+export async function safeRemoveTracked(
+  id: string,
+  itemType: 'task' | 'project'
+): Promise<{ success: boolean; error?: string }> {
+  const result = await removeItem({ id, itemType });
+  if (result.success) {
+    registry.untrack(id);
+  }
+  return result;
+}
+
+// Re-export primitives for direct use in tests
+export { editItem, removeItem, batchAddItems, batchRemoveItems };
+
+/**
+ * Call in each test file's top-level describe:
+ *   setupIntegration();
+ */
+export function setupIntegration() {
+  beforeAll(async () => {
+    await assertOmniFocusRunning();
+
+    // Create unique run folder
+    const folderId = await createFolder(registry.runFolder);
+    registry.runFolderId = folderId;
+    registry.track(folderId, registry.runFolder, 'folder');
+
+    // Create test project inside the run folder
+    const projResult = await addProject({
+      name: registry.testProject,
+      folderName: registry.runFolder,
+    });
+    if (!projResult.success || !projResult.projectId) {
+      throw new Error(`Failed to create test project: ${projResult.error}`);
+    }
+    registry.testProjectId = projResult.projectId;
+    registry.track(projResult.projectId, registry.testProject, 'project');
+  }, 60000); // generous timeout for setup
+
+  afterAll(async () => {
+    await registry.cleanupAll();
+  }, 60000);
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npx tsc --noEmit src/tests/integration/setup.ts`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tests/integration/setup.ts
+git commit -m "Add integration test setup with registry and tracked wrappers"
+```
+
+---
+
+### Task 5: Standalone Cleanup Script
+
+**Files:**
+- Create: `src/tests/integration/cleanup.ts`
+
+- [ ] **Step 1: Create cleanup.ts**
+
+```typescript
+import { findItemsByPrefix, safeDeleteById, TEST_PREFIX } from './helpers.js';
+
+/**
+ * Standalone cleanup: find and remove all TEST:-prefixed items.
+ * Run manually after a crashed test run: npm run test:integration:cleanup
+ */
+async function main() {
+  console.log(`Cleaning up all OmniFocus items with prefix "${TEST_PREFIX}"...`);
+
+  const types = ['task', 'project', 'tag', 'folder'] as const;
+
+  for (const type of types) {
+    const items = await findItemsByPrefix(TEST_PREFIX, type);
+    if (items.length === 0) {
+      console.log(`  ${type}s: none found`);
+      continue;
+    }
+    console.log(`  ${type}s: found ${items.length}`);
+    for (const item of items) {
+      try {
+        await safeDeleteById(item.id, type);
+        console.log(`    deleted: ${item.name}`);
+      } catch (error: any) {
+        console.warn(`    FAILED to delete ${item.name}: ${error.message}`);
+      }
+    }
+  }
+
+  console.log('Cleanup complete.');
+}
+
+main().catch(error => {
+  console.error('Cleanup failed:', error);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/tests/integration/cleanup.ts
+git commit -m "Add standalone cleanup script for crashed test runs"
+```
+
+---
+
+## Chunk 2: Test Suites
+
+### Task 6: Task Lifecycle Tests
+
+**Files:**
+- Create: `src/tests/integration/task-lifecycle.test.ts`
+
+- [ ] **Step 1: Create task-lifecycle.test.ts with create tests**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  setupIntegration,
+  registry,
+  createTrackedTask,
+  editItem,
+  safeRemoveTracked,
+} from './setup.js';
+
+describe('Task Lifecycle (integration)', () => {
+  setupIntegration();
+
+  let inboxTaskId: string;
+  let projectTaskId: string;
+
+  it('creates an inbox task', async () => {
+    const result = await createTrackedTask({ name: 'TEST:Inbox Task' });
+    expect(result.success).toBe(true);
+    expect(result.taskId).toBeTruthy();
+    inboxTaskId = result.taskId!;
+  });
+
+  it('creates a task in the test project', async () => {
+    const result = await createTrackedTask({
+      name: 'TEST:Project Task',
+      projectName: registry.testProject,
+    });
+    expect(result.success).toBe(true);
+    expect(result.taskId).toBeTruthy();
+    projectTaskId = result.taskId!;
+  });
+
+  it('moves inbox task to the test project', async () => {
+    const result = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newProjectName: registry.testProject,
+    });
+    expect(result.success).toBe(true);
+    expect(result.changedProperties).toContain('project');
+  });
+
+  it('edits task properties', async () => {
+    const result = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newName: 'TEST:Renamed Task',
+      newFlagged: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.changedProperties).toContain('name');
+    expect(result.changedProperties).toContain('flagged');
+  });
+
+  it('marks task complete then incomplete', async () => {
+    const complete = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newStatus: 'completed',
+    });
+    expect(complete.success).toBe(true);
+
+    const incomplete = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newStatus: 'incomplete',
+    });
+    expect(incomplete.success).toBe(true);
+  });
+
+  it('marks task dropped', async () => {
+    const result = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newStatus: 'dropped',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('removes a task', async () => {
+    const result = await safeRemoveTracked(projectTaskId, 'task');
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `npm run test:integration`
+Expected: All tests pass (OmniFocus must be running). Tests create items inside the run folder, exercise CRUD, and clean up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tests/integration/task-lifecycle.test.ts
+git commit -m "Add task lifecycle integration tests"
+```
+
+---
+
+### Task 7: Project Lifecycle Tests
+
+**Files:**
+- Create: `src/tests/integration/project-lifecycle.test.ts`
+
+- [ ] **Step 1: Create project-lifecycle.test.ts**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  setupIntegration,
+  registry,
+  createTrackedProject,
+  createTrackedTask,
+  editItem,
+  safeRemoveTracked,
+} from './setup.js';
+
+describe('Project Lifecycle (integration)', () => {
+  setupIntegration();
+
+  let projectId: string;
+
+  it('creates a project in the run folder', async () => {
+    const result = await createTrackedProject({
+      name: 'TEST:New Project',
+      folderName: registry.runFolder,
+    });
+    expect(result.success).toBe(true);
+    expect(result.projectId).toBeTruthy();
+    projectId = result.projectId!;
+  });
+
+  it('edits project properties', async () => {
+    const result = await editItem({
+      itemType: 'project',
+      id: projectId,
+      newName: 'TEST:Edited Project',
+      newSequential: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.changedProperties).toContain('name');
+    expect(result.changedProperties).toContain('sequential');
+  });
+
+  it('changes project status', async () => {
+    const onHold = await editItem({
+      itemType: 'project',
+      id: projectId,
+      newProjectStatus: 'onHold',
+    });
+    expect(onHold.success).toBe(true);
+
+    const active = await editItem({
+      itemType: 'project',
+      id: projectId,
+      newProjectStatus: 'active',
+    });
+    expect(active.success).toBe(true);
+  });
+
+  it('adds a task to the project', async () => {
+    const result = await createTrackedTask({
+      name: 'TEST:Child Task',
+      projectName: 'TEST:Edited Project',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('removes the project', async () => {
+    const result = await safeRemoveTracked(projectId, 'project');
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `npm run test:integration`
+Expected: All tests in both suites pass.
+
+- [ ] **Step 3: Run unit tests to verify no interference**
+
+Run: `npm test`
+Expected: All 68 unit tests still pass. Integration tests not included.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tests/integration/project-lifecycle.test.ts
+git commit -m "Add project lifecycle integration tests"
+```
+
+---
+
+### Task 8: Final Verification and Cleanup
+
+- [ ] **Step 1: Run full integration suite end-to-end**
+
+Run: `npm run test:integration`
+Expected: All tests pass. Verify in OmniFocus that no TEST: items remain after the run.
+
+- [ ] **Step 2: Test the standalone cleanup script**
+
+Create a TEST: item manually in OmniFocus (or let a test fail mid-run), then:
+Run: `npm run test:integration:cleanup`
+Expected: Script finds and removes all TEST: prefixed items, reports what it deleted.
+
+- [ ] **Step 3: Run unit tests one more time**
+
+Run: `npm test`
+Expected: All 68 unit tests pass.
+
+- [ ] **Step 4: Commit everything and push**
+
+```bash
+git add -A
+git commit -m "Integration test infrastructure complete"
+git push origin feature/task-moves-and-fixes
+```

--- a/docs/superpowers/specs/2026-03-15-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-03-15-test-infrastructure-design.md
@@ -1,0 +1,125 @@
+# Test Infrastructure Design
+
+## Summary
+
+Add Vitest test infrastructure to the OmniFocus MCP server. Export `generateAppleScript` functions from primitives for direct unit testing. Write thorough structural tests for new/changed code and smoke tests for existing primitives. Add a `prepare` script to `package.json` so TypeScript compiles on install.
+
+## Motivation
+
+The codebase has zero tests. Recent improvements (task project moves, folder path disambiguation, AppleScript fixes) generate complex AppleScript strings that are easy to get wrong and hard to manually verify. Pure function testing catches regressions without needing OmniFocus running.
+
+## Framework
+
+**Vitest** — native ESM and TypeScript support, zero-config for this project shape, fast execution.
+
+## Test Strategy
+
+**Structural assertions** — tests assert that generated AppleScript contains (or doesn't contain) specific commands and patterns. This tests intent rather than exact formatting, making tests resilient to whitespace or ordering changes.
+
+**Co-located test files** — `*.test.ts` files sit next to the source files they test.
+
+## Source Changes
+
+Export `generateAppleScript` from these primitives (function is currently private in each):
+
+- `src/tools/primitives/editItem.ts`
+- `src/tools/primitives/addProject.ts`
+- `src/tools/primitives/addOmniFocusTask.ts`
+- `src/tools/primitives/removeItem.ts`
+
+Note: `batchAddItems.ts` is excluded — it is an orchestrator that delegates to `addOmniFocusTask`/`addProject` and has no `generateAppleScript` function of its own.
+
+No other source logic changes. The functions are internal server modules, not a public library API.
+
+## Test Files
+
+### `src/utils/appleScriptHelpers.test.ts` — Thorough
+
+Tests for `generateFolderLookupScript`:
+
+- Single-name folder lookup (e.g., `"Work"`) — generates `first flattened folder where name =`
+- Multi-segment path (e.g., `"Work/Engineering"`) — generates ancestor chain walk
+- Three-level path (e.g., `"A/B/C"`) — correct component count and leaf name
+- Special characters in folder name (quotes, backslashes) — properly escaped
+- Empty/whitespace input — returns `missing value` assignment
+- Error return JSON — embedded correctly in `return` statement
+
+### `src/tools/primitives/editItem.test.ts` — Thorough (new code)
+
+Tests for `generateAppleScript`:
+
+- `newProjectName` set to a project name — contains `move foundItem to destProject` and project lookup loop
+- `newProjectName` set to empty string — contains `set assigned container of foundItem to missing value`
+- `newProjectName` set to `"inbox"` — same inbox behavior as empty string
+- `newStatus: "dropped"` — contains `mark dropped foundItem`, does NOT contain `set dropped of`
+- `newStatus: "incomplete"` — contains `mark incomplete foundItem`, does NOT contain `set completed of foundItem to false`
+- `newStatus: "completed"` — contains `mark complete foundItem` (existing, unchanged)
+- `newFolderName` with path — contains ancestor chain walk (from `generateFolderLookupScript`)
+- Tag add/remove/replace — generates correct AppleScript (smoke level)
+- Requires either `id` or `name` — error return when both missing
+
+### `src/tools/primitives/addProject.test.ts` — Thorough (changed code)
+
+Tests for `generateAppleScript`:
+
+- No folder — contains `make new project with properties` at root
+- Simple folder name — contains folder lookup
+- Nested folder path — contains ancestor chain walk
+- Special characters in project name — properly escaped
+- Note with quotes — properly escaped
+- Tags — generates tag lookup/creation blocks
+- Sequential flag — generates `set sequential of newProject to true/false`
+
+### `src/tools/primitives/addOmniFocusTask.test.ts` — Smoke
+
+- Basic task (name only) — generates `make new inbox task`
+- Task with project — generates project lookup and `make new task ... at end of tasks of theProject`
+
+### `src/tools/primitives/removeItem.test.ts` — Smoke
+
+- Remove task by name — generates task search loop
+
+## Configuration
+
+### `vitest.config.ts` (project root)
+
+Minimal config pointing at `src/`:
+
+```typescript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});
+```
+
+### `tsconfig.json`
+
+Exclude test files from compilation output (they shouldn't end up in `dist/`):
+
+```json
+"exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+```
+
+### `package.json` changes
+
+```json
+"scripts": {
+  "test": "vitest run",
+  "prepare": "npm run build",   # replaces existing prepublishOnly
+  ...existing scripts...
+},
+"devDependencies": {
+  "vitest": "^3.1.0",
+  ...existing deps...
+}
+```
+
+## What Is NOT In Scope
+
+- Integration tests that require OmniFocus running
+- Tests for the JXA/OmniJS query scripts (`queryOmnifocus`, `dumpDatabase`, `listPerspectives`, etc.) — these generate JavaScript, not AppleScript, and would need a different testing approach
+- Tests for MCP resource handlers or server registration
+- Mocking `execAsync` for end-to-end primitive testing

--- a/docs/superpowers/specs/2026-03-16-integration-tests-design.md
+++ b/docs/superpowers/specs/2026-03-16-integration-tests-design.md
@@ -1,0 +1,197 @@
+# Integration Test Infrastructure Design
+
+## Summary
+
+Add integration tests that execute real AppleScript against OmniFocus to verify end-to-end behavior. Tests are isolated via a **run-scoped container** — a unique folder created per test run that owns all test data. Only items created in that specific run are cleaned up. Tests run via a separate vitest config so they never execute during `npm test`.
+
+## Motivation
+
+Unit tests verify generated AppleScript strings but can't catch runtime issues like indirect references, silent failures, or OmniFocus API quirks. We've hit several bugs (loop references, move vs assigned container, whose clause) that only manifest at execution time. Integration tests catch these.
+
+## Safety Model: Run-Scoped Containment
+
+The previous design relied on a `TEST:` name prefix and global cleanup ("delete everything named TEST:"). That's fragile — it can't distinguish between runs, risks collisions, and could delete legitimate items if a name happens to match.
+
+The new model is: **only items created in this specific run, tracked by ID, inside a unique container, are safe to destroy.**
+
+### Three Layers of Safety
+
+**Layer 1: Unique run container**
+Each test run creates a folder with a unique name: `TEST:<timestamp>` (e.g. `TEST:1710612345678`). All test projects and tasks are created inside this folder. The folder acts as a blast radius boundary — nothing outside it is touched.
+
+**Layer 2: Item registry (tracked by ID)**
+A `TestRegistry` tracks the OmniFocus ID of every item created during the run. Cleanup iterates this registry and deletes by ID — never by name pattern or glob. If an item wasn't created by this run, its ID isn't in the registry, and it won't be deleted.
+
+**Layer 3: TEST: prefix as defense-in-depth**
+Items still use the `TEST:` prefix in their names as an additional safety check. Before any delete, verify the resolved name starts with `TEST:`. This catches bugs where an ID was somehow wrong. But the prefix is the last line of defense, not the primary mechanism.
+
+### Why This Is Better
+
+| Concern | Old (prefix-based) | New (run-scoped) |
+|---------|-------------------|------------------|
+| Parallel runs | Collision — both see each other's TEST: items | Safe — each has unique container + registry |
+| Crashed run leaves items | Global cleanup deletes ALL TEST: items (maybe from another run) | Standalone cleanup targets a specific run folder by name |
+| Accidental name match | Deletes legitimate item named "TEST: something" | Only deletes tracked IDs inside the run container |
+| Ambiguous deletes | Name-based lookup could match wrong item | ID-based deletion is unambiguous |
+
+## TestRegistry
+
+Central tracking object, shared across the test run:
+
+```typescript
+class TestRegistry {
+  private items: Map<string, { id: string; name: string; type: 'task' | 'project' | 'tag' | 'folder' }>;
+
+  /** The unique run folder name, e.g. "TEST:1710612345678" */
+  readonly runFolder: string;
+
+  /** Record an item created during this run */
+  track(id: string, name: string, type: 'task' | 'project' | 'tag' | 'folder'): void;
+
+  /** Get all tracked items of a given type */
+  getByType(type: string): Array<{ id: string; name: string }>;
+
+  /** Remove an item from tracking (after successful deletion) */
+  untrack(id: string): void;
+
+  /** Clean up all tracked items in safe order: tasks → projects → tags → folder */
+  async cleanupAll(): Promise<void>;
+}
+```
+
+The registry is instantiated in `setup.ts` and exported for use in test files.
+
+## Test Lifecycle
+
+### Setup (`beforeAll`)
+
+1. **Pre-flight check** — run trivial AppleScript to verify OmniFocus is running; skip suite with clear message if not
+2. **Create run folder** — `make new folder with properties {name:"TEST:1710612345678"}` via AppleScript; track the folder ID in the registry
+3. **Create test project** — `addProject({ name: 'TEST:Sample Project', folderName: 'TEST:1710612345678' })`; track the project ID
+
+### Teardown (`afterAll`)
+
+1. **`registry.cleanupAll()`** — iterates tracked items in safe order:
+   - Delete all tracked tasks (by ID, with TEST: prefix verification on resolved name)
+   - Delete all tracked projects (by ID, with same verification)
+   - Delete all tracked tags (by ID, with same verification)
+   - Delete the run folder (by ID, with same verification)
+2. If any delete fails, log a warning but continue (don't let one failure prevent the rest from being cleaned up)
+
+### Standalone Cleanup (`cleanup.ts`)
+
+For crashed runs that left items behind. Takes a different approach since we don't have the registry:
+- Lists all OmniFocus folders whose name matches `TEST:*` pattern
+- For each, deletes all contents (tasks, projects) inside the folder, then the folder itself
+- Also deletes any tags matching `TEST:*`
+- This is the only place that uses name-pattern-based deletion, and it's a manually invoked escape hatch, not automated
+
+## New AppleScript Helpers
+
+Internal to test infrastructure only — NOT new MCP tools:
+
+- **`createFolder(name: string)`** — `make new folder with properties {name:...}`, returns the created folder's ID
+- **`deleteFolderById(id: string)`** — Deletes folder by ID after verifying its name starts with `TEST:`
+- **`deleteTagById(id: string)`** — Deletes tag by ID after verifying its name starts with `TEST:`
+- **`resolveItemName(id: string, type: string)`** — Looks up an item's current name by ID (for safety verification before delete)
+- **`findItemsByPrefix(prefix: string, type: string)`** — For standalone cleanup only; finds items whose name starts with prefix
+
+## Test Runner Configuration
+
+### Vitest Config Changes
+
+**`vitest.config.ts`** (modify existing) — exclude integration tests:
+```typescript
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['src/tests/integration/**'],
+  },
+});
+```
+
+**`vitest.integration.config.ts`** (new) — integration tests only:
+```typescript
+export default defineConfig({
+  test: {
+    include: ['src/tests/integration/**/*.test.ts'],
+    testTimeout: 30000,
+    sequence: { concurrent: false, shuffle: false },
+  },
+});
+```
+
+### Package.json Scripts
+
+```json
+{
+  "test": "vitest run",
+  "test:integration": "vitest run --config vitest.integration.config.ts",
+  "test:integration:cleanup": "npx tsx src/tests/integration/cleanup.ts"
+}
+```
+
+## File Structure
+
+```
+src/tests/integration/
+  registry.ts               — TestRegistry class
+  helpers.ts                — AppleScript helpers (createFolder, deleteById, resolveItemName, etc.)
+  setup.ts                  — Global beforeAll/afterAll, creates registry and run folder
+  cleanup.ts                — Standalone cleanup script for crashed runs
+  task-lifecycle.test.ts    — Full task CRUD lifecycle
+  project-lifecycle.test.ts — Full project CRUD lifecycle
+```
+
+## Test Suites
+
+### Wrapped Create Helpers
+
+Each test file imports convenience wrappers that call the real primitives AND track the result in the registry:
+
+```typescript
+// In the test file
+const task = await createTrackedTask(registry, { name: 'TEST:Inbox Task' });
+// Calls addOmniFocusTask, parses result, registers task.id in registry
+```
+
+This ensures every created item is automatically tracked for cleanup.
+
+### `task-lifecycle.test.ts`
+
+Tests run sequentially (shuffle disabled), building on each other. If an early test fails, later tests in the suite will also fail — this is expected for lifecycle tests.
+
+1. **Create inbox task** — `createTrackedTask({ name: 'TEST:Inbox Task' })`, query to verify it exists in inbox
+2. **Create project task** — `createTrackedTask({ name: 'TEST:Project Task', projectName: registry.testProject })`, query to verify
+3. **Move inbox task to project** — `editItem({ id: task.id, newProjectName: registry.testProject })`, query to verify it moved
+4. **Edit task properties** — Rename to `TEST:Renamed Task`, set due date, flag, add tags (`TEST:Tag A`); track the tag
+5. **Change task status** — Mark complete, verify; mark incomplete, verify; mark dropped, verify
+6. **Remove task** — `safeRemoveById(registry, task.id)`, verify gone, untrack from registry
+
+### `project-lifecycle.test.ts`
+
+1. **Create project** — `createTrackedProject({ name: 'TEST:New Project', folderName: registry.runFolder })`, query to verify
+2. **Edit project** — Rename to `TEST:Edited Project`, change status, set sequential
+3. **Add tasks to project** — Create tracked tasks, verify they appear under project
+4. **Remove project** — `safeRemoveById(registry, project.id)`, verify tasks are also removed
+
+### Batch Operations (in either file)
+
+- **Batch add** — `batchAddItems` with mix of tasks and projects, all TEST: prefixed; parse result and track all IDs
+- **Batch remove** — `batchRemoveItems` on the batch-added items by tracked ID
+
+## What Is NOT In Scope
+
+- Performance benchmarking
+- Testing perspectives, tags listing, or database dump (read-only, low risk)
+- Testing concurrent access or sync behavior
+- CI/CD integration (these require a Mac with OmniFocus installed)
+- Mocking OmniFocus — the whole point is real execution
+- New MCP tools for folder/tag management (helpers are internal to tests only)
+
+## Execution Requirements
+
+- OmniFocus must be running on the Mac (pre-flight check verifies this)
+- Tests modify real OmniFocus data (but only tracked items inside the run container)
+- Tests must run sequentially (OmniFocus state is shared)
+- Default timeout 30s per test; individual tests can override with `{ timeout: 60000 }` for batch operations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnifocus-mcp",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnifocus-mcp",
-      "version": "1.6.1",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
@@ -17,8 +17,50 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.19",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.8.0",
@@ -41,6 +83,348 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.17.28",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
@@ -49,6 +433,92 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -62,6 +532,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/body-parser": {
@@ -160,6 +640,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -180,6 +670,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.1",
@@ -252,6 +749,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -299,6 +806,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -316,6 +830,16 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -345,6 +869,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -405,6 +939,24 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -461,6 +1013,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -600,6 +1167,277 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -666,6 +1504,25 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -695,6 +1552,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -744,6 +1612,33 @@
         "node": ">=16"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
@@ -751,6 +1646,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -803,6 +1727,40 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
       }
     },
     "node_modules/router": {
@@ -1012,6 +1970,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1019,6 +2001,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1029,6 +2062,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -1092,6 +2133,194 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": "0.115.0",
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.9",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1105,6 +2334,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "copy-files": "mkdir -p dist/utils/omnifocusScripts && cp src/utils/omnifocusScripts/*.js dist/utils/omnifocusScripts/",
     "start": "node dist/server.js",
     "dev": "tsc -w",
-    "prepublishOnly": "npm run build"
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:integration:cleanup": "npx tsx src/tests/integration/cleanup.ts",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
@@ -20,7 +23,8 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.19",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/tests/integration/cleanup.ts
+++ b/src/tests/integration/cleanup.ts
@@ -1,0 +1,28 @@
+import { findItemsByPrefix, safeDeleteById, TEST_PREFIX } from './helpers.js';
+
+async function main() {
+  console.log(`Cleaning up all OmniFocus items with prefix "${TEST_PREFIX}"...`);
+  const types = ['task', 'project', 'tag', 'folder'] as const;
+  for (const type of types) {
+    const items = await findItemsByPrefix(TEST_PREFIX, type);
+    if (items.length === 0) {
+      console.log(`  ${type}s: none found`);
+      continue;
+    }
+    console.log(`  ${type}s: found ${items.length}`);
+    for (const item of items) {
+      try {
+        await safeDeleteById(item.id, type);
+        console.log(`    deleted: ${item.name}`);
+      } catch (error: any) {
+        console.warn(`    FAILED to delete ${item.name}: ${error.message}`);
+      }
+    }
+  }
+  console.log('Cleanup complete.');
+}
+
+main().catch(error => {
+  console.error('Cleanup failed:', error);
+  process.exit(1);
+});

--- a/src/tests/integration/helpers.ts
+++ b/src/tests/integration/helpers.ts
@@ -1,0 +1,107 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const execAsync = promisify(exec);
+
+export const TEST_PREFIX = 'TEST:';
+
+export async function execAppleScript(script: string): Promise<string> {
+  const tempFile = join(tmpdir(), `test_omnifocus_${Date.now()}.applescript`);
+  try {
+    writeFileSync(tempFile, script);
+    const { stdout } = await execAsync(`osascript "${tempFile}"`);
+    return stdout.trim();
+  } finally {
+    try { unlinkSync(tempFile); } catch { /* ignore */ }
+  }
+}
+
+export function assertTestPrefix(name: string): void {
+  if (!name.startsWith(TEST_PREFIX)) {
+    throw new Error(`Safety check failed: "${name}" does not start with "${TEST_PREFIX}"`);
+  }
+}
+
+export async function assertOmniFocusRunning(): Promise<void> {
+  try {
+    const result = await execAppleScript('tell application "OmniFocus" to return "ok"');
+    if (!result.includes('ok')) throw new Error('Unexpected response');
+  } catch (error: any) {
+    throw new Error(`OmniFocus is not running or not accessible. Integration tests require OmniFocus.\n${error.message}`);
+  }
+}
+
+export async function createFolder(name: string): Promise<string> {
+  assertTestPrefix(name);
+  const escapedName = name.replace(/["\\]/g, '\\$&');
+  const result = await execAppleScript(`
+    tell application "OmniFocus"
+      tell front document
+        set newFolder to make new folder with properties {name:"${escapedName}"}
+        return id of newFolder as string
+      end tell
+    end tell
+  `);
+  return result;
+}
+
+export async function resolveItemName(id: string, type: 'task' | 'project' | 'tag' | 'folder'): Promise<string | null> {
+  const escapedId = id.replace(/["\\]/g, '\\$&');
+  const singular = type === 'task' ? 'flattened task' : type === 'project' ? 'flattened project' : type === 'tag' ? 'flattened tag' : 'flattened folder';
+  try {
+    const result = await execAppleScript(`
+      tell application "OmniFocus"
+        tell front document
+          set foundItem to first ${singular} whose id is "${escapedId}"
+          return name of foundItem
+        end tell
+      end tell
+    `);
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function safeDeleteById(id: string, type: 'task' | 'project' | 'tag' | 'folder'): Promise<boolean> {
+  const name = await resolveItemName(id, type);
+  if (name === null) return false;
+  assertTestPrefix(name);
+  const escapedId = id.replace(/["\\]/g, '\\$&');
+  const singular = type === 'task' ? 'flattened task' : type === 'project' ? 'flattened project' : type === 'tag' ? 'flattened tag' : 'flattened folder';
+  await execAppleScript(`
+    tell application "OmniFocus"
+      tell front document
+        delete (first ${singular} whose id is "${escapedId}")
+      end tell
+    end tell
+  `);
+  return true;
+}
+
+export async function findItemsByPrefix(prefix: string, type: 'task' | 'project' | 'tag' | 'folder'): Promise<Array<{ id: string; name: string }>> {
+  const escapedPrefix = prefix.replace(/["\\]/g, '\\$&');
+  const collection = type === 'task' ? 'flattened tasks' : type === 'project' ? 'flattened projects' : type === 'tag' ? 'flattened tags' : 'flattened folders';
+  const result = await execAppleScript(`
+    tell application "OmniFocus"
+      tell front document
+        set matches to {}
+        repeat with anItem in ${collection}
+          if name of anItem starts with "${escapedPrefix}" then
+            set end of matches to (id of anItem as string) & "|||" & name of anItem
+          end if
+        end repeat
+        set AppleScript's text item delimiters to "\\n"
+        return matches as text
+      end tell
+    end tell
+  `);
+  if (!result) return [];
+  return result.split('\n').filter(Boolean).map(line => {
+    const [id, name] = line.split('|||');
+    return { id, name };
+  });
+}

--- a/src/tests/integration/project-lifecycle.test.ts
+++ b/src/tests/integration/project-lifecycle.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setupIntegration,
+  registry,
+  createTrackedProject,
+  createTrackedTask,
+  editItem,
+  safeRemoveTracked,
+} from './setup.js';
+
+describe('Project Lifecycle (integration)', () => {
+  setupIntegration();
+
+  let projectId: string;
+
+  it('creates a project in the run folder', async () => {
+    const result = await createTrackedProject({
+      name: 'TEST:New Project',
+      folderName: registry.runFolder,
+    });
+    expect(result.success).toBe(true);
+    expect(result.projectId).toBeTruthy();
+    projectId = result.projectId!;
+  });
+
+  it('edits project properties', async () => {
+    const result = await editItem({
+      itemType: 'project',
+      id: projectId,
+      newName: 'TEST:Edited Project',
+      newSequential: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.changedProperties).toContain('name');
+    expect(result.changedProperties).toContain('sequential');
+  });
+
+  it('changes project status', async () => {
+    const onHold = await editItem({
+      itemType: 'project',
+      id: projectId,
+      newProjectStatus: 'onHold',
+    });
+    expect(onHold.success).toBe(true);
+
+    const active = await editItem({
+      itemType: 'project',
+      id: projectId,
+      newProjectStatus: 'active',
+    });
+    expect(active.success).toBe(true);
+  });
+
+  it('adds a task to the project', async () => {
+    const result = await createTrackedTask({
+      name: 'TEST:Child Task',
+      projectName: 'TEST:Edited Project',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('removes the project', async () => {
+    const result = await safeRemoveTracked(projectId, 'project');
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/tests/integration/registry.ts
+++ b/src/tests/integration/registry.ts
@@ -1,0 +1,48 @@
+import { safeDeleteById } from './helpers.js';
+
+type ItemType = 'task' | 'project' | 'tag' | 'folder';
+
+interface TrackedItem {
+  id: string;
+  name: string;
+  type: ItemType;
+}
+
+export class TestRegistry {
+  private items = new Map<string, TrackedItem>();
+  readonly runFolder: string;
+  runFolderId: string = '';
+  readonly testProject: string;
+  testProjectId: string = '';
+
+  constructor() {
+    this.runFolder = `TEST:${Date.now()}`;
+    this.testProject = `TEST:Sample Project`;
+  }
+
+  track(id: string, name: string, type: ItemType): void {
+    this.items.set(id, { id, name, type });
+  }
+
+  getByType(type: ItemType): TrackedItem[] {
+    return [...this.items.values()].filter(item => item.type === type);
+  }
+
+  untrack(id: string): void {
+    this.items.delete(id);
+  }
+
+  async cleanupAll(): Promise<void> {
+    const order: ItemType[] = ['task', 'project', 'tag', 'folder'];
+    for (const type of order) {
+      for (const item of this.getByType(type)) {
+        try {
+          await safeDeleteById(item.id, item.type);
+          this.untrack(item.id);
+        } catch (error) {
+          console.warn(`Cleanup warning: failed to delete ${item.type} "${item.name}" (${item.id}):`, error);
+        }
+      }
+    }
+  }
+}

--- a/src/tests/integration/setup.ts
+++ b/src/tests/integration/setup.ts
@@ -1,0 +1,66 @@
+import { beforeAll, afterAll } from 'vitest';
+import { TestRegistry } from './registry.js';
+import { assertOmniFocusRunning, createFolder, TEST_PREFIX } from './helpers.js';
+import { addOmniFocusTask } from '../../tools/primitives/addOmniFocusTask.js';
+import { addProject } from '../../tools/primitives/addProject.js';
+import { editItem } from '../../tools/primitives/editItem.js';
+import { removeItem } from '../../tools/primitives/removeItem.js';
+import { batchAddItems } from '../../tools/primitives/batchAddItems.js';
+import { batchRemoveItems } from '../../tools/primitives/batchRemoveItems.js';
+
+export const registry = new TestRegistry();
+
+export async function createTrackedTask(
+  params: Parameters<typeof addOmniFocusTask>[0]
+): Promise<{ success: boolean; taskId?: string; error?: string }> {
+  const result = await addOmniFocusTask(params);
+  if (result.success && result.taskId) {
+    registry.track(result.taskId, params.name, 'task');
+  }
+  return result;
+}
+
+export async function createTrackedProject(
+  params: Parameters<typeof addProject>[0]
+): Promise<{ success: boolean; projectId?: string; error?: string }> {
+  const result = await addProject(params);
+  if (result.success && result.projectId) {
+    registry.track(result.projectId, params.name, 'project');
+  }
+  return result;
+}
+
+export async function safeRemoveTracked(
+  id: string,
+  itemType: 'task' | 'project'
+): Promise<{ success: boolean; error?: string }> {
+  const result = await removeItem({ id, itemType });
+  if (result.success) {
+    registry.untrack(id);
+  }
+  return result;
+}
+
+export { editItem, removeItem, batchAddItems, batchRemoveItems };
+
+export function setupIntegration() {
+  beforeAll(async () => {
+    await assertOmniFocusRunning();
+    const folderId = await createFolder(registry.runFolder);
+    registry.runFolderId = folderId;
+    registry.track(folderId, registry.runFolder, 'folder');
+    const projResult = await addProject({
+      name: registry.testProject,
+      folderName: registry.runFolder,
+    });
+    if (!projResult.success || !projResult.projectId) {
+      throw new Error(`Failed to create test project: ${projResult.error}`);
+    }
+    registry.testProjectId = projResult.projectId;
+    registry.track(projResult.projectId, registry.testProject, 'project');
+  }, 60000);
+
+  afterAll(async () => {
+    await registry.cleanupAll();
+  }, 60000);
+}

--- a/src/tests/integration/task-lifecycle.test.ts
+++ b/src/tests/integration/task-lifecycle.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setupIntegration,
+  registry,
+  createTrackedTask,
+  editItem,
+  safeRemoveTracked,
+} from './setup.js';
+
+describe('Task Lifecycle (integration)', () => {
+  setupIntegration();
+
+  let inboxTaskId: string;
+  let projectTaskId: string;
+
+  it('creates an inbox task', async () => {
+    const result = await createTrackedTask({ name: 'TEST:Inbox Task' });
+    expect(result.success).toBe(true);
+    expect(result.taskId).toBeTruthy();
+    inboxTaskId = result.taskId!;
+  });
+
+  it('creates a task in the test project', async () => {
+    const result = await createTrackedTask({
+      name: 'TEST:Project Task',
+      projectName: registry.testProject,
+    });
+    expect(result.success).toBe(true);
+    expect(result.taskId).toBeTruthy();
+    projectTaskId = result.taskId!;
+  });
+
+  it('moves inbox task to the test project', async () => {
+    expect(inboxTaskId).toBeTruthy();
+    const result = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newProjectName: registry.testProject,
+    });
+    expect(result.success).toBe(true);
+    expect(result.changedProperties).toContain('project');
+  });
+
+  it('moves task from project to a different project', async () => {
+    expect(inboxTaskId).toBeTruthy();
+    // Create a second project to move into
+    const { addProject } = await import('../../tools/primitives/addProject.js');
+    const projResult = await addProject({
+      name: 'TEST:Second Project',
+      folderName: registry.runFolder,
+    });
+    expect(projResult.success).toBe(true);
+    if (projResult.projectId) {
+      registry.track(projResult.projectId, 'TEST:Second Project', 'project');
+    }
+
+    // Move inboxTaskId (now in testProject) to second project
+    const result = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newProjectName: 'TEST:Second Project',
+    });
+    expect(result.success).toBe(true);
+    expect(result.changedProperties).toContain('project');
+  });
+
+  it('moves task from project to inbox', async () => {
+    expect(inboxTaskId).toBeTruthy();
+    const result = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newProjectName: '',
+    });
+    expect(result.success).toBe(true);
+    expect(result.changedProperties).toContain('inbox');
+  });
+
+  it('edits task properties', async () => {
+    expect(inboxTaskId).toBeTruthy();
+    const result = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newName: 'TEST:Renamed Task',
+      newFlagged: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.changedProperties).toContain('name');
+    expect(result.changedProperties).toContain('flagged');
+  });
+
+  it('marks task complete then incomplete', async () => {
+    expect(inboxTaskId).toBeTruthy();
+    const complete = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newStatus: 'completed',
+    });
+    expect(complete.success).toBe(true);
+
+    const incomplete = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newStatus: 'incomplete',
+    });
+    expect(incomplete.success).toBe(true);
+  });
+
+  it('marks task dropped', async () => {
+    expect(inboxTaskId).toBeTruthy();
+    const result = await editItem({
+      itemType: 'task',
+      id: inboxTaskId,
+      newStatus: 'dropped',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('removes a task', async () => {
+    expect(projectTaskId).toBeTruthy();
+    const result = await safeRemoveTracked(projectTaskId, 'task');
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -21,7 +21,8 @@ export const schema = z.object({
   addTags: z.array(z.string()).optional().describe("Tags to add to the task"),
   removeTags: z.array(z.string()).optional().describe("Tags to remove from the task"),
   replaceTags: z.array(z.string()).optional().describe("Tags to replace all existing tags with"),
-  
+  newProjectName: z.string().optional().describe("Move this task to a different project by name or folder path (e.g. 'My Project' or 'Work/My Project' to disambiguate). Pass an empty string or 'inbox' to move the task to the inbox. (tasks only)"),
+
   // Project-specific fields
   newSequential: z.boolean().optional().describe("Whether the project should be sequential"),
   newFolderName: z.string().optional().describe("New folder to move the project to"),

--- a/src/tools/primitives/addOmniFocusTask.test.ts
+++ b/src/tools/primitives/addOmniFocusTask.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { generateAppleScript } from './addOmniFocusTask.js';
+
+describe('addOmniFocusTask generateAppleScript', () => {
+  it('creates inbox task when no project specified', () => {
+    const script = generateAppleScript({ name: 'Buy milk' });
+    expect(script).toContain('make new inbox task with properties {name:"Buy milk"}');
+  });
+
+  it('creates task in project when projectName specified', () => {
+    const script = generateAppleScript({
+      name: 'Write tests',
+      projectName: 'Development',
+    });
+    expect(script).toContain('first flattened project where name = "Development"');
+    expect(script).toContain('make new task with properties {name:"Write tests"}');
+    expect(script).toContain('at end of tasks of theProject');
+  });
+});

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -26,19 +26,19 @@ export interface AddOmniFocusTaskParams {
 /**
  * Generate pure AppleScript for task creation
  */
-function generateAppleScript(params: AddOmniFocusTaskParams): string {
+export function generateAppleScript(params: AddOmniFocusTaskParams): string {
   // Sanitize and prepare parameters for AppleScript
-  const name = params.name.replace(/["\\]/g, '\\$&'); // Escape quotes and backslashes
-  const note = params.note?.replace(/["\\]/g, '\\$&') || '';
+  const name = params.name.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '); // Escape quotes and backslashes
+  const note = params.note?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
   const dueDate = params.dueDate || '';
   const deferDate = params.deferDate || '';
   const plannedDate = params.plannedDate || '';
   const flagged = params.flagged === true;
   const estimatedMinutes = params.estimatedMinutes?.toString() || '';
   const tags = params.tags || [];
-  const projectName = params.projectName?.replace(/["\\]/g, '\\$&') || '';
-  const parentTaskId = params.parentTaskId?.replace(/["\\]/g, '\\$&') || '';
-  const parentTaskName = params.parentTaskName?.replace(/["\\]/g, '\\$&') || '';
+  const projectName = params.projectName?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
+  const parentTaskId = params.parentTaskId?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
+  const parentTaskName = params.parentTaskName?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
 
   // Generate date constructions outside tell blocks
   let datePreScript = '';
@@ -182,7 +182,7 @@ function generateAppleScript(params: AddOmniFocusTaskParams): string {
         
         -- Add tags if provided
         ${tags.length > 0 ? tags.map(tag => {
-          const sanitizedTag = tag.replace(/["\\]/g, '\\$&');
+          const sanitizedTag = tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
           return `
           try
             set theTag to first flattened tag where name = "${sanitizedTag}"
@@ -224,7 +224,7 @@ export async function addOmniFocusTask(params: AddOmniFocusTaskParams): Promise<
     writeFileSync(tempFile, script, { encoding: 'utf8' });
 
     // Execute AppleScript from file
-    const { stdout, stderr } = await execAsync(`osascript ${tempFile}`);
+    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
 
     if (stderr) {
       console.error("AppleScript stderr:", stderr);

--- a/src/tools/primitives/addProject.test.ts
+++ b/src/tools/primitives/addProject.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { generateAppleScript, AddProjectParams } from './addProject.js';
+
+function makeParams(overrides: Partial<AddProjectParams> = {}): AddProjectParams {
+  return { name: 'Test Project', ...overrides };
+}
+
+describe('addProject generateAppleScript', () => {
+  describe('folder handling', () => {
+    it('creates project at root when no folder specified', () => {
+      const script = generateAppleScript(makeParams());
+      expect(script).toContain('make new project with properties {name:"Test Project"}');
+      expect(script).not.toContain('theFolder');
+    });
+
+    it('generates simple folder lookup for single name', () => {
+      const script = generateAppleScript(makeParams({ folderName: 'Work' }));
+      expect(script).toContain('first flattened folder where name = "Work"');
+      expect(script).toContain('at end of projects of theFolder');
+    });
+
+    it('generates ancestor chain walk for nested path', () => {
+      const script = generateAppleScript(makeParams({ folderName: 'Work/Engineering' }));
+      expect(script).toContain('pathComponents');
+      expect(script).toContain('"Work"');
+      expect(script).toContain('"Engineering"');
+      expect(script).toContain('ancestorOk');
+      expect(script).toContain('at end of projects of theFolder');
+    });
+
+    it('includes error return when folder not found', () => {
+      const script = generateAppleScript(makeParams({ folderName: 'Missing' }));
+      expect(script).toContain('Folder not found');
+      expect(script).toContain('Missing');
+    });
+  });
+
+  describe('special characters', () => {
+    it('escapes quotes in project name', () => {
+      const script = generateAppleScript(makeParams({ name: 'My "Project"' }));
+      expect(script).toContain('My \\"Project\\"');
+    });
+
+    it('escapes quotes in note', () => {
+      const script = generateAppleScript(makeParams({ note: 'A "quoted" note' }));
+      expect(script).toContain('set note of newProject to "A \\"quoted\\" note"');
+    });
+
+    it('escapes backslashes in project name', () => {
+      const script = generateAppleScript(makeParams({ name: 'Back\\slash' }));
+      expect(script).toContain('Back\\\\slash');
+    });
+  });
+
+  describe('tags', () => {
+    it('generates tag lookup and creation for tags', () => {
+      const script = generateAppleScript(makeParams({ tags: ['urgent', 'work'] }));
+      expect(script).toContain('"urgent"');
+      expect(script).toContain('"work"');
+      expect(script).toContain('first flattened tag where name =');
+      expect(script).toContain('add theTag to tags of newProject');
+    });
+
+    it('generates no tag block when tags empty', () => {
+      const script = generateAppleScript(makeParams({ tags: [] }));
+      expect(script).not.toContain('flattened tag');
+    });
+  });
+
+  describe('sequential flag', () => {
+    it('sets sequential to true', () => {
+      const script = generateAppleScript(makeParams({ sequential: true }));
+      expect(script).toContain('set sequential of newProject to true');
+    });
+
+    it('sets sequential to false by default', () => {
+      const script = generateAppleScript(makeParams());
+      expect(script).toContain('set sequential of newProject to false');
+    });
+  });
+
+  describe('dates', () => {
+    it('generates due date pre-script and assignment', () => {
+      const script = generateAppleScript(makeParams({ dueDate: '2026-03-20' }));
+      expect(script).toContain('copy current date to');
+      expect(script).toContain('set due date of newProject to');
+    });
+
+    it('generates defer date pre-script and assignment', () => {
+      const script = generateAppleScript(makeParams({ deferDate: '2026-03-15' }));
+      expect(script).toContain('set defer date of newProject to');
+    });
+  });
+
+  describe('other properties', () => {
+    it('sets flagged when true', () => {
+      const script = generateAppleScript(makeParams({ flagged: true }));
+      expect(script).toContain('set flagged of newProject to true');
+    });
+
+    it('does not set flagged when false', () => {
+      const script = generateAppleScript(makeParams({ flagged: false }));
+      expect(script).not.toContain('set flagged of newProject to true');
+    });
+
+    it('sets estimated minutes', () => {
+      const script = generateAppleScript(makeParams({ estimatedMinutes: 45 }));
+      expect(script).toContain('set estimated minutes of newProject to 45');
+    });
+
+    it('returns success JSON with project ID', () => {
+      const script = generateAppleScript(makeParams());
+      expect(script).toContain('success');
+      expect(script).toContain('projectId');
+    });
+  });
+});

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -1,6 +1,10 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { createDateOutsideTellBlock } from '../../utils/dateFormatting.js';
+import { generateFolderLookupScript } from '../../utils/appleScriptHelpers.js';
 const execAsync = promisify(exec);
 
 // Interface for project creation parameters
@@ -12,59 +16,62 @@ export interface AddProjectParams {
   flagged?: boolean;
   estimatedMinutes?: number;
   tags?: string[]; // Tag names
-  folderName?: string; // Folder name to add project to
+  folderName?: string; // Folder name or path (e.g. "Work/Engineering") to add project to
   sequential?: boolean; // Whether tasks should be sequential or parallel
 }
 
 /**
  * Generate pure AppleScript for project creation
  */
-function generateAppleScript(params: AddProjectParams): string {
+export function generateAppleScript(params: AddProjectParams): string {
   // Sanitize and prepare parameters for AppleScript
-  const name = params.name.replace(/["\\]/g, '\\$&'); // Escape quotes and backslashes
-  const note = params.note?.replace(/["\\]/g, '\\$&') || '';
+  const name = params.name.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '); // Escape quotes and backslashes
+  const note = params.note?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
   const dueDate = params.dueDate || '';
   const deferDate = params.deferDate || '';
   const flagged = params.flagged === true;
   const estimatedMinutes = params.estimatedMinutes?.toString() || '';
   const tags = params.tags || [];
-  const folderName = params.folderName?.replace(/["\\]/g, '\\$&') || '';
   const sequential = params.sequential === true;
-  
+
   // Generate date constructions outside tell blocks
   let datePreScript = '';
   let dueDateVar = '';
   let deferDateVar = '';
-  
+
   if (dueDate) {
     dueDateVar = `dueDate${Math.random().toString(36).substr(2, 9)}`;
     datePreScript += createDateOutsideTellBlock(dueDate, dueDateVar) + '\n\n';
   }
-  
+
   if (deferDate) {
     deferDateVar = `deferDate${Math.random().toString(36).substr(2, 9)}`;
     datePreScript += createDateOutsideTellBlock(deferDate, deferDateVar) + '\n\n';
   }
-  
+
+  // Build project creation block — either at root or in a folder
+  let projectCreationBlock: string;
+  if (params.folderName) {
+    const escapedFolderName = params.folderName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
+    const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${escapedFolderName}\\\"}`;
+    const folderLookup = generateFolderLookupScript(params.folderName, 'theFolder', errorJson);
+    projectCreationBlock = `
+        -- Find the folder (supports nested paths like "Work/Engineering")
+        ${folderLookup}
+        set newProject to make new project with properties {name:"${name}"} at end of projects of theFolder`;
+  } else {
+    projectCreationBlock = `
+        -- Create project at the root level
+        set newProject to make new project with properties {name:"${name}"}`;
+  }
+
   // Construct AppleScript with error handling
   let script = datePreScript + `
   try
     tell application "OmniFocus"
       tell front document
-        -- Determine the container (root or folder)
-        if "${folderName}" is "" then
-          -- Create project at the root level
-          set newProject to make new project with properties {name:"${name}"}
-        else
-          -- Use specified folder
-          try
-            set theFolder to first flattened folder where name = "${folderName}"
-            set newProject to make new project with properties {name:"${name}"} at end of projects of theFolder
-          on error
-            return "{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${folderName}\\\"}"
-          end try
-        end if
-        
+        ${projectCreationBlock}
+
         -- Set project properties
         ${note ? `set note of newProject to "${note}"` : ''}
         ${dueDate ? `
@@ -76,13 +83,13 @@ function generateAppleScript(params: AddProjectParams): string {
         ${flagged ? `set flagged of newProject to true` : ''}
         ${estimatedMinutes ? `set estimated minutes of newProject to ${estimatedMinutes}` : ''}
         ${`set sequential of newProject to ${sequential}`}
-        
+
         -- Get the project ID
         set projectId to id of newProject as string
-        
+
         -- Add tags if provided
         ${tags.length > 0 ? tags.map(tag => {
-          const sanitizedTag = tag.replace(/["\\]/g, '\\$&');
+          const sanitizedTag = tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
           return `
           try
             set theTag to first flattened tag where name = "${sanitizedTag}"
@@ -97,7 +104,7 @@ function generateAppleScript(params: AddProjectParams): string {
             end try
           end try`;
         }).join('\n') : ''}
-        
+
         -- Return success with project ID
         return "{\\\"success\\\":true,\\\"projectId\\\":\\"" & projectId & "\\",\\\"name\\\":\\"${name}\\"}"
       end tell
@@ -106,7 +113,7 @@ function generateAppleScript(params: AddProjectParams): string {
     return "{\\\"success\\\":false,\\\"error\\\":\\"" & errorMessage & "\\"}"
   end try
   `;
-  
+
   return script;
 }
 
@@ -114,25 +121,34 @@ function generateAppleScript(params: AddProjectParams): string {
  * Add a project to OmniFocus
  */
 export async function addProject(params: AddProjectParams): Promise<{success: boolean, projectId?: string, error?: string}> {
+  let tempFile: string | undefined;
+
   try {
     // Generate AppleScript
     const script = generateAppleScript(params);
-    
-    console.error("Executing AppleScript directly...");
-    
-    // Execute AppleScript directly
-    const { stdout, stderr } = await execAsync(`osascript -e '${script}'`);
-    
+
+    console.error("Executing AppleScript via temp file...");
+
+    // Write to a temporary AppleScript file to avoid shell escaping issues
+    tempFile = join(tmpdir(), `add_project_${Date.now()}.applescript`);
+    writeFileSync(tempFile, script, { encoding: 'utf8' });
+
+    // Execute AppleScript from file
+    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
+
+    // Clean up temp file
+    try { unlinkSync(tempFile); } catch {}
+
     if (stderr) {
       console.error("AppleScript stderr:", stderr);
     }
-    
+
     console.error("AppleScript stdout:", stdout);
-    
+
     // Parse the result
     try {
       const result = JSON.parse(stdout);
-      
+
       // Return the result
       return {
         success: result.success,
@@ -147,10 +163,15 @@ export async function addProject(params: AddProjectParams): Promise<{success: bo
       };
     }
   } catch (error: any) {
+    // Clean up temp file if it exists
+    if (tempFile) {
+      try { unlinkSync(tempFile); } catch {}
+    }
+
     console.error("Error in addProject:", error);
     return {
       success: false,
       error: error?.message || "Unknown error in addProject"
     };
   }
-} 
+}

--- a/src/tools/primitives/editItem.test.ts
+++ b/src/tools/primitives/editItem.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import { generateAppleScript, EditItemParams } from './editItem.js';
+
+function makeParams(overrides: Partial<EditItemParams>): EditItemParams {
+  return { itemType: 'task', name: 'Test Task', ...overrides };
+}
+
+describe('editItem generateAppleScript', () => {
+  describe('newProjectName — move task between projects', () => {
+    it('generates move to a named project', () => {
+      const script = generateAppleScript(makeParams({
+        newProjectName: 'Marketing',
+      }));
+      expect(script).toContain('move foundItem to end of tasks of destProject');
+      expect(script).toContain('first flattened project whose name is "Marketing"');
+      expect(script).toContain('project (moved to Marketing)');
+    });
+
+    it('generates move to inbox when newProjectName is empty string', () => {
+      const script = generateAppleScript(makeParams({
+        newProjectName: '',
+      }));
+      expect(script).toContain('set assigned container of foundItem to missing value');
+      expect(script).toContain('project (moved to inbox)');
+      expect(script).not.toContain('move foundItem to end of tasks of destProject');
+    });
+
+    it('generates move to inbox when newProjectName is "inbox"', () => {
+      const script = generateAppleScript(makeParams({
+        newProjectName: 'inbox',
+      }));
+      expect(script).toContain('set assigned container of foundItem to missing value');
+      expect(script).toContain('project (moved to inbox)');
+    });
+
+    it('generates move to inbox case-insensitively', () => {
+      const script = generateAppleScript(makeParams({
+        newProjectName: 'Inbox',
+      }));
+      expect(script).toContain('set assigned container of foundItem to missing value');
+    });
+
+    it('escapes special characters in project name', () => {
+      const script = generateAppleScript(makeParams({
+        newProjectName: 'My "Project"',
+      }));
+      expect(script).toContain('My \\"Project\\"');
+    });
+
+    it('generates folder-qualified project lookup for path', () => {
+      const script = generateAppleScript(makeParams({
+        newProjectName: 'Work/Community Outreach',
+      }));
+      expect(script).toContain('move foundItem to end of tasks of destProject');
+      expect(script).toContain('"Community Outreach"');
+      expect(script).toContain('folderPath');
+      expect(script).toContain('"Work"');
+      expect(script).toContain('container of aProject');
+    });
+
+    it('generates nested folder-qualified project lookup', () => {
+      const script = generateAppleScript(makeParams({
+        newProjectName: 'Personal/Committees/Community Outreach',
+      }));
+      expect(script).toContain('"Personal"');
+      expect(script).toContain('"Committees"');
+      expect(script).toContain('"Community Outreach"');
+      expect(script).toContain('folderPath');
+    });
+
+    it('does not generate project move for project itemType', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'Test Project',
+        newProjectName: 'Other',
+      });
+      // newProjectName is task-specific, should not appear for projects
+      expect(script).not.toContain('move foundItem to end of tasks of destProject');
+    });
+  });
+
+  describe('newStatus — task status changes', () => {
+    it('uses mark dropped for dropped status', () => {
+      const script = generateAppleScript(makeParams({
+        newStatus: 'dropped',
+      }));
+      expect(script).toContain('mark dropped foundItem');
+      expect(script).not.toContain('set dropped of foundItem to true');
+    });
+
+    it('uses mark incomplete for incomplete status', () => {
+      const script = generateAppleScript(makeParams({
+        newStatus: 'incomplete',
+      }));
+      expect(script).toContain('mark incomplete foundItem');
+      expect(script).not.toContain('set completed of foundItem to false');
+      expect(script).not.toContain('set dropped of foundItem to false');
+    });
+
+    it('uses mark complete for completed status', () => {
+      const script = generateAppleScript(makeParams({
+        newStatus: 'completed',
+      }));
+      expect(script).toContain('mark complete foundItem');
+    });
+  });
+
+  describe('newFolderName — project folder move with paths', () => {
+    it('generates folder path lookup for nested path', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'Test Project',
+        newFolderName: 'Work/Engineering',
+      });
+      expect(script).toContain('pathComponents');
+      expect(script).toContain('"Work"');
+      expect(script).toContain('"Engineering"');
+      expect(script).toContain('move {foundItem} to end of projects of destFolder');
+    });
+
+    it('generates simple folder lookup for single name', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'Test Project',
+        newFolderName: 'Work',
+      });
+      expect(script).toContain('first flattened folder where name = "Work"');
+      expect(script).toContain('move {foundItem} to end of projects of destFolder');
+    });
+  });
+
+  describe('tag operations', () => {
+    it('generates tag add script', () => {
+      const script = generateAppleScript(makeParams({
+        addTags: ['urgent', 'review'],
+      }));
+      expect(script).toContain('"urgent"');
+      expect(script).toContain('"review"');
+      expect(script).toContain('add tagObj to tags of foundItem');
+    });
+
+    it('generates tag remove script', () => {
+      const script = generateAppleScript(makeParams({
+        removeTags: ['old-tag'],
+      }));
+      expect(script).toContain('"old-tag"');
+      expect(script).toContain('remove tagObj from tags of foundItem');
+    });
+
+    it('generates tag replace script', () => {
+      const script = generateAppleScript(makeParams({
+        replaceTags: ['new-tag'],
+      }));
+      expect(script).toContain('"new-tag"');
+      expect(script).toContain('remove existingTag from tags of foundItem');
+      expect(script).toContain('add tagObj to tags of foundItem');
+    });
+  });
+
+  describe('item lookup', () => {
+    it('returns error when neither id nor name provided', () => {
+      const script = generateAppleScript({
+        itemType: 'task',
+      });
+      expect(script).toContain('success');
+      expect(script).toContain('false');
+      expect(script).toContain('Either id or name must be provided');
+    });
+
+    it('searches by id when provided', () => {
+      const script = generateAppleScript(makeParams({
+        id: 'abc123',
+      }));
+      expect(script).toContain('first flattened task whose id is "abc123"');
+    });
+
+    it('searches by name when no id', () => {
+      const script = generateAppleScript(makeParams({
+        name: 'My Task',
+      }));
+      expect(script).toContain('first flattened task whose name is "My Task"');
+    });
+
+    it('uses whose clause for direct references', () => {
+      const script = generateAppleScript(makeParams({
+        id: 'test123',
+      }));
+      expect(script).toContain('first flattened task whose id is');
+      expect(script).not.toContain('repeat with aTask');
+    });
+  });
+
+  describe('common properties', () => {
+    it('generates name update', () => {
+      const script = generateAppleScript(makeParams({
+        newName: 'Updated Name',
+      }));
+      expect(script).toContain('set name of foundItem to "Updated Name"');
+    });
+
+    it('generates note update', () => {
+      const script = generateAppleScript(makeParams({
+        newNote: 'A note',
+      }));
+      expect(script).toContain('set note of foundItem to "A note"');
+    });
+
+    it('generates flagged update', () => {
+      const script = generateAppleScript(makeParams({
+        newFlagged: true,
+      }));
+      expect(script).toContain('set flagged of foundItem to true');
+    });
+
+    it('generates estimated minutes update', () => {
+      const script = generateAppleScript(makeParams({
+        newEstimatedMinutes: 30,
+      }));
+      expect(script).toContain('set estimated minutes of foundItem to 30');
+    });
+  });
+
+  describe('project-specific fields', () => {
+    it('generates sequential update', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'P',
+        newSequential: true,
+      });
+      expect(script).toContain('set sequential of foundItem to true');
+    });
+
+    it('generates project status update', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'P',
+        newProjectStatus: 'onHold',
+      });
+      expect(script).toContain('set status of foundItem to on hold status');
+    });
+  });
+});

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -4,6 +4,7 @@ import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { generateDateAssignmentV2 } from '../../utils/dateFormatting.js';
+import { generateFolderLookupScript, generateProjectLookupScript } from '../../utils/appleScriptHelpers.js';
 const execAsync = promisify(exec);
 
 // Status options for tasks and projects
@@ -30,6 +31,7 @@ export interface EditItemParams {
   addTags?: string[];           // Tags to add to the task
   removeTags?: string[];        // Tags to remove from the task
   replaceTags?: string[];       // Tags to replace all existing tags with
+  newProjectName?: string;      // Move task to this project; empty string or 'inbox' = move to inbox
   
   // Project-specific fields
   newSequential?: boolean;      // Whether the project should be sequential
@@ -40,10 +42,10 @@ export interface EditItemParams {
 /**
  * Generate pure AppleScript for item editing with dates constructed outside tell blocks
  */
-function generateAppleScript(params: EditItemParams): string {
+export function generateAppleScript(params: EditItemParams): string {
   // Sanitize and prepare parameters for AppleScript
-  const id = params.id?.replace(/["\\]/g, '\\$&') || ''; // Escape quotes and backslashes
-  const name = params.name?.replace(/["\\]/g, '\\$&') || '';
+  const id = params.id?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || ''; // Escape quotes and backslashes
+  const name = params.name?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
   const itemType = params.itemType;
   
   // Verify we have at least one identifier
@@ -102,33 +104,17 @@ function generateAppleScript(params: EditItemParams): string {
   if (id) {
     if (itemType === 'task') {
       script += `
-      -- Try to find task by ID
-      repeat with aTask in (flattened tasks)
-        if (id of aTask as string) = "${id}" then
-          set foundItem to aTask
-          exit repeat
-        end if
-      end repeat
-      
-      -- If not found in projects, search in inbox
-      if foundItem is missing value then
-        repeat with aTask in (inbox tasks)
-          if (id of aTask as string) = "${id}" then
-            set foundItem to aTask
-            exit repeat
-          end if
-        end repeat
-      end if
+      -- Find task by ID (flattened tasks includes inbox tasks and returns direct references)
+      try
+        set foundItem to first flattened task whose id is "${id}"
+      end try
 `;
     } else {
       script += `
-      -- Try to find project by ID
-      repeat with aProject in (flattened projects)
-        if (id of aProject as string) = "${id}" then
-          set foundItem to aProject
-          exit repeat
-        end if
-      end repeat
+      -- Find project by ID
+      try
+        set foundItem to first flattened project whose id is "${id}"
+      end try
 `;
     }
   }
@@ -137,33 +123,17 @@ function generateAppleScript(params: EditItemParams): string {
   if (!id && name) {
     if (itemType === 'task') {
       script += `
-      -- Find task by name (search in projects first, then inbox)
-      repeat with aTask in (flattened tasks)
-        if (name of aTask) = "${name}" then
-          set foundItem to aTask
-          exit repeat
-        end if
-      end repeat
-      
-      -- If not found in projects, search in inbox
-      if foundItem is missing value then
-        repeat with aTask in (inbox tasks)
-          if (name of aTask) = "${name}" then
-            set foundItem to aTask
-            exit repeat
-          end if
-        end repeat
-      end if
+      -- Find task by name (flattened tasks includes inbox tasks)
+      try
+        set foundItem to first flattened task whose name is "${name}"
+      end try
 `;
     } else {
       script += `
       -- Find project by name
-      repeat with aProject in (flattened projects)
-        if (name of aProject) = "${name}" then
-          set foundItem to aProject
-          exit repeat
-        end if
-      end repeat
+      try
+        set foundItem to first flattened project whose name is "${name}"
+      end try
 `;
     }
   } else if (id && name) {
@@ -171,34 +141,18 @@ function generateAppleScript(params: EditItemParams): string {
       script += `
       -- If ID search failed, try to find by name as fallback
       if foundItem is missing value then
-        repeat with aTask in (flattened tasks)
-          if (name of aTask) = "${name}" then
-            set foundItem to aTask
-            exit repeat
-          end if
-        end repeat
-      end if
-      
-      -- If still not found, search in inbox
-      if foundItem is missing value then
-        repeat with aTask in (inbox tasks)
-          if (name of aTask) = "${name}" then
-            set foundItem to aTask
-            exit repeat
-          end if
-        end repeat
+        try
+          set foundItem to first flattened task whose name is "${name}"
+        end try
       end if
 `;
     } else {
       script += `
       -- If ID search failed, try to find project by name as fallback
       if foundItem is missing value then
-        repeat with aProject in (flattened projects)
-          if (name of aProject) = "${name}" then
-            set foundItem to aProject
-            exit repeat
-          end if
-        end repeat
+        try
+          set foundItem to first flattened project whose name is "${name}"
+        end try
       end if
 `;
     }
@@ -217,7 +171,7 @@ function generateAppleScript(params: EditItemParams): string {
   if (params.newName !== undefined) {
     script += `
         -- Update name
-        set name of foundItem to "${params.newName.replace(/["\\]/g, '\\$&')}"
+        set name of foundItem to "${params.newName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"
         set end of changedProperties to "name"
 `;
   }
@@ -225,7 +179,7 @@ function generateAppleScript(params: EditItemParams): string {
   if (params.newNote !== undefined) {
     script += `
         -- Update note
-        set note of foundItem to "${params.newNote.replace(/["\\]/g, '\\$&')}"
+        set note of foundItem to "${params.newNote.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"
         set end of changedProperties to "note"
 `;
   }
@@ -284,14 +238,13 @@ function generateAppleScript(params: EditItemParams): string {
       } else if (params.newStatus === 'dropped') {
         script += `
         -- Mark task as dropped
-        set dropped of foundItem to true
+        mark dropped foundItem
         set end of changedProperties to "status (dropped)"
 `;
       } else if (params.newStatus === 'incomplete') {
         script += `
         -- Mark task as incomplete
-        set completed of foundItem to false
-        set dropped of foundItem to false
+        mark incomplete foundItem
         set end of changedProperties to "status (incomplete)"
 `;
       }
@@ -299,7 +252,7 @@ function generateAppleScript(params: EditItemParams): string {
     
     // Handle tag operations
     if (params.replaceTags && params.replaceTags.length > 0) {
-      const tagsList = params.replaceTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&')}"`).join(", ");
+      const tagsList = params.replaceTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
       script += `
         -- Replace all tags
         set tagNames to {${tagsList}}
@@ -328,7 +281,7 @@ function generateAppleScript(params: EditItemParams): string {
     } else {
       // Add tags if specified
       if (params.addTags && params.addTags.length > 0) {
-        const tagsList = params.addTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&')}"`).join(", ");
+        const tagsList = params.addTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
         script += `
         -- Add tags
         set tagNames to {${tagsList}}
@@ -350,7 +303,7 @@ function generateAppleScript(params: EditItemParams): string {
       
       // Remove tags if specified
       if (params.removeTags && params.removeTags.length > 0) {
-        const tagsList = params.removeTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&')}"`).join(", ");
+        const tagsList = params.removeTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
         script += `
         -- Remove tags
         set tagNames to {${tagsList}}
@@ -364,8 +317,30 @@ function generateAppleScript(params: EditItemParams): string {
 `;
       }
     }
+
+    // Move task to a different project
+    if (params.newProjectName !== undefined) {
+      if (params.newProjectName === '' || params.newProjectName.toLowerCase() === 'inbox') {
+        script += `
+        -- Move task to inbox by clearing its assigned container
+        set assigned container of foundItem to missing value
+        set end of changedProperties to "project (moved to inbox)"
+`;
+      } else {
+        const escapedProjectPath = params.newProjectName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
+        const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${escapedProjectPath}\\\"}`;
+        const projectLookup = generateProjectLookupScript(params.newProjectName, 'destProject', errorJson);
+        script += `
+        -- Find the destination project (supports folder paths like "Work/My Project")
+        ${projectLookup}
+
+        move foundItem to end of tasks of destProject
+        set end of changedProperties to "project (moved to ${escapedProjectPath})"
+`;
+      }
+    }
   }
-  
+
   // Project-specific updates
   if (itemType === 'project') {
     // Update sequential status
@@ -390,23 +365,17 @@ function generateAppleScript(params: EditItemParams): string {
 `;
     }
     
-    // Move to a new folder
-    if (params.newFolderName !== undefined) {
-      const folderName = params.newFolderName.replace(/["\\]/g, '\\$&');
+    // Move to a new folder (supports nested paths like "Work/Engineering")
+    if (params.newFolderName !== undefined && params.newFolderName !== '') {
+      const escapedFolderName = params.newFolderName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
+      const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${escapedFolderName}\\\"}`;
+      const folderLookup = generateFolderLookupScript(params.newFolderName, 'destFolder', errorJson);
       script += `
-        -- Move to new folder
-        set destFolder to missing value
-        try
-          set destFolder to first flattened folder where name = "${folderName}"
-        end try
-        
-        if destFolder is missing value then
-          -- Create the folder if it doesn't exist
-          set destFolder to make new folder with properties {name:"${folderName}"}
-        end if
-        
+        -- Find the destination folder
+        ${folderLookup}
+
         -- Move project to the folder
-        move foundItem to destFolder
+        move {foundItem} to end of projects of destFolder
         set end of changedProperties to "folder"
 `;
     }
@@ -466,7 +435,7 @@ export async function editItem(params: EditItemParams): Promise<{
     writeFileSync(tempFile, script);
     
     // Execute AppleScript from file
-    const { stdout, stderr } = await execAsync(`osascript ${tempFile}`);
+    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
     
     // Clean up temp file
     try {

--- a/src/tools/primitives/removeItem.test.ts
+++ b/src/tools/primitives/removeItem.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { generateAppleScript } from './removeItem.js';
+
+describe('removeItem generateAppleScript', () => {
+  it('generates task removal by name', () => {
+    const script = generateAppleScript({
+      name: 'Old Task',
+      itemType: 'task',
+    });
+    expect(script).toContain('first flattened task whose name is "Old Task"');
+    expect(script).toContain('delete');
+  });
+
+  it('generates task removal by id', () => {
+    const script = generateAppleScript({
+      id: 'abc123',
+      itemType: 'task',
+    });
+    expect(script).toContain('first flattened task whose id is "abc123"');
+    expect(script).toContain('delete');
+  });
+
+  it('generates project removal by name', () => {
+    const script = generateAppleScript({
+      name: 'Old Project',
+      itemType: 'project',
+    });
+    expect(script).toContain('first flattened project whose name is "Old Project"');
+  });
+
+  it('returns error when neither id nor name provided', () => {
+    const script = generateAppleScript({
+      itemType: 'task',
+    });
+    expect(script).toContain('Either id or name must be provided');
+  });
+});

--- a/src/tools/primitives/removeItem.ts
+++ b/src/tools/primitives/removeItem.ts
@@ -15,10 +15,10 @@ export interface RemoveItemParams {
 /**
  * Generate pure AppleScript for item removal
  */
-function generateAppleScript(params: RemoveItemParams): string {
+export function generateAppleScript(params: RemoveItemParams): string {
   // Sanitize and prepare parameters for AppleScript
-  const id = params.id?.replace(/["\\]/g, '\\$&') || ''; // Escape quotes and backslashes
-  const name = params.name?.replace(/["\\]/g, '\\$&') || '';
+  const id = params.id?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || ''; // Escape quotes and backslashes
+  const name = params.name?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
   const itemType = params.itemType;
 
   // Verify we have at least one identifier
@@ -35,37 +35,21 @@ function generateAppleScript(params: RemoveItemParams): string {
         set foundItem to missing value
 `;
 
-  // Add ID search if provided — use loop iteration for reliable matching
+  // Add ID search if provided — whose clause gives direct references
   if (id) {
     if (itemType === 'task') {
       script += `
-        -- Try to find task by ID
-        repeat with aTask in (flattened tasks)
-          if (id of aTask as string) = "${id}" then
-            set foundItem to aTask
-            exit repeat
-          end if
-        end repeat
-
-        -- If not found in projects, search in inbox
-        if foundItem is missing value then
-          repeat with aTask in (inbox tasks)
-            if (id of aTask as string) = "${id}" then
-              set foundItem to aTask
-              exit repeat
-            end if
-          end repeat
-        end if
+        -- Find task by ID (flattened tasks includes inbox tasks)
+        try
+          set foundItem to first flattened task whose id is "${id}"
+        end try
 `;
     } else {
       script += `
-        -- Try to find project by ID
-        repeat with aProject in (flattened projects)
-          if (id of aProject as string) = "${id}" then
-            set foundItem to aProject
-            exit repeat
-          end if
-        end repeat
+        -- Find project by ID
+        try
+          set foundItem to first flattened project whose id is "${id}"
+        end try
 `;
     }
   }
@@ -74,33 +58,17 @@ function generateAppleScript(params: RemoveItemParams): string {
   if (!id && name) {
     if (itemType === 'task') {
       script += `
-        -- Find task by name (search in projects first, then inbox)
-        repeat with aTask in (flattened tasks)
-          if (name of aTask) = "${name}" then
-            set foundItem to aTask
-            exit repeat
-          end if
-        end repeat
-
-        -- If not found in projects, search in inbox
-        if foundItem is missing value then
-          repeat with aTask in (inbox tasks)
-            if (name of aTask) = "${name}" then
-              set foundItem to aTask
-              exit repeat
-            end if
-          end repeat
-        end if
+        -- Find task by name (flattened tasks includes inbox tasks)
+        try
+          set foundItem to first flattened task whose name is "${name}"
+        end try
 `;
     } else {
       script += `
         -- Find project by name
-        repeat with aProject in (flattened projects)
-          if (name of aProject) = "${name}" then
-            set foundItem to aProject
-            exit repeat
-          end if
-        end repeat
+        try
+          set foundItem to first flattened project whose name is "${name}"
+        end try
 `;
     }
   } else if (id && name) {
@@ -108,34 +76,18 @@ function generateAppleScript(params: RemoveItemParams): string {
       script += `
         -- If ID search failed, try to find by name as fallback
         if foundItem is missing value then
-          repeat with aTask in (flattened tasks)
-            if (name of aTask) = "${name}" then
-              set foundItem to aTask
-              exit repeat
-            end if
-          end repeat
-        end if
-
-        -- If still not found, search in inbox
-        if foundItem is missing value then
-          repeat with aTask in (inbox tasks)
-            if (name of aTask) = "${name}" then
-              set foundItem to aTask
-              exit repeat
-            end if
-          end repeat
+          try
+            set foundItem to first flattened task whose name is "${name}"
+          end try
         end if
 `;
     } else {
       script += `
         -- If ID search failed, try to find project by name as fallback
         if foundItem is missing value then
-          repeat with aProject in (flattened projects)
-            if (name of aProject) = "${name}" then
-              set foundItem to aProject
-              exit repeat
-            end if
-          end repeat
+          try
+            set foundItem to first flattened project whose name is "${name}"
+          end try
         end if
 `;
     }
@@ -189,7 +141,7 @@ export async function removeItem(params: RemoveItemParams): Promise<{success: bo
     writeFileSync(tempFile, script);
 
     // Execute AppleScript from file
-    const { stdout, stderr } = await execAsync(`osascript ${tempFile}`);
+    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
 
     // Clean up temp file
     try {

--- a/src/utils/appleScriptHelpers.test.ts
+++ b/src/utils/appleScriptHelpers.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { generateFolderLookupScript, generateProjectLookupScript } from './appleScriptHelpers.js';
+
+describe('generateFolderLookupScript', () => {
+  it('generates simple name lookup for single-component path', () => {
+    const result = generateFolderLookupScript('Work', 'destFolder', 'error');
+    expect(result).toContain('first flattened folder where name = "Work"');
+    expect(result).not.toContain('pathComponents');
+    expect(result).not.toContain('ancestorOk');
+  });
+
+  it('generates ancestor chain walk for multi-segment path', () => {
+    const result = generateFolderLookupScript('Work/Engineering', 'destFolder', 'error');
+    expect(result).toContain('"Work"');
+    expect(result).toContain('"Engineering"');
+    expect(result).toContain('pathComponents');
+    expect(result).toContain('ancestorOk');
+    expect(result).toContain('name of aFolder = "Engineering"');
+    expect(result).toContain('container of currentItem');
+  });
+
+  it('handles three-level paths correctly', () => {
+    const result = generateFolderLookupScript('A/B/C', 'theFolder', 'error');
+    expect(result).toContain('"A", "B", "C"');
+    expect(result).toContain('name of aFolder = "C"');
+    expect(result).toContain('pathComponents');
+  });
+
+  it('escapes special characters in folder names', () => {
+    const result = generateFolderLookupScript('My "Folder"', 'f', 'error');
+    expect(result).toContain('My \\"Folder\\"');
+  });
+
+  it('escapes backslashes in folder names', () => {
+    const result = generateFolderLookupScript('Back\\slash', 'f', 'error');
+    expect(result).toContain('Back\\\\slash');
+  });
+
+  it('escapes special characters in path segments', () => {
+    const result = generateFolderLookupScript('Parent/Child "Folder"', 'f', 'error');
+    expect(result).toContain('Child \\"Folder\\"');
+    expect(result).toContain('"Parent"');
+  });
+
+  it('returns missing value for empty input', () => {
+    const result = generateFolderLookupScript('', 'f', 'error');
+    expect(result).toContain('set f to missing value');
+    expect(result).not.toContain('flattened folder');
+  });
+
+  it('returns missing value for slash-only input', () => {
+    const result = generateFolderLookupScript('/', 'f', 'error');
+    expect(result).toContain('set f to missing value');
+  });
+
+  it('uses the provided variable name', () => {
+    const result = generateFolderLookupScript('Work', 'myVar', 'error');
+    expect(result).toContain('set myVar to missing value');
+    expect(result).toContain('set myVar to first flattened folder');
+    expect(result).toContain('if myVar is missing value');
+  });
+
+  it('embeds error return JSON in the return statement', () => {
+    const errorJson = '{\\\"success\\\":false}';
+    const result = generateFolderLookupScript('Work', 'f', errorJson);
+    expect(result).toContain(`return "${errorJson}"`);
+  });
+
+  it('checks folder not found with error return for multi-segment paths', () => {
+    const errorJson = 'not-found-error';
+    const result = generateFolderLookupScript('A/B', 'f', errorJson);
+    expect(result).toContain('if f is missing value');
+    expect(result).toContain(`return "${errorJson}"`);
+  });
+
+  it('strips empty segments from paths with trailing slashes', () => {
+    const result = generateFolderLookupScript('Work/', 'f', 'error');
+    // Should behave like single "Work" — no ancestor walk
+    expect(result).toContain('first flattened folder where name = "Work"');
+    expect(result).not.toContain('pathComponents');
+  });
+});
+
+describe('generateProjectLookupScript', () => {
+  it('generates simple name lookup for unqualified project name', () => {
+    const result = generateProjectLookupScript('Marketing', 'destProject', 'error');
+    expect(result).toContain('first flattened project whose name is "Marketing"');
+    expect(result).not.toContain('folderPath');
+  });
+
+  it('generates folder-qualified lookup for path', () => {
+    const result = generateProjectLookupScript('Work/Community Outreach', 'destProject', 'error');
+    expect(result).toContain('"Community Outreach"');
+    expect(result).toContain('folderPath');
+    expect(result).toContain('"Work"');
+    expect(result).toContain('container of aProject');
+    expect(result).toContain('ancestorOk');
+  });
+
+  it('handles nested folder paths', () => {
+    const result = generateProjectLookupScript('Personal/Committees/Outreach', 'p', 'error');
+    expect(result).toContain('"Personal", "Committees"');
+    expect(result).toContain('"Outreach"');
+    expect(result).toContain('folderPath');
+  });
+
+  it('returns missing value for empty input', () => {
+    const result = generateProjectLookupScript('', 'p', 'error');
+    expect(result).toContain('set p to missing value');
+    expect(result).not.toContain('flattened projects');
+  });
+
+  it('escapes special characters in project name', () => {
+    const result = generateProjectLookupScript('My "Project"', 'p', 'error');
+    expect(result).toContain('My \\"Project\\"');
+  });
+
+  it('uses the provided variable name', () => {
+    const result = generateProjectLookupScript('Test', 'myProj', 'error');
+    expect(result).toContain('set myProj to missing value');
+    expect(result).toContain('set myProj to first flattened project whose name is "Test"');
+    expect(result).toContain('if myProj is missing value');
+  });
+
+  it('embeds error return JSON', () => {
+    const errorJson = '{\\\"success\\\":false}';
+    const result = generateProjectLookupScript('Test', 'p', errorJson);
+    expect(result).toContain(`return "${errorJson}"`);
+  });
+});

--- a/src/utils/appleScriptHelpers.ts
+++ b/src/utils/appleScriptHelpers.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared AppleScript generation helpers for OmniFocus MCP primitives.
+ */
+
+/**
+ * Generate AppleScript that resolves a folder by path (e.g. "Work/Engineering")
+ * or by simple name (e.g. "Work"). Sets `varName` to the found folder object,
+ * or returns `errorReturnJson` if not found.
+ *
+ * The generated code must be placed inside a `tell front document` block.
+ */
+export function generateFolderLookupScript(
+  rawFolderPath: string,
+  varName: string,
+  errorReturnJson: string
+): string {
+  const components = rawFolderPath.split('/').filter(c => c.length > 0);
+  if (components.length === 0) {
+    return `set ${varName} to missing value`;
+  }
+
+  const escaped = components.map(c => c.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '));
+  const leafName = escaped[escaped.length - 1];
+
+  if (components.length === 1) {
+    // Simple name lookup — same behavior as the original code
+    return `set ${varName} to missing value
+        try
+          set ${varName} to first flattened folder where name = "${leafName}"
+        end try
+        if ${varName} is missing value then
+          return "${errorReturnJson}"
+        end if`;
+  }
+
+  // Path-based lookup: find the leaf folder, then verify ancestor chain
+  const listItems = escaped.map(c => `"${c}"`).join(', ');
+  return `set ${varName} to missing value
+        set pathComponents to {${listItems}}
+        repeat with aFolder in (flattened folders)
+          if name of aFolder = "${leafName}" then
+            -- Verify ancestor chain matches path
+            set ancestorOk to true
+            set currentItem to aFolder
+            repeat with i from ((count of pathComponents) - 1) to 1 by -1
+              try
+                set currentItem to container of currentItem
+                if class of currentItem is not folder or name of currentItem is not equal to (item i of pathComponents) then
+                  set ancestorOk to false
+                  exit repeat
+                end if
+              on error
+                set ancestorOk to false
+                exit repeat
+              end try
+            end repeat
+            if ancestorOk then
+              set ${varName} to aFolder
+              exit repeat
+            end if
+          end if
+        end repeat
+        if ${varName} is missing value then
+          return "${errorReturnJson}"
+        end if`;
+}
+
+/**
+ * Generate AppleScript that resolves a project by name or folder-qualified path
+ * (e.g. "Community Outreach" or "Work/Community Outreach").
+ * Sets `varName` to the found project object, or returns `errorReturnJson` if not found.
+ *
+ * When a path is provided, all components except the last are treated as the folder
+ * ancestry (parent, grandparent, etc.) and the last component is the project name.
+ *
+ * The generated code must be placed inside a `tell front document` block.
+ */
+export function generateProjectLookupScript(
+  rawProjectPath: string,
+  varName: string,
+  errorReturnJson: string
+): string {
+  const components = rawProjectPath.split('/').filter(c => c.length > 0);
+  if (components.length === 0) {
+    return `set ${varName} to missing value`;
+  }
+
+  const escaped = components.map(c => c.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '));
+  const projectName = escaped[escaped.length - 1];
+
+  if (components.length === 1) {
+    // Simple name lookup — whose gives a direct reference
+    return `set ${varName} to missing value
+        try
+          set ${varName} to first flattened project whose name is "${projectName}"
+        end try
+        if ${varName} is missing value then
+          return "${errorReturnJson}"
+        end if`;
+  }
+
+  // Path-based lookup: last component is project name, preceding are folder ancestry
+  const folderComponents = escaped.slice(0, -1);
+  const folderItems = folderComponents.map(c => `"${c}"`).join(', ');
+  return `set ${varName} to missing value
+        set folderPath to {${folderItems}}
+        repeat with aProject in (flattened projects)
+          if (name of aProject as string) = "${projectName}" then
+            -- Verify folder ancestry matches path
+            set ancestorOk to true
+            set currentItem to container of aProject
+            repeat with i from (count of folderPath) to 1 by -1
+              try
+                if class of currentItem is not folder or name of currentItem is not equal to (item i of folderPath) then
+                  set ancestorOk to false
+                  exit repeat
+                end if
+                set currentItem to container of currentItem
+              on error
+                set ancestorOk to false
+                exit repeat
+              end try
+            end repeat
+            if ancestorOk then
+              set ${varName} to aProject
+              exit repeat
+            end if
+          end if
+        end repeat
+        if ${varName} is missing value then
+          return "${errorReturnJson}"
+        end if`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/tests/integration/**", "vitest.config.ts", "vitest.integration.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['src/tests/integration/**'],
+  },
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/tests/integration/**/*.test.ts'],
+    testTimeout: 30000,
+    sequence: { concurrent: false, shuffle: false },
+  },
+});


### PR DESCRIPTION
## Summary

- **Task moves between projects** via `newProjectName` on `edit_item`, with folder-qualified paths (e.g. `Work/My Project`) to disambiguate duplicate project names
- **AppleScript execution fixes** — use `whose` clause for direct object references instead of loop iteration (which produces indirect references that silently fail with move/delete/set assigned container)
- **68 unit tests** (vitest) with structural assertions on generated AppleScript
- **14 integration tests** that run against a real OmniFocus instance with run-scoped safety containment

## Details

### Task Moves
- `newProjectName: "My Project"` moves a task to that project
- `newProjectName: "Work/My Project"` disambiguates with folder path
- `newProjectName: ""` or `"inbox"` moves task to inbox
- Works for inbox→project, project→project, and project→inbox

### AppleScript Fixes
- **Indirect references:** `repeat with X in (collection)` produces indirect refs that fail with `move`, `delete`, and `set assigned container`. Replaced with `whose` clause lookups that return direct references.
- **Move syntax:** `move X to end of tasks of Y` with proper location specifier
- **`set assigned container`:** Used for inbox→project moves; `move` for project→project
- **`mark dropped/incomplete`:** Use `mark` commands instead of invalid `set dropped/set completed` properties
- **Temp file execution:** `addProject` now uses temp files instead of inline `-e` (fixes names with single quotes)

### Test Infrastructure
- **Unit tests:** 68 tests across 5 files verifying generated AppleScript structure
- **Integration tests:** 14 tests running against real OmniFocus with safety guardrails:
  - Unique `TEST:<timestamp>` folder per run
  - `TestRegistry` tracks all created items by ID
  - Cleanup deletes only tracked items
  - Separate vitest config (`npm run test:integration`)
  - Standalone cleanup script for crashed runs

## Test plan

- [x] All 68 unit tests pass (`npm test`)
- [x] All 14 integration tests pass (`npm run test:integration`)
- [x] TypeScript compiles cleanly
- [x] Manual verification of task moves in OmniFocus (inbox→project, project→project, project→inbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)