### PR TITLE
Add date and repeating filters to query_omnifocus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnifocus-mcp",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnifocus-mcp",
-      "version": "1.6.1",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -22,6 +22,7 @@ export const schema = z.object({
     plannedOn: z.number().optional().describe("Returns tasks with planned date on exactly this day. 0 = today, 1 = tomorrow, etc."),
     addedWithin: z.number().optional().describe("Returns items added (created) within the last N days. Example: 7 = items added in the last week"),
     addedOn: z.number().optional().describe("Returns items added (created) on exactly this day. 0 = today, 1 = tomorrow, -1 = yesterday. Negative values look backward"),
+    isRepeating: z.boolean().optional().describe("Filter by repeating status. true = only repeating tasks, false = only non-repeating tasks"),
     completedWithin: z.number().optional().describe("Returns items completed or dropped within the last N days (uses completionDate which OmniFocus sets for both). Example: 7 = items completed in the last week. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true"),
     completedOn: z.number().optional().describe("Returns items completed or dropped on exactly this day (uses completionDate which OmniFocus sets for both). 0 = today, -1 = yesterday. Negative values look backward. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true")
   }).optional().describe("Optional filters to narrow results. ALL filters combine with AND logic (must match all). Within array filters (tags, status) OR logic applies"),
@@ -138,6 +139,7 @@ function formatFilters(filters: any): string {
   if (filters.plannedOn !== undefined) parts.push(`planned on day +${filters.plannedOn}`);
   if (filters.addedWithin !== undefined) parts.push(`added within ${filters.addedWithin} days`);
   if (filters.addedOn !== undefined) parts.push(`added on day ${filters.addedOn}`);
+  if (filters.isRepeating !== undefined) parts.push(`repeating: ${filters.isRepeating}`);
   if (filters.completedWithin !== undefined) parts.push(`completed within ${filters.completedWithin} days`);
   if (filters.completedOn !== undefined) parts.push(`completed on day ${filters.completedOn}`);
   return parts.join(', ');

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -19,7 +19,9 @@ export const schema = z.object({
     inbox: z.boolean().optional().describe("Filter tasks by inbox status. true = only inbox tasks (no project), false = only tasks in a project"),
     dueOn: z.number().optional().describe("Returns items due on exactly this day. 0 = today, 1 = tomorrow, etc."),
     deferOn: z.number().optional().describe("Returns items with defer date on exactly this day. 0 = today, 1 = tomorrow, etc."),
-    plannedOn: z.number().optional().describe("Returns tasks with planned date on exactly this day. 0 = today, 1 = tomorrow, etc.")
+    plannedOn: z.number().optional().describe("Returns tasks with planned date on exactly this day. 0 = today, 1 = tomorrow, etc."),
+    addedWithin: z.number().optional().describe("Returns items added (created) within the last N days. Example: 7 = items added in the last week"),
+    addedOn: z.number().optional().describe("Returns items added (created) on exactly this day. 0 = today, 1 = tomorrow, -1 = yesterday. Negative values look backward")
   }).optional().describe("Optional filters to narrow results. ALL filters combine with AND logic (must match all). Within array filters (tags, status) OR logic applies"),
   
   fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
@@ -132,6 +134,8 @@ function formatFilters(filters: any): string {
   if (filters.dueOn !== undefined) parts.push(`due on day +${filters.dueOn}`);
   if (filters.deferOn !== undefined) parts.push(`defer on day +${filters.deferOn}`);
   if (filters.plannedOn !== undefined) parts.push(`planned on day +${filters.plannedOn}`);
+  if (filters.addedWithin !== undefined) parts.push(`added within ${filters.addedWithin} days`);
+  if (filters.addedOn !== undefined) parts.push(`added on day ${filters.addedOn}`);
   return parts.join(', ');
 }
 

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -21,7 +21,9 @@ export const schema = z.object({
     deferOn: z.number().optional().describe("Returns items with defer date on exactly this day. 0 = today, 1 = tomorrow, etc."),
     plannedOn: z.number().optional().describe("Returns tasks with planned date on exactly this day. 0 = today, 1 = tomorrow, etc."),
     addedWithin: z.number().optional().describe("Returns items added (created) within the last N days. Example: 7 = items added in the last week"),
-    addedOn: z.number().optional().describe("Returns items added (created) on exactly this day. 0 = today, 1 = tomorrow, -1 = yesterday. Negative values look backward")
+    addedOn: z.number().optional().describe("Returns items added (created) on exactly this day. 0 = today, 1 = tomorrow, -1 = yesterday. Negative values look backward"),
+    completedWithin: z.number().optional().describe("Returns items completed or dropped within the last N days (uses completionDate which OmniFocus sets for both). Example: 7 = items completed in the last week. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true"),
+    completedOn: z.number().optional().describe("Returns items completed or dropped on exactly this day (uses completionDate which OmniFocus sets for both). 0 = today, -1 = yesterday. Negative values look backward. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true")
   }).optional().describe("Optional filters to narrow results. ALL filters combine with AND logic (must match all). Within array filters (tags, status) OR logic applies"),
   
   fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
@@ -136,6 +138,8 @@ function formatFilters(filters: any): string {
   if (filters.plannedOn !== undefined) parts.push(`planned on day +${filters.plannedOn}`);
   if (filters.addedWithin !== undefined) parts.push(`added within ${filters.addedWithin} days`);
   if (filters.addedOn !== undefined) parts.push(`added on day ${filters.addedOn}`);
+  if (filters.completedWithin !== undefined) parts.push(`completed within ${filters.completedWithin} days`);
+  if (filters.completedOn !== undefined) parts.push(`completed on day ${filters.completedOn}`);
   return parts.join(', ');
 }
 

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -17,6 +17,8 @@ export interface QueryOmnifocusParams {
     dueOn?: number;
     deferOn?: number;
     plannedOn?: number;
+    addedWithin?: number;
+    addedOn?: number;
   };
   fields?: string[];
   limit?: number;
@@ -90,6 +92,15 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
         const futureDate = new Date();
         futureDate.setDate(futureDate.getDate() + daysFromNow);
         return itemDate <= futureDate;
+      }
+
+      // Helper to check if date is within last N days (backward-looking)
+      function checkDateWithinPast(itemDate, daysAgo) {
+        if (!itemDate) return false;
+        const pastDate = new Date();
+        pastDate.setDate(pastDate.getDate() - daysAgo);
+        pastDate.setHours(0, 0, 0, 0);
+        return itemDate >= pastDate;
       }
 
       // Helper to check exact day match
