### PR TITLE
Add folderId filter support for tasks and recursive folder matching

### DIFF
--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -8,7 +8,7 @@ export const schema = z.object({
   filters: z.object({
     projectId: z.string().optional().describe("Filter tasks by exact project ID (use when you know the specific project ID)"),
     projectName: z.string().optional().describe("Filter tasks by project name. CASE-INSENSITIVE PARTIAL MATCHING - 'review' matches 'Weekly Review', 'Review Documents', etc. Special value: 'inbox' returns inbox tasks"),
-    folderId: z.string().optional().describe("Filter projects by exact folder ID (use when you know the specific folder ID)"),
+    folderId: z.string().optional().describe("Filter by folder ID. For tasks, returns tasks whose containing project is in this folder (or a subfolder). For projects, returns projects in this folder (or a subfolder)"),
     tags: z.array(z.string()).optional().describe("Filter by tag names. EXACT MATCH, CASE-SENSITIVE. OR logic - items must have at least ONE of the specified tags. Example: ['Work'] and ['work'] are different"),
     status: z.array(z.string()).optional().describe("Filter by status (OR logic - matches any). TASKS: 'Next' (next action), 'Available' (ready to work), 'Blocked' (waiting), 'DueSoon' (due <24h), 'Overdue' (past due), 'Completed', 'Dropped'. PROJECTS: 'Active', 'OnHold', 'Done', 'Dropped'"),
     flagged: z.boolean().optional().describe("Filter by flagged status. true = only flagged items, false = only unflagged items"),

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -72,7 +72,7 @@ export async function queryOmnifocus(params: QueryOmnifocusParams): Promise<Quer
 
 function generateQueryScript(params: QueryOmnifocusParams): string {
   const { entity, filters = {}, fields, limit, sortBy, sortOrder, includeCompleted = false, summary = false } = params;
-  
+
   // Build the JXA script based on the entity type and filters
   return `(() => {
     try {
@@ -214,8 +214,28 @@ function generateFilterConditions(entity: string, filters: any): string {
       `);
     }
     
+    if (filters.folderId) {
+      conditions.push(`
+        {
+          const targetFolderId = "${filters.folderId}";
+          let matchesFolder = false;
+          if (item.containingProject && item.containingProject.parentFolder) {
+            let folder = item.containingProject.parentFolder;
+            while (folder) {
+              if (folder.id.primaryKey === targetFolderId) {
+                matchesFolder = true;
+                break;
+              }
+              folder = folder.parentFolder;
+            }
+          }
+          if (!matchesFolder) return false;
+        }
+      `);
+    }
+
     if (filters.tags && filters.tags.length > 0) {
-      const tagCondition = filters.tags.map((tag: string) => 
+      const tagCondition = filters.tags.map((tag: string) =>
         `item.tags.some(t => t.name === "${tag}")`
       ).join(' || ');
       conditions.push(`if (!(${tagCondition})) return false;`);
@@ -279,13 +299,24 @@ function generateFilterConditions(entity: string, filters: any): string {
   if (entity === 'projects') {
     if (filters.folderId) {
       conditions.push(`
-        if (!item.parentFolder || 
-            item.parentFolder.id.primaryKey !== "${filters.folderId}") {
-          return false;
+        {
+          const targetFolderId = "${filters.folderId}";
+          let matchesFolder = false;
+          if (item.parentFolder) {
+            let folder = item.parentFolder;
+            while (folder) {
+              if (folder.id.primaryKey === targetFolderId) {
+                matchesFolder = true;
+                break;
+              }
+              folder = folder.parentFolder;
+            }
+          }
+          if (!matchesFolder) return false;
         }
       `);
     }
-    
+
     if (filters.status && filters.status.length > 0) {
       const statusCondition = filters.status.map((status: string) => 
         `projectStatusMap[item.status] === "${status}"`


### PR DESCRIPTION
The folderId filter was only implemented for the projects entity, so querying tasks with a folderId silently returned unfiltered results. Now tasks check their containing project's folder hierarchy, and both tasks and projects walk up the folder tree to match subfolders.