### PR TITLE
Add taskName fuzzy filter, hierarchy fields display, and JXA injection fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "copy-files": "mkdir -p dist/utils/omnifocusScripts && cp src/utils/omnifocusScripts/*.js dist/utils/omnifocusScripts/",
     "start": "node dist/server.js",
     "dev": "tsc -w",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
@@ -20,7 +22,8 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.19",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.4"
   },
   "repository": {
     "type": "git",

--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import { _testExports as primitives } from '../primitives/queryOmnifocus.js';
+import { _testExports as definitions } from '../definitions/queryOmnifocus.js';
+
+const { escapeJXA, generateFilterConditions, generateFieldMapping } = primitives;
+const { formatTasks, formatFilters } = definitions;
+
+// ============================================================
+// escapeJXA
+// ============================================================
+describe('escapeJXA', () => {
+  it('returns plain string unchanged', () => {
+    expect(escapeJXA('hello world')).toBe('hello world');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeJXA('test"inject')).toBe('test\\"inject');
+  });
+
+  it('escapes backslashes before quotes', () => {
+    expect(escapeJXA('path\\to\\"file')).toBe('path\\\\to\\\\\\"file');
+  });
+
+  it('escapes newlines and carriage returns', () => {
+    expect(escapeJXA('line1\nline2\rline3')).toBe('line1\\nline2\\rline3');
+  });
+
+  it('handles empty string', () => {
+    expect(escapeJXA('')).toBe('');
+  });
+
+  it('handles non-ASCII (CJK) characters unchanged', () => {
+    expect(escapeJXA('send email')).toBe('send email');
+  });
+
+  it('handles combined special characters', () => {
+    expect(escapeJXA('a"b\\c\nd')).toBe('a\\"b\\\\c\\nd');
+  });
+});
+
+// ============================================================
+// generateFilterConditions - taskName filter
+// ============================================================
+describe('generateFilterConditions - taskName', () => {
+  it('generates case-insensitive includes check for taskName', () => {
+    const result = generateFilterConditions('tasks', { taskName: 'Email' });
+    expect(result).toContain('.toLowerCase()');
+    expect(result).toContain('.includes("email")');
+  });
+
+  it('escapes special chars in taskName', () => {
+    const result = generateFilterConditions('tasks', { taskName: 'test"value' });
+    expect(result).toContain('test\\"value');
+    expect(result).not.toContain('test"value"');
+  });
+
+  it('does not generate taskName filter for projects entity', () => {
+    const result = generateFilterConditions('projects', { taskName: 'anything' });
+    expect(result).not.toContain('taskName');
+    expect(result).not.toContain('includes');
+  });
+
+  it('combines taskName and projectName filters', () => {
+    const result = generateFilterConditions('tasks', {
+      taskName: 'email',
+      projectName: 'devices',
+    });
+    expect(result).toContain('email');
+    expect(result).toContain('devices');
+    // Both should produce return false conditions
+    const returnFalseCount = (result.match(/return false/g) || []).length;
+    expect(returnFalseCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ============================================================
+// generateFilterConditions - injection safety (all filters)
+// ============================================================
+describe('generateFilterConditions - injection safety', () => {
+  it('escapes projectName with quotes', () => {
+    const result = generateFilterConditions('tasks', { projectName: 'a"b' });
+    expect(result).toContain('a\\"b');
+  });
+
+  it('escapes projectId with quotes', () => {
+    const result = generateFilterConditions('tasks', { projectId: 'id"bad' });
+    expect(result).toContain('id\\"bad');
+  });
+
+  it('escapes tags with quotes', () => {
+    const result = generateFilterConditions('tasks', { tags: ['tag"evil'] });
+    expect(result).toContain('tag\\"evil');
+  });
+
+  it('escapes status with quotes', () => {
+    const result = generateFilterConditions('tasks', { status: ['Next"bad'] });
+    expect(result).toContain('Next\\"bad');
+  });
+
+  it('escapes folderId with quotes (projects entity)', () => {
+    const result = generateFilterConditions('projects', { folderId: 'f"id' });
+    expect(result).toContain('f\\"id');
+  });
+});
+
+// ============================================================
+// generateFieldMapping - hierarchy fields
+// ============================================================
+describe('generateFieldMapping - hierarchy fields', () => {
+  it('includes parentId mapping when requested', () => {
+    const result = generateFieldMapping('tasks', ['parentId']);
+    expect(result).toContain('parentId');
+    expect(result).toContain('item.parent');
+  });
+
+  it('includes childIds mapping when requested', () => {
+    const result = generateFieldMapping('tasks', ['childIds']);
+    expect(result).toContain('childIds');
+    expect(result).toContain('item.children');
+  });
+
+  it('includes hasChildren mapping when requested', () => {
+    const result = generateFieldMapping('tasks', ['hasChildren']);
+    expect(result).toContain('hasChildren');
+    expect(result).toContain('item.children');
+  });
+
+  it('default task fields do NOT include hierarchy (keeps response small)', () => {
+    const result = generateFieldMapping('tasks');
+    expect(result).not.toContain('parentId');
+    expect(result).not.toContain('childIds');
+    expect(result).not.toContain('hasChildren');
+  });
+
+  it('maps multiple fields correctly', () => {
+    const result = generateFieldMapping('tasks', ['id', 'name', 'parentId', 'childIds']);
+    expect(result).toContain('id: item.id.primaryKey');
+    expect(result).toContain('name');
+    expect(result).toContain('parentId');
+    expect(result).toContain('childIds');
+  });
+});
+
+// ============================================================
+// formatTasks - hierarchy display
+// ============================================================
+describe('formatTasks - hierarchy fields display', () => {
+  it('shows parentId when present', () => {
+    const result = formatTasks([
+      { name: 'Child Task', id: 'child1', parentId: 'parent1' },
+    ]);
+    expect(result).toContain('[parent: parent1]');
+  });
+
+  it('shows children when hasChildren is true', () => {
+    const result = formatTasks([
+      { name: 'Parent Task', id: 'p1', hasChildren: true, childIds: ['c1', 'c2'] },
+    ]);
+    expect(result).toContain('[children: c1, c2]');
+  });
+
+  it('does NOT show children section when hasChildren is false', () => {
+    const result = formatTasks([
+      { name: 'Leaf Task', id: 'l1', hasChildren: false, childIds: [] },
+    ]);
+    expect(result).not.toContain('[children');
+  });
+
+  it('does NOT show parent when parentId is null/undefined', () => {
+    const result = formatTasks([
+      { name: 'Root Task', id: 'r1', parentId: null },
+    ]);
+    expect(result).not.toContain('[parent');
+  });
+
+  it('does NOT show hierarchy fields when they are absent from data', () => {
+    const result = formatTasks([
+      { name: 'Simple Task', id: 's1' },
+    ]);
+    expect(result).not.toContain('[parent');
+    expect(result).not.toContain('[children');
+  });
+});
+
+// ============================================================
+// formatFilters - taskName display
+// ============================================================
+describe('formatFilters', () => {
+  it('displays taskName filter', () => {
+    const result = formatFilters({ taskName: 'email' });
+    expect(result).toContain('taskName: "email"');
+  });
+
+  it('displays combined filters', () => {
+    const result = formatFilters({ projectName: 'Test', taskName: 'foo' });
+    expect(result).toContain('project: "Test"');
+    expect(result).toContain('taskName: "foo"');
+  });
+
+  it('returns empty string for empty filters', () => {
+    const result = formatFilters({});
+    expect(result).toBe('');
+  });
+});

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -8,6 +8,7 @@ export const schema = z.object({
   filters: z.object({
     projectId: z.string().optional().describe("Filter tasks by exact project ID (use when you know the specific project ID)"),
     projectName: z.string().optional().describe("Filter tasks by project name. CASE-INSENSITIVE PARTIAL MATCHING - 'review' matches 'Weekly Review', 'Review Documents', etc. Special value: 'inbox' returns inbox tasks"),
+    taskName: z.string().optional().describe("Filter tasks by task name. CASE-INSENSITIVE PARTIAL MATCHING - 'email' matches 'Send email to IT', 'Confirm email' etc. Useful for fuzzy searching specific tasks across all projects"),
     folderId: z.string().optional().describe("Filter projects by exact folder ID (use when you know the specific folder ID)"),
     tags: z.array(z.string()).optional().describe("Filter by tag names. EXACT MATCH, CASE-SENSITIVE. OR logic - items must have at least ONE of the specified tags. Example: ['Work'] and ['work'] are different"),
     status: z.array(z.string()).optional().describe("Filter by status (OR logic - matches any). TASKS: 'Next' (next action), 'Available' (ready to work), 'Blocked' (waiting), 'DueSoon' (due <24h), 'Overdue' (past due), 'Completed', 'Dropped'. PROJECTS: 'Active', 'OnHold', 'Done', 'Dropped'"),
@@ -121,6 +122,7 @@ function formatFilters(filters: any): string {
   const parts = [];
   if (filters.projectId) parts.push(`projectId: "${filters.projectId}"`);
   if (filters.projectName) parts.push(`project: "${filters.projectName}"`);
+  if (filters.taskName) parts.push(`taskName: "${filters.taskName}"`);
   if (filters.folderId) parts.push(`folderId: "${filters.folderId}"`);
   if (filters.tags) parts.push(`tags: [${filters.tags.join(', ')}]`);
   if (filters.status) parts.push(`status: [${filters.status.join(', ')}]`);
@@ -193,6 +195,14 @@ function formatTasks(tasks: any[]): string {
       parts.push(`[completed: ${formatDate(task.completionDate)}]`);
     }
 
+    // Hierarchy info
+    if (task.parentId) {
+      parts.push(`[parent: ${task.parentId}]`);
+    }
+    if (task.hasChildren && task.childIds?.length > 0) {
+      parts.push(`[children: ${task.childIds.join(', ')}]`);
+    }
+
     let result = parts.join(' ');
 
     // Add note on a new line if present
@@ -236,3 +246,12 @@ function formatDate(dateStr: string): string {
   const date = new Date(dateStr);
   return `${date.getMonth() + 1}/${date.getDate()}`;
 }
+
+// Exported for testing only - not part of the public API
+export const _testExports = {
+  formatTasks,
+  formatProjects,
+  formatFolders,
+  formatQueryResults,
+  formatFilters,
+};

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -1,10 +1,21 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
 
+// Escape user-provided strings before embedding in JXA script template literals.
+// Prevents syntax errors and code injection from characters like " \ newlines.
+function escapeJXA(str: string): string {
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+}
+
 export interface QueryOmnifocusParams {
   entity: 'tasks' | 'projects' | 'folders';
   filters?: {
     projectId?: string;
     projectName?: string;
+    taskName?: string;
     folderId?: string;
     tags?: string[];
     status?: string[];
@@ -195,35 +206,45 @@ function generateFilterConditions(entity: string, filters: any): string {
   
   if (entity === 'tasks') {
     if (filters.projectName) {
+      const safeName = escapeJXA(filters.projectName.toLowerCase());
       conditions.push(`
         if (item.containingProject) {
           const projectName = item.containingProject.name.toLowerCase();
-          if (!projectName.includes("${filters.projectName.toLowerCase()}")) return false;
-        } else if ("${filters.projectName.toLowerCase()}" !== "inbox") {
+          if (!projectName.includes("${safeName}")) return false;
+        } else if ("${safeName}" !== "inbox") {
           return false;
         }
       `);
     }
+
+    if (filters.taskName) {
+      const safeName = escapeJXA(filters.taskName.toLowerCase());
+      conditions.push(`
+        const taskName = (item.name || "").toLowerCase();
+        if (!taskName.includes("${safeName}")) return false;
+      `);
+    }
     
     if (filters.projectId) {
+      const safeId = escapeJXA(filters.projectId);
       conditions.push(`
-        if (!item.containingProject || 
-            item.containingProject.id.primaryKey !== "${filters.projectId}") {
+        if (!item.containingProject ||
+            item.containingProject.id.primaryKey !== "${safeId}") {
           return false;
         }
       `);
     }
     
     if (filters.tags && filters.tags.length > 0) {
-      const tagCondition = filters.tags.map((tag: string) => 
-        `item.tags.some(t => t.name === "${tag}")`
+      const tagCondition = filters.tags.map((tag: string) =>
+        `item.tags.some(t => t.name === "${escapeJXA(tag)}")`
       ).join(' || ');
       conditions.push(`if (!(${tagCondition})) return false;`);
     }
-    
+
     if (filters.status && filters.status.length > 0) {
-      const statusCondition = filters.status.map((status: string) => 
-        `taskStatusMap[item.taskStatus] === "${status}"`
+      const statusCondition = filters.status.map((status: string) =>
+        `taskStatusMap[item.taskStatus] === "${escapeJXA(status)}"`
       ).join(' || ');
       conditions.push(`if (!(${statusCondition})) return false;`);
     }
@@ -278,17 +299,18 @@ function generateFilterConditions(entity: string, filters: any): string {
   
   if (entity === 'projects') {
     if (filters.folderId) {
+      const safeId = escapeJXA(filters.folderId);
       conditions.push(`
-        if (!item.parentFolder || 
-            item.parentFolder.id.primaryKey !== "${filters.folderId}") {
+        if (!item.parentFolder ||
+            item.parentFolder.id.primaryKey !== "${safeId}") {
           return false;
         }
       `);
     }
-    
+
     if (filters.status && filters.status.length > 0) {
-      const statusCondition = filters.status.map((status: string) => 
-        `projectStatusMap[item.status] === "${status}"`
+      const statusCondition = filters.status.map((status: string) =>
+        `projectStatusMap[item.status] === "${escapeJXA(status)}"`
       ).join(' || ');
       conditions.push(`if (!(${statusCondition})) return false;`);
     }
@@ -443,3 +465,10 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
     };
   `;
 }
+
+// Exported for testing only - not part of the public API
+export const _testExports = {
+  escapeJXA,
+  generateFilterConditions,
+  generateFieldMapping,
+};


### PR DESCRIPTION
## Summary

- **taskName filter**: Add case-insensitive partial matching on task names to `query_omnifocus`, complementing the existing `projectName` filter. Enables fuzzy search like `'email'` matching `'Send email to IT'`.
- **Hierarchy fields display**: Fix `formatTasks()` to include `parentId`, `childIds`, and `hasChildren` in output when explicitly requested via the `fields` parameter. The JXA layer already fetched these correctly, but the TypeScript formatter was dropping them.
- **JXA injection fix**: Add `escapeJXA()` helper to sanitize all user-provided filter strings (`projectName`, `taskName`, `projectId`, `folderId`, `tags`, `status`) before embedding in JXA script templates. Prevents `SyntaxError` and potential code injection from characters like `"`, `\`, and newlines. This also fixes a pre-existing issue in the upstream `projectName` filter.
- **Unit tests**: Set up vitest with 29 tests covering escapeJXA, filter generation, injection safety, field mapping, and output formatting.

## Test plan

- [x] `taskName` filter: normal match, no match, combined with `projectName`
- [x] Hierarchy fields: `parentId`/`childIds`/`hasChildren` display in output
- [x] Injection: double-quote in `taskName` and `projectName` no longer crashes
- [x] Edge cases: empty string filter, non-tasks entity with `taskName`
- [x] Unit tests: `npm run test` — 29 tests passing
- [ ] Verify no regressions on existing `projectName`, `tags`, `status` filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)