### PR TITLE
Filter out projects dropped/completed via container

### DIFF
--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -145,6 +145,27 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
         [Project.Status.OnHold]: "OnHold"
       };
       
+      // Helper to collect all descendant folder IDs by walking down from a folder.
+      // parentFolder is unreliable on flattenedFolders, so we walk children instead.
+      function collectDescendantFolderIds(folder, idSet) {
+        idSet.add(folder.id.primaryKey);
+        var children = folder.folders;
+        for (var i = 0; i < children.length; i++) {
+          collectDescendantFolderIds(children[i], idSet);
+        }
+      }
+
+      // Check if any ancestor folder is dropped.
+      // OmniJS doesn't expose effectivelyDropped on projects, so we walk up manually.
+      function isAncestorFolderDropped(project) {
+        var folder = project.parentFolder;
+        while (folder) {
+          if (folder.status === Folder.Status.Dropped) return true;
+          folder = folder.parentFolder;
+        }
+        return false;
+      }
+
       // Get the appropriate collection based on entity type
       let items = [];
       const entityType = "${entity}";
@@ -167,8 +188,9 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
               return false;
             }
           } else if (entityType === "projects") {
-            if (item.status === Project.Status.Done || 
-                item.status === Project.Status.Dropped) {
+            if (item.status === Project.Status.Done ||
+                item.status === Project.Status.Dropped ||
+                isAncestorFolderDropped(item)) {
               return false;
             }
           }

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -160,10 +160,21 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
       // parentFolder is unreliable on flattenedFolders, so we walk children instead.
       function collectDescendantFolderIds(folder, idSet) {
         idSet.add(folder.id.primaryKey);
-        const children = folder.folders;
-        for (let i = 0; i < children.length; i++) {
+        var children = folder.folders;
+        for (var i = 0; i < children.length; i++) {
           collectDescendantFolderIds(children[i], idSet);
         }
+      }
+
+      // Check if any ancestor folder is dropped.
+      // OmniJS doesn't expose effectivelyDropped on projects, so we walk up manually.
+      function isAncestorFolderDropped(project) {
+        var folder = project.parentFolder;
+        while (folder) {
+          if (folder.status === Folder.Status.Dropped) return true;
+          folder = folder.parentFolder;
+        }
+        return false;
       }
 
       // Get the appropriate collection based on entity type
@@ -201,8 +212,9 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
               return false;
             }
           } else if (entityType === "projects") {
-            if (item.status === Project.Status.Done || 
-                item.status === Project.Status.Dropped) {
+            if (item.status === Project.Status.Done ||
+                item.status === Project.Status.Dropped ||
+                isAncestorFolderDropped(item)) {
               return false;
             }
           }


### PR DESCRIPTION
## Summary

- Uses OmniFocus's native `effectivelyDropped` and `effectivelyCompleted` properties when filtering projects, in addition to the direct `item.status` check
- Fixes an issue where projects inside a dropped folder (e.g., on-hold projects whose parent folder was dropped) would still appear in query results like `reviewDue: true`