### PR TITLE
Add project review support: query by review status and mark as reviewed

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,8 @@ QUERY FILTER TIPS:
 - projectName filter is case-insensitive partial match
 - Status values for tasks: Next, Available, Blocked, DueSoon, Overdue
 - Status values for projects: Active, OnHold, Done, Dropped
+- Use reviewDue: true filter on projects to find projects needing review
+- Use edit_item with markReviewed: true to mark a project as reviewed
 - Combine filters with AND logic; within arrays, OR logic applies`
   }
 );

--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -178,6 +178,52 @@ describe('formatTasks - hierarchy fields display', () => {
 });
 
 // ============================================================
+// generateFilterConditions - reviewDue filter (projects)
+// ============================================================
+describe('generateFilterConditions - reviewDue', () => {
+  it('generates review date check when reviewDue is true', () => {
+    const result = generateFilterConditions('projects', { reviewDue: true });
+    expect(result).toContain('nextReviewDate');
+    expect(result).toContain('return false');
+  });
+
+  it('generates inverse review check when reviewDue is false', () => {
+    const result = generateFilterConditions('projects', { reviewDue: false });
+    expect(result).toContain('nextReviewDate');
+    expect(result).toContain('return false');
+  });
+
+  it('does not generate reviewDue filter for tasks entity', () => {
+    const result = generateFilterConditions('tasks', { reviewDue: true });
+    expect(result).not.toContain('nextReviewDate');
+    expect(result).not.toContain('reviewDate');
+  });
+});
+
+// ============================================================
+// generateFieldMapping - review fields
+// ============================================================
+describe('generateFieldMapping - review fields', () => {
+  it('includes nextReviewDate mapping when requested', () => {
+    const result = generateFieldMapping('projects', ['nextReviewDate']);
+    expect(result).toContain('nextReviewDate');
+    expect(result).toContain('item.nextReviewDate');
+  });
+
+  it('includes reviewInterval mapping when requested', () => {
+    const result = generateFieldMapping('projects', ['reviewInterval']);
+    expect(result).toContain('reviewInterval');
+    expect(result).toContain('item.reviewInterval');
+  });
+
+  it('default project fields include review fields', () => {
+    const result = generateFieldMapping('projects');
+    expect(result).toContain('nextReviewDate');
+    expect(result).toContain('reviewInterval');
+  });
+});
+
+// ============================================================
 // formatFilters - taskName display
 // ============================================================
 describe('formatFilters', () => {
@@ -222,5 +268,10 @@ describe('formatFilters', () => {
   it('displays ISO date dueOn naturally', () => {
     const result = formatFilters({ dueOn: '2026-04-15' });
     expect(result).toBe('due on 2026-04-15');
+  });
+
+  it('displays reviewDue filter', () => {
+    const result = formatFilters({ reviewDue: true });
+    expect(result).toBe('review due: true');
   });
 });

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -26,7 +26,8 @@ export const schema = z.object({
   // Project-specific fields
   newSequential: z.boolean().optional().describe("Whether the project should be sequential"),
   newFolderName: z.string().optional().describe("New folder to move the project to"),
-  newProjectStatus: z.enum(['active', 'completed', 'dropped', 'onHold']).optional().describe("New status for projects")
+  newProjectStatus: z.enum(['active', 'completed', 'dropped', 'onHold']).optional().describe("New status for projects"),
+  markReviewed: z.boolean().optional().describe("Mark the project as reviewed (projects only). Sets the next review date to now + the project's review interval. Only works when set to true.")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/queryOmnifocus.test.ts
+++ b/src/tools/definitions/queryOmnifocus.test.ts
@@ -31,4 +31,24 @@ describe('queryOmnifocus schema', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe('reviewDue filter', () => {
+    it('accepts boolean true', () => {
+      const input = { entity: 'projects', filters: { reviewDue: true } };
+      const result = schema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts boolean false', () => {
+      const input = { entity: 'projects', filters: { reviewDue: false } };
+      const result = schema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects non-boolean types', () => {
+      const input = { entity: 'projects', filters: { reviewDue: 'yes' } };
+      const result = schema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -26,10 +26,11 @@ export const schema = z.object({
     addedOn: z.number().optional().describe("Returns items added (created) on exactly this day. 0 = today, 1 = tomorrow, -1 = yesterday. Negative values look backward"),
     isRepeating: z.boolean().optional().describe("Filter by repeating status. true = only repeating tasks, false = only non-repeating tasks"),
     completedWithin: z.number().optional().describe("Returns items completed or dropped within the last N days (uses completionDate which OmniFocus sets for both). Example: 7 = items completed in the last week. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true"),
-    completedOn: z.number().optional().describe("Returns items completed or dropped on exactly this day (uses completionDate which OmniFocus sets for both). 0 = today, -1 = yesterday. Negative values look backward. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true")
+    completedOn: z.number().optional().describe("Returns items completed or dropped on exactly this day (uses completionDate which OmniFocus sets for both). 0 = today, -1 = yesterday. Negative values look backward. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true"),
+    reviewDue: z.boolean().optional().describe("Filter projects by review status. true = only projects whose next review date is today or in the past (due for review). false = only projects not yet due for review. Only applies to 'projects' entity")
   }).optional().describe("Optional filters to narrow results. ALL filters combine with AND logic (must match all). Within array filters (tags, status) OR logic applies"),
   
-  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
+  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, nextReviewDate, reviewInterval, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
   
   limit: z.number().optional().describe("Maximum number of items to return. Useful for large result sets. Default: no limit"),
   
@@ -158,6 +159,7 @@ function formatFilters(filters: any): string {
   if (filters.isRepeating !== undefined) parts.push(`repeating: ${filters.isRepeating}`);
   if (filters.completedWithin !== undefined) parts.push(`completed within ${filters.completedWithin} days`);
   if (filters.completedOn !== undefined) parts.push(`completed on day ${filters.completedOn}`);
+  if (filters.reviewDue !== undefined) parts.push(`review due: ${filters.reviewDue}`);
   return parts.join(', ');
 }
 
@@ -255,8 +257,10 @@ function formatProjects(projects: any[]): string {
     const taskCount = project.taskCount !== undefined && project.taskCount !== null ? ` (${project.taskCount} tasks)` : '';
     const flagged = project.flagged ? '🚩 ' : '';
     const due = project.dueDate ? ` [due: ${formatDate(project.dueDate)}]` : '';
+    const review = project.nextReviewDate ? ` [review: ${formatDate(project.nextReviewDate)}]` : '';
+    const reviewInterval = project.reviewInterval ? ` [review every: ${project.reviewInterval}]` : '';
 
-    let result = `P: ${flagged}${project.name}${status}${due}${folder}${taskCount}`;
+    let result = `P: ${flagged}${project.name}${status}${due}${review}${reviewInterval}${folder}${taskCount}`;
 
     // Add note on a new line if present
     if (project.note) {

--- a/src/tools/dumpDatabase.ts
+++ b/src/tools/dumpDatabase.ts
@@ -37,6 +37,8 @@ interface OmnifocusDumpProject {
   containsSingletonActions: boolean;
   note: string;
   tasks: string[];
+  nextReviewDate: string | null;
+  reviewInterval: string | null;
 }
 
 interface OmnifocusDumpFolder {
@@ -154,7 +156,9 @@ export async function dumpDatabase(): Promise<OmnifocusDatabase> {
           note: String(project.note || ""),
           tasks: project.tasks || [],
           flagged: false, // Default value
-          estimatedMinutes: null // Default value
+          estimatedMinutes: null, // Default value
+          nextReviewDate: project.nextReviewDate || null,
+          reviewInterval: project.reviewInterval || null
         };
       }
     }

--- a/src/tools/primitives/editItem.test.ts
+++ b/src/tools/primitives/editItem.test.ts
@@ -252,5 +252,36 @@ describe('editItem generateAppleScript', () => {
       });
       expect(script).toContain('set status of foundItem to on hold status');
     });
+
+    it('generates markReviewed script for projects', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'P',
+        markReviewed: true,
+      });
+      expect(script).toContain('set ri to review interval of foundItem');
+      expect(script).toContain('set next review date of foundItem to newReviewDate');
+      expect(script).toContain('marked reviewed');
+    });
+
+    it('does not generate markReviewed when false', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'P',
+        markReviewed: false,
+      });
+      expect(script).not.toContain('review interval');
+      expect(script).not.toContain('next review date');
+    });
+
+    it('does not generate markReviewed for tasks', () => {
+      const script = generateAppleScript({
+        itemType: 'task',
+        name: 'T',
+        markReviewed: true,
+      });
+      expect(script).not.toContain('review interval');
+      expect(script).not.toContain('next review date');
+    });
   });
 });

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -37,6 +37,7 @@ export interface EditItemParams {
   newSequential?: boolean;      // Whether the project should be sequential
   newFolderName?: string;       // New folder to move the project to
   newProjectStatus?: ProjectStatus; // New status for projects
+  markReviewed?: boolean;       // Mark the project as reviewed (advances next review date)
 }
 
 /**
@@ -388,6 +389,43 @@ export function generateAppleScript(params: EditItemParams): string {
 `;
     }
     
