### PR TITLE
Add isRepeating and repetitionRule as returnable fields in query_omnifocus

### DIFF
--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -22,7 +22,7 @@ export const schema = z.object({
     plannedOn: z.number().optional().describe("Returns tasks with planned date on exactly this day. 0 = today, 1 = tomorrow, etc.")
   }).optional().describe("Optional filters to narrow results. ALL filters combine with AND logic (must match all). Within array filters (tags, status) OR logic applies"),
   
-  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
+  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
   
   limit: z.number().optional().describe("Maximum number of items to return. Useful for large result sets. Default: no limit"),
   
@@ -181,7 +181,17 @@ function formatTasks(tasks: any[]): string {
     if (task.taskStatus) {
       parts.push(`#${task.taskStatus.toLowerCase()}`);
     }
+
+    // Repeating
+    if (task.isRepeating !== undefined) {
+      parts.push(task.isRepeating ? '[repeating]' : '[not repeating]');
+    }
     
+    // Repetition rule
+    if (task.repetitionRule) {
+      parts.push(`[rule: ${task.repetitionRule}]`);
+    }
+
     // Metadata dates if requested
     if (task.creationDate) {
       parts.push(`[created: ${formatDate(task.creationDate)}]`);

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -427,6 +427,10 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
       return `subfolders: item.folders ? item.folders.map(f => f.id.primaryKey) : []`;
     } else if (field === 'path') {
       return `path: item.container ? item.container.name + "/" + item.name : item.name`;
+    } else if (field === 'isRepeating') {
+      return `isRepeating: item.repetitionRule !== null`;
+    } else if (field === 'repetitionRule') {
+      return `repetitionRule: item.repetitionRule ? item.repetitionRule.toString() : null`;
     } else if (field === 'estimatedMinutes') {
       return `estimatedMinutes: item.estimatedMinutes || null`;
     } else if (field === 'note') {


### PR DESCRIPTION
Add two new fields that can be requested via the fields parameter:
- isRepeating: boolean indicating whether a task has a repetition rule
- repetitionRule: string representation of the repetition rule, or null