@@ -260,6 +271,18 @@ function generateFilterConditions(entity: string, filters: any): string {
       conditions.push(`if (!checkSameDay(item.plannedDate, ${filters.plannedOn})) return false;`);
     }
 
+    if (filters.addedWithin !== undefined) {
+      conditions.push(`
+        if (!item.added || !checkDateWithinPast(item.added, ${filters.addedWithin})) {
+          return false;
+        }
+      `);
+    }
+
+    if (filters.addedOn !== undefined) {
+      conditions.push(`if (!checkSameDay(item.added, ${filters.addedOn})) return false;`);
+    }
+
     if (filters.hasNote !== undefined) {
       conditions.push(`
         const hasNote = item.note && item.note.trim().length > 0;
@@ -287,10 +310,22 @@ function generateFilterConditions(entity: string, filters: any): string {
     }
     
     if (filters.status && filters.status.length > 0) {
-      const statusCondition = filters.status.map((status: string) => 
+      const statusCondition = filters.status.map((status: string) =>
         `projectStatusMap[item.status] === "${status}"`
       ).join(' || ');
       conditions.push(`if (!(${statusCondition})) return false;`);
+    }
+
+    if (filters.addedWithin !== undefined) {
+      conditions.push(`
+        if (!item.added || !checkDateWithinPast(item.added, ${filters.addedWithin})) {
+          return false;
+        }
+      `);
+    }
+
+    if (filters.addedOn !== undefined) {
+      conditions.push(`if (!checkSameDay(item.added, ${filters.addedOn})) return false;`);
     }
   }
   

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -19,6 +19,8 @@ export interface QueryOmnifocusParams {
     plannedOn?: number;
     addedWithin?: number;
     addedOn?: number;
+    completedWithin?: number;
+    completedOn?: number;
   };
   fields?: string[];
   limit?: number;
@@ -283,6 +285,18 @@ function generateFilterConditions(entity: string, filters: any): string {
       conditions.push(`if (!checkSameDay(item.added, ${filters.addedOn})) return false;`);
     }
 
+    if (filters.completedWithin !== undefined) {
+      conditions.push(`
+        if (!item.completionDate || !checkDateWithinPast(item.completionDate, ${filters.completedWithin})) {
+          return false;
+        }
+      `);
+    }
+
+    if (filters.completedOn !== undefined) {
+      conditions.push(`if (!checkSameDay(item.completionDate, ${filters.completedOn})) return false;`);
+    }
+
     if (filters.hasNote !== undefined) {
       conditions.push(`
         const hasNote = item.note && item.note.trim().length > 0;
@@ -327,8 +341,20 @@ function generateFilterConditions(entity: string, filters: any): string {
     if (filters.addedOn !== undefined) {
       conditions.push(`if (!checkSameDay(item.added, ${filters.addedOn})) return false;`);
     }
+
+    if (filters.completedWithin !== undefined) {
+      conditions.push(`
+        if (!item.completionDate || !checkDateWithinPast(item.completionDate, ${filters.completedWithin})) {
+          return false;
+        }
+      `);
+    }
+
+    if (filters.completedOn !== undefined) {
+      conditions.push(`if (!checkSameDay(item.completionDate, ${filters.completedOn})) return false;`);
+    }
   }
-  
+
   return conditions.join('\n');
 }
 

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -19,6 +19,7 @@ export interface QueryOmnifocusParams {
     plannedOn?: number;
     addedWithin?: number;
     addedOn?: number;
+    isRepeating?: boolean;
     completedWithin?: number;
     completedOn?: number;
   };
@@ -283,6 +284,14 @@ function generateFilterConditions(entity: string, filters: any): string {
 
     if (filters.addedOn !== undefined) {
       conditions.push(`if (!checkSameDay(item.added, ${filters.addedOn})) return false;`);
+    }
+
+    if (filters.isRepeating !== undefined) {
+      if (filters.isRepeating) {
+        conditions.push(`if (item.repetitionRule === null) return false;`);
+      } else {
+        conditions.push(`if (item.repetitionRule !== null) return false;`);
+      }
     }
 
     if (filters.completedWithin !== undefined) {


### PR DESCRIPTION
## Summary

- **addedWithin / addedOn**: Filter by creation date. `addedWithin` returns items created within the last N days (backward-looking). `addedOn` matches an exact day (supports negative values for past days).
- **completedWithin / completedOn**: Filter by completion date. Works for both completed and dropped items (OmniFocus sets `completionDate` for both). Combine with `status: ['Dropped']` to find only dropped items. Use with `includeCompleted: true`.
- **isRepeating**: Filter tasks by repeating status. `true` = only repeating tasks, `false` = only non-repeating.

All date filters apply to both tasks and projects, following the same pattern as existing dueWithin/dueOn, deferredUntil/deferOn, and plannedWithin/plannedOn filters.