### PR TITLE
Add newProjectName to edit_item for moving tasks between projects

### DIFF
--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -18,6 +18,7 @@ export const schema = z.object({
 
   // Task-specific fields
   newStatus: z.enum(['incomplete', 'completed', 'dropped']).optional().describe("New status for tasks (incomplete, completed, dropped)"),
+  newProjectName: z.string().optional().describe("New project to move the task to (tasks only)"),
   addTags: z.array(z.string()).optional().describe("Tags to add to the task"),
   removeTags: z.array(z.string()).optional().describe("Tags to remove from the task"),
   replaceTags: z.array(z.string()).optional().describe("Tags to replace all existing tags with"),

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -31,6 +31,9 @@ export interface EditItemParams {
   removeTags?: string[];        // Tags to remove from the task
   replaceTags?: string[];       // Tags to replace all existing tags with
   
+  // Task-specific: move to project
+  newProjectName?: string;      // New project to move the task to
+
   // Project-specific fields
   newSequential?: boolean;      // Whether the project should be sequential
   newFolderName?: string;       // New folder to move the project to
@@ -364,8 +367,27 @@ function generateAppleScript(params: EditItemParams): string {
 `;
       }
     }
+
+    // Move task to a new project
+    if (params.newProjectName !== undefined) {
+      const projectName = params.newProjectName.replace(/["\\]/g, '\\$&');
+      script += `
+        -- Move to new project
+        set destProject to missing value
+        try
+          set destProject to first flattened project where name = "${projectName}"
+        end try
+
+        if destProject is not missing value then
+          move foundItem to end of tasks of destProject
+          set end of changedProperties to "project"
+        else
+          error "Project '${projectName}' not found"
+        end if
+`;
+    }
   }
-  
+
   // Project-specific updates
   if (itemType === 'project') {
     // Update sequential status


### PR DESCRIPTION
Allows moving existing tasks to a different project via the edit_item tool, filling a gap where tasks could only be assigned to projects at creation time.