+    // Mark project as reviewed
+    if (params.markReviewed === true) {
+      script += `
+        -- Mark project as reviewed (advances next review date by the project's review interval)
+        -- review interval is a structured record {unit, steps, fixed}, not a simple number
+        set ri to review interval of foundItem
+        set newReviewDate to current date
+        if ri is not missing value then
+          set riUnit to unit of ri
+          set riSteps to steps of ri
+          if riUnit is month then
+            -- Add months by adjusting the month component
+            set curMonth to (month of newReviewDate) as integer
+            set newMonth to curMonth + riSteps
+            set extraYears to (newMonth - 1) div 12
+            set newMonth to ((newMonth - 1) mod 12) + 1
+            set year of newReviewDate to (year of newReviewDate) + extraYears
+            set month of newReviewDate to newMonth
+          else if riUnit is year then
+            set year of newReviewDate to (year of newReviewDate) + riSteps
+          else if riUnit is week then
+            set newReviewDate to newReviewDate + (riSteps * 7 * days)
+          else if riUnit is day then
+            set newReviewDate to newReviewDate + (riSteps * days)
+          else
+            -- Fallback: default to 1 week
+            set newReviewDate to newReviewDate + (7 * days)
+          end if
+        else
+          -- No review interval set, default to 1 week
+          set newReviewDate to newReviewDate + (7 * days)
+        end if
+        set next review date of foundItem to newReviewDate
+        set end of changedProperties to "marked reviewed"
+`;
+    }
+
     // Move to a new folder (supports nested paths like "Work/Engineering")
     if (params.newFolderName !== undefined && params.newFolderName !== '') {
       const escapedFolderName = params.newFolderName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -33,6 +33,7 @@ export interface QueryOmnifocusParams {
     isRepeating?: boolean;
     completedWithin?: number;
     completedOn?: number;
+    reviewDue?: boolean;
   };
   fields?: string[];
   limit?: number;
@@ -422,6 +423,31 @@ function generateFilterConditions(entity: string, filters: any): string {
     if (filters.completedOn !== undefined) {
       conditions.push(`if (!checkSameDay(item.completionDate, ${filters.completedOn})) return false;`);
     }
+
+    if (filters.reviewDue !== undefined) {
+      if (filters.reviewDue) {
+        conditions.push(`
+          {
+            const reviewDate = item.nextReviewDate;
+            if (!reviewDate) return false;
+            const now = new Date();
+            now.setHours(23, 59, 59, 999);
+            if (reviewDate > now) return false;
+          }
+        `);
+      } else {
+        conditions.push(`
+          {
+            const reviewDate = item.nextReviewDate;
+            if (reviewDate) {
+              const now = new Date();
+              now.setHours(23, 59, 59, 999);
+              if (reviewDate <= now) return false;
+            }
+          }
+        `);
+      }
+    }
   }
 
   return conditions.join('\n');
@@ -475,6 +501,16 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
     } else if (entity === 'projects') {
       return `
         const taskArray = item.tasks || [];
+        const ri = item.reviewInterval;
+        let riStr = null;
+        if (ri) {
+          const parts = [];
+          if (ri.years && ri.years > 0) parts.push(ri.years === 1 ? "1 year" : ri.years + " years");
+          if (ri.months && ri.months > 0) parts.push(ri.months === 1 ? "1 month" : ri.months + " months");
+          if (ri.weeks && ri.weeks > 0) parts.push(ri.weeks === 1 ? "1 week" : ri.weeks + " weeks");
+          if (ri.days && ri.days > 0) parts.push(ri.days === 1 ? "1 day" : ri.days + " days");
+          if (parts.length > 0) riStr = parts.join(", ");
+        }
         return {
           id: item.id.primaryKey,
           name: item.name || "",
@@ -484,7 +520,9 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
           flagged: item.flagged || false,
           dueDate: formatDate(item.dueDate),
           deferDate: formatDate(item.deferDate),
-          note: item.note || ""
+          note: item.note || "",
+          nextReviewDate: formatDate(item.nextReviewDate),
+          reviewInterval: riStr
         };
       `;
     } else if (entity === 'folders') {
@@ -563,6 +601,19 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
       return `repetitionRule: item.repetitionRule ? item.repetitionRule.toString() : null`;
     } else if (field === 'estimatedMinutes') {
       return `estimatedMinutes: item.estimatedMinutes || null`;
+    } else if (field === 'nextReviewDate') {
+      return `nextReviewDate: formatDate(item.nextReviewDate)`;
+    } else if (field === 'reviewInterval') {
+      return `reviewInterval: (() => {
+          const ri = item.reviewInterval;
+          if (!ri) return null;
+          const parts = [];
+          if (ri.years && ri.years > 0) parts.push(ri.years === 1 ? "1 year" : ri.years + " years");
+          if (ri.months && ri.months > 0) parts.push(ri.months === 1 ? "1 month" : ri.months + " months");
+          if (ri.weeks && ri.weeks > 0) parts.push(ri.weeks === 1 ? "1 week" : ri.weeks + " weeks");
+          if (ri.days && ri.days > 0) parts.push(ri.days === 1 ? "1 day" : ri.days + " days");
+          return parts.length > 0 ? parts.join(", ") : null;
+        })()`;
     } else if (field === 'note') {
       return `note: item.note || ""`;
     } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,8 @@ export interface OmnifocusProject {
   tasks: string[]; // Task IDs
   flagged?: boolean;
   estimatedMinutes?: number | null;
+  nextReviewDate: string | null;
+  reviewInterval: string | null; // Human-readable review interval (e.g. "1 week", "1 month")
 }
 
 export interface OmnifocusFolder {

--- a/src/utils/omnifocusScripts/omnifocusDump.js
+++ b/src/utils/omnifocusScripts/omnifocusDump.js
@@ -37,6 +37,17 @@
           return mapObj[enumObj] || "Unknown";
         }
 
