### PR TITLE
Fix perspective date filter returning empty results

### DIFF
--- a/src/resources/perspective.ts
+++ b/src/resources/perspective.ts
@@ -10,7 +10,9 @@ export async function readPerspective(uri: URL, variables: Variables, logger: Lo
 
   const result = await getPerspectiveView({ perspectiveName: name });
 
-  const data = result.success ? result.items ?? [] : { error: result.error };
+  const data = result.success
+    ? { items: result.items ?? [], debug: result.debug }
+    : { error: result.error };
 
   return {
     contents: [{

--- a/src/tools/primitives/getPerspectiveView.ts
+++ b/src/tools/primitives/getPerspectiveView.ts
@@ -11,6 +11,14 @@ interface PerspectiveViewResult {
   success: boolean;
   items?: any[];
   error?: string;
+  debug?: {
+    rules: any;
+    tasksEvaluated: number;
+    unknownRuleTypes?: string[];
+    isCustomPerspective?: boolean;
+    rulesUsed?: boolean;
+    ruleParseError?: string;
+  };
 }
 
 export async function getPerspectiveView(params: GetPerspectiveViewParams): Promise<PerspectiveViewResult> {
@@ -51,7 +59,13 @@ export async function getPerspectiveView(params: GetPerspectiveViewParams): Prom
     
     return {
       success: true,
-      items: items
+      items: items,
+      debug: result.debug ? {
+        ...result.debug,
+        isCustomPerspective: result.isCustomPerspective,
+        rulesUsed: result.rulesUsed,
+        ruleParseError: result.ruleParseError,
+      } : undefined,
     };
     
   } catch (error) {

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -189,15 +189,25 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       return value.some((term) => searchText.includes(term.toLowerCase()));
     };
 
+    // OmniFocus stores "completed" as the field name but the JS property is completionDate.
+    var normalizeDateFieldName = (dateField) => {
+      const map = { completed: "completion" };
+      return map[dateField] || dateField;
+    };
+
+    var getTaskDateField = (task, dateField) => {
+      return task[normalizeDateFieldName(dateField) + "Date"];
+    };
+
     var evaluateActionDateIsToday = (task, dateField) => {
-      const fieldDate = task[dateField + "Date"]; // e.g., dueDate, deferDate
+      const fieldDate = getTaskDateField(task, dateField);
       if (!fieldDate) return false;
       const today = new Date();
       return fieldDate.toDateString() === today.toDateString();
     };
 
     var evaluateActionDateIsYesterday = (task, dateField) => {
-      const fieldDate = task[dateField + "Date"];
+      const fieldDate = getTaskDateField(task, dateField);
       if (!fieldDate) return false;
       const yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);
@@ -205,11 +215,31 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     };
 
     var evaluateActionDateIsTomorrow = (task, dateField) => {
-      const fieldDate = task[dateField + "Date"];
+      const fieldDate = getTaskDateField(task, dateField);
       if (!fieldDate) return false;
       const tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
       return fieldDate.toDateString() === tomorrow.toDateString();
+    };
+
+    var evaluateActionDateIsInThePast = (task, dateField, value) => {
+      const fieldDate = getTaskDateField(task, dateField);
+      if (!fieldDate) return false;
+      const { relativeBeforeAmount, relativeComponent } = value;
+      const cutoff = new Date();
+      if (relativeComponent === "day") {
+        cutoff.setDate(cutoff.getDate() - relativeBeforeAmount);
+      } else if (relativeComponent === "week") {
+        cutoff.setDate(cutoff.getDate() - relativeBeforeAmount * 7);
+      } else if (relativeComponent === "month") {
+        cutoff.setMonth(cutoff.getMonth() - relativeBeforeAmount);
+      } else if (relativeComponent === "year") {
+        cutoff.setFullYear(cutoff.getFullYear() - relativeBeforeAmount);
+      } else {
+        return false;
+      }
+      const now = new Date();
+      return fieldDate >= cutoff && fieldDate <= now;
     };
 
     // filter rules and values are defined here: https://omni-automation.com/omnifocus/perspective.html
@@ -251,8 +281,18 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         if (rule.actionDateIsTomorrow) {
           return evaluateActionDateIsTomorrow(task, dateField);
         }
+        if (rule.actionDateIsInThePast) {
+          return evaluateActionDateIsInThePast(task, dateField, rule.actionDateIsInThePast);
+        }
 
-        // Add other date conditions as needed
+        // Record any unrecognised date conditions so callers can diagnose gaps
+        const knownDateKeys = new Set(["actionDateField", "actionDateIsToday", "actionDateIsYesterday", "actionDateIsTomorrow", "actionDateIsInThePast"]);
+        Object.keys(rule).forEach((k) => {
+          if (!knownDateKeys.has(k)) {
+            const entry = k + "(field=" + dateField + ", value=" + JSON.stringify(rule[k]) + ")";
+            if (!unknownRuleTypes.includes(entry)) unknownRuleTypes.push(entry);
+          }
+        });
         return false;
       }
 
@@ -268,6 +308,11 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         }
       }
 
