### PR TITLE
Preserve newlines in note fields

### DIFF
--- a/src/tools/primitives/addOmniFocusTask.test.ts
+++ b/src/tools/primitives/addOmniFocusTask.test.ts
@@ -16,4 +16,14 @@ describe('addOmniFocusTask generateAppleScript', () => {
     expect(script).toContain('make new task with properties {name:"Write tests"}');
     expect(script).toContain('at end of tasks of theProject');
   });
+
+  it('preserves newlines in note via linefeed concatenation', () => {
+    const script = generateAppleScript({
+      name: 'A task',
+      note: 'Line 1\nLine 2\nLine 3',
+    });
+    expect(script).toContain(
+      'set note of newTask to "Line 1" & linefeed & "Line 2" & linefeed & "Line 3"'
+    );
+  });
 });

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -29,7 +29,9 @@ export interface AddOmniFocusTaskParams {
 export function generateAppleScript(params: AddOmniFocusTaskParams): string {
   // Sanitize and prepare parameters for AppleScript
   const name = params.name.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '); // Escape quotes and backslashes
-  const note = params.note?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
+  const note = params.note
+    ?.replace(/["\\]/g, '\\$&')
+    .replace(/\r\n|\r|\n/g, '" & linefeed & "') || '';
   const dueDate = params.dueDate || '';
   const deferDate = params.deferDate || '';
   const plannedDate = params.plannedDate || '';

--- a/src/tools/primitives/addProject.test.ts
+++ b/src/tools/primitives/addProject.test.ts
@@ -46,6 +46,13 @@ describe('addProject generateAppleScript', () => {
       expect(script).toContain('set note of newProject to "A \\"quoted\\" note"');
     });
 
+    it('preserves newlines in note via linefeed concatenation', () => {
+      const script = generateAppleScript(makeParams({ note: 'Line 1\nLine 2' }));
+      expect(script).toContain(
+        'set note of newProject to "Line 1" & linefeed & "Line 2"'
+      );
+    });
+
     it('escapes backslashes in project name', () => {
       const script = generateAppleScript(makeParams({ name: 'Back\\slash' }));
       expect(script).toContain('Back\\\\slash');

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -26,7 +26,9 @@ export interface AddProjectParams {
 export function generateAppleScript(params: AddProjectParams): string {
   // Sanitize and prepare parameters for AppleScript
   const name = params.name.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '); // Escape quotes and backslashes
-  const note = params.note?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
+  const note = params.note
+    ?.replace(/["\\]/g, '\\$&')
+    .replace(/\r\n|\r|\n/g, '" & linefeed & "') || '';
   const dueDate = params.dueDate || '';
   const deferDate = params.deferDate || '';
   const flagged = params.flagged === true;

--- a/src/tools/primitives/editItem.test.ts
+++ b/src/tools/primitives/editItem.test.ts
@@ -219,6 +219,33 @@ describe('editItem generateAppleScript', () => {
       expect(script).toContain('set note of foundItem to "A note"');
     });
 
+    it('preserves newlines in note via linefeed concatenation', () => {
+      const script = generateAppleScript(makeParams({
+        newNote: 'Line 1\nLine 2\nLine 3',
+      }));
+      expect(script).toContain(
+        'set note of foundItem to "Line 1" & linefeed & "Line 2" & linefeed & "Line 3"'
+      );
+    });
+
+    it('handles CRLF and bare CR line endings in note', () => {
+      const script = generateAppleScript(makeParams({
+        newNote: 'a\r\nb\rc',
+      }));
+      expect(script).toContain(
+        'set note of foundItem to "a" & linefeed & "b" & linefeed & "c"'
+      );
+    });
+
+    it('still escapes quotes alongside newlines in note', () => {
+      const script = generateAppleScript(makeParams({
+        newNote: 'He said "hi"\nthen left',
+      }));
+      expect(script).toContain(
+        'set note of foundItem to "He said \\"hi\\"" & linefeed & "then left"'
+      );
+    });
+
     it('generates flagged update', () => {
       const script = generateAppleScript(makeParams({
         newFlagged: true,

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -179,7 +179,7 @@ export function generateAppleScript(params: EditItemParams): string {
   if (params.newNote !== undefined) {
     script += `
         -- Update note
-        set note of foundItem to "${params.newNote.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"
+        set note of foundItem to "${params.newNote.replace(/["\\]/g, '\\$&').replace(/\r\n|\r|\n/g, '" & linefeed & "')}"
         set end of changedProperties to "note"
 `;
   }


### PR DESCRIPTION
## Summary

`add_omnifocus_task`, `add_project`, and `edit_item` all sanitize the `note` field by stripping every `\r` and `\n` before embedding it into AppleScript. The result: any structure in a note — paragraphs, bullet lists, code blocks, multi-line URLs — collapses to a single-line blob in OmniFocus. Round-tripping a note through the MCP destroys its formatting.

The original `[\r\n] → ' '` substitution was a workaround for the fact that a literal newline inside an AppleScript double-quoted string is a syntax error. The fix replaces newlines with `" & linefeed & "` (AppleScript string concatenation against the `linefeed` constant) — valid AppleScript that stores a real newline on the OmniFocus item.

Names, tags, project paths, and folder names keep their existing single-line flattening — those are single-line by nature in OmniFocus UX, and there are no reported issues with them.

## Repro (before)

```
add_omnifocus_task({ name: "test", note: "Line 1\nLine 2\nLine 3" })
→ OmniFocus note: "Line 1 Line 2 Line 3"
```

## After

```
add_omnifocus_task({ name: "test", note: "Line 1\nLine 2\nLine 3" })
→ OmniFocus note: "Line 1\nLine 2\nLine 3" (three actual lines)
```

The escaping order matters and is covered by tests: quotes/backslashes are escaped first, then the newline split runs against the escaped string, so a quote on either side of a newline is escaped exactly once.

## Files changed

- `src/tools/primitives/addOmniFocusTask.ts`
- `src/tools/primitives/addProject.ts`
- `src/tools/primitives/editItem.ts`
- corresponding `.test.ts` files (5 new tests covering `\n`, `\r\n`, bare `\r`, quotes-around-newlines, and multi-line project notes)

## Test plan

- [x] `npm test` — 143 passing (138 previous + 5 new)
- [x] Built the patched bundle and invoked `osascript` against a real OmniFocus database; verified the resulting task's `note` contains real newlines (confirmed via JXA readback returning `"First line\nSecond line\n\nAfter blank line"`)
- [ ] Reviewer: confirm none of the existing MCP clients rely on the newline-flattening behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)