+        // Format a DateComponents interval into a human-readable string
+        function formatReviewInterval(interval) {
+          if (!interval) return null;
+          const parts = [];
+          if (interval.years && interval.years > 0) parts.push(interval.years === 1 ? "1 year" : interval.years + " years");
+          if (interval.months && interval.months > 0) parts.push(interval.months === 1 ? "1 month" : interval.months + " months");
+          if (interval.weeks && interval.weeks > 0) parts.push(interval.weeks === 1 ? "1 week" : interval.weeks + " weeks");
+          if (interval.days && interval.days > 0) parts.push(interval.days === 1 ? "1 day" : interval.days + " days");
+          return parts.length > 0 ? parts.join(", ") : null;
+        }
+
         // Create database export object using Maps for faster lookups
         const exportData = {
           exportDate: new Date().toISOString(),
@@ -84,7 +95,9 @@
               completedByChildren: project.completedByChildren,
               containsSingletonActions: project.containsSingletonActions,
               note: project.note || "",
-              tasks: [] // Will be populated in the task loop
+              tasks: [], // Will be populated in the task loop
+              nextReviewDate: formatDate(project.nextReviewDate),
+              reviewInterval: formatReviewInterval(project.reviewInterval)
             };
             projectsMap.set(projectId, projectData);
             exportData.projects[projectId] = projectData;


### PR DESCRIPTION
## Summary

- Adds `nextReviewDate` and `reviewInterval` fields to the project data model and JXA extraction, so project review information is now visible in database dumps and queries
- Adds a `reviewDue` boolean filter to `query_omnifocus` for the `projects` entity — `true` returns projects whose next review date is today or past, `false` returns projects not yet due
- Adds `nextReviewDate` and `reviewInterval` to default project query output and as requestable fields
- Adds a `markReviewed` boolean parameter to `edit_item` (project only) that extracts the project's review interval record (unit + steps) and computes the correct next review date, handling day/week/month/year intervals
- Updates MCP server instructions to document the new review capabilities

### Usage examples

**Find projects needing review:**
```json
{"entity": "projects", "filters": {"reviewDue": true}}
```

**Mark a project as reviewed:**
```json
{"itemType": "project", "name": "My Project", "markReviewed": true}
```