+      // Record unrecognised rule types so callers can diagnose gaps
+      Object.keys(rule).forEach((k) => {
+        const entry = "unknown:" + k + "=" + JSON.stringify(rule[k]);
+        if (!unknownRuleTypes.includes(entry)) unknownRuleTypes.push(entry);
+      });
       return false;
     }
 
@@ -370,9 +415,12 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     }
 
     let filteredTasks = [];
+    let unknownRuleTypes = [];
+    let tasksEvaluated = 0;
 
     if (isCustomPerspective && perspectiveRules) {
       flattenedTasks.forEach((task) => {
+        tasksEvaluated++;
         if (evaluateTask(task, perspectiveRules, perspectiveAggregation)) {
           filteredTasks.push(getTaskDetails(task));
         }
@@ -381,16 +429,19 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       // Use built-in perspective logic for default perspectives
       if (perspectiveName === "Inbox") {
         inbox.forEach((task) => {
+          tasksEvaluated++;
           filteredTasks.push(getTaskDetails(task));
         });
       } else if (perspectiveName === "Flagged") {
         flattenedTasks.forEach((task) => {
+          tasksEvaluated++;
           if (task.flagged && !task.completed) {
             filteredTasks.push(getTaskDetails(task));
           }
         });
       } else if (perspectiveName === "Projects") {
         flattenedProjects.forEach((project) => {
+          tasksEvaluated++;
           if (project.status === Project.Status.Active) {
             const projectTask = project.task;
             if (projectTask) {
@@ -401,6 +452,7 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       } else if (perspectiveName === "Tags") {
         flattenedTags.forEach((tag) => {
           tag.remainingTasks.forEach((task) => {
+            tasksEvaluated++;
             const taskDetail = getTaskDetails(task);
             if (!filteredTasks.some((item) => item.id === taskDetail.id)) {
               filteredTasks.push(taskDetail);
@@ -409,6 +461,7 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         });
       } else {
         flattenedTasks.forEach((task) => {
+          tasksEvaluated++;
           if (task.taskStatus === Task.Status.Available && !task.completed) {
             filteredTasks.push(getTaskDetails(task));
           }
@@ -423,6 +476,11 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       rulesUsed: perspectiveRules !== null,
       aggregationType: perspectiveAggregation,
       ruleParseError: typeof ruleParseError !== "undefined" ? ruleParseError : undefined,
+      debug: {
+        rules: perspectiveRules,
+        tasksEvaluated: tasksEvaluated,
+        unknownRuleTypes: unknownRuleTypes.length > 0 ? unknownRuleTypes : undefined,
+      },
       items: filteredTasks.slice(0, limit),
     };
 


### PR DESCRIPTION
## Summary

Custom perspectives using a completed-date filter (e.g. the **Finished** perspective) returned zero results despite having matching tasks. Two bugs were responsible:

- **`actionDateIsInThePast` unimplemented** — OmniFocus stores relative date windows as `{ actionDateField: "completed", actionDateIsInThePast: { relativeBeforeAmount: 14, relativeComponent: "day" } }`. The filter evaluator had no handler for this condition, so it fell through to `return false` for every task, silently discarding all results.
- **Wrong field name for completion date** — `actionDateField: "completed"` was used to build `task.completedDate`, which doesn't exist in the OmniFocus JS API. The correct property is `task.completionDate`. Fixed via a `normalizeDateFieldName` helper that maps `"completed"` → `"completion"` before appending `"Date"`.

## Changes

- `getPerspectiveView.js`: Add `evaluateActionDateIsInThePast` supporting `day`, `week`, `month`, and `year` components. Add `normalizeDateFieldName`/`getTaskDateField` helpers to centralise field name mapping. Add `unknownRuleTypes` tracking so any future unhandled rule type is named in the response rather than silently returning false.
- `getPerspectiveView.ts`: Extend `PerspectiveViewResult` with a `debug` field and pass it through from the script response.
- `perspective.ts`: Surface `debug` in the resource JSON response so it's visible when reading a perspective resource directly.

## Test plan

- [ ] Read `omnifocus://perspective/Finished` — should return completed tasks from the last 14 days tagged "Claude Slack Task"
- [ ] Confirm `debug.unknownRuleTypes` is absent (no unhandled rules)
- [ ] Confirm `debug.tasksEvaluated` is non-zero
- [ ] Other perspectives (Today, Forecast, Flagged) still return correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)