### PR TITLE
Fix custom perspective evaluation returning wrong items

### DIFF
--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -306,11 +306,6 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return false;
       }
 
-      // Skip disabled rules — they are toggled off in the perspective editor
-      if (rule.disabledRule !== undefined) {
-        return true;
-      }
-
       // Handle standard rules
       for (const [key, value] of Object.entries(rule)) {
         if (possibleRuleTypes[key]) {
@@ -329,7 +324,18 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     function evaluateTask(task, filters, aggregationType = "all") {
       if (!Array.isArray(filters) || filters.length === 0) return true;
 
-      const results = filters.map((filter) => {
+      // Disabled rules (toggled off in the perspective editor) must be excluded
+      // from aggregation entirely, not coerced to a boolean. Coercing them to
+      // true breaks "none" groups (every result must be false) and would create
+      // false positives in "any" groups; coercing to false breaks "all" groups.
+      const activeFilters = filters.filter(
+        (filter) => filter.disabledRule === undefined
+      );
+
+      // A group consisting only of disabled rules imposes no constraint.
+      if (activeFilters.length === 0) return true;
+
+      const results = activeFilters.map((filter) => {
         if (filter.aggregateType && filter.aggregateRules) {
           // Handle nested aggregate rules
           return evaluateTask(
@@ -428,9 +434,22 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     let unknownRuleTypes = [];
     let tasksEvaluated = 0;
 
+    // A project's own root task ("project header" row). Action-list
+    // perspectives display actions, not the project root, so OmniFocus hides
+    // these in the GUI; we must skip them to avoid spurious header rows.
+    function isProjectRootTask(task) {
+      const proj = task.containingProject;
+      return !!(
+        proj &&
+        proj.task &&
+        proj.task.id.primaryKey === task.id.primaryKey
+      );
+    }
+
     if (isCustomPerspective && perspectiveRules) {
       flattenedTasks.forEach((task) => {
         tasksEvaluated++;
+        if (isProjectRootTask(task)) return;
         if (evaluateTask(task, perspectiveRules, perspectiveAggregation)) {
           filteredTasks.push(getTaskDetails(task));
         }


### PR DESCRIPTION
## Problem

Custom perspectives that use **disabled rules** or contain **project groups** return incorrect items from `get_perspective_view`. In a real-world perspective with disabled rules inside `none` groups, the tool returned **1 item** when the OmniFocus GUI showed **15**.

## Root causes & fixes (both in `src/utils/omnifocusScripts/getPerspectiveView.js`)

### 1. Disabled rules break `none`/`any` aggregation
A `disabledRule` (a rule toggled off in the perspective editor) was coerced to `true` in `evaluateRule`. That is only safe inside an **`all`** group:

- In a **`none of the following`** group (passes only when *every* sub-result is `false`), a disabled rule returning `true` makes the whole group **permanently false**.
- In an **`any`** group it would produce **false positives**.

Real perspectives commonly nest disabled rules inside `none` groups, so entire branches silently matched nothing.

**Fix:** exclude disabled rules from aggregation entirely in `evaluateTask`, so they affect neither `all`/`any`/`none`. A group containing only disabled rules imposes no constraint.

> Note: this is a follow-up to the earlier `disabledRule` handling — that change correctly stopped disabled rules from rejecting tasks in `all` groups, but coercing to `true` regressed `none`/`any` groups.

### 2. Project header rows leak into action perspectives
A project's own root task was evaluated like an action and could match rules such as *"contained within folder"*, producing spurious project-header rows that the OmniFocus GUI hides in action-list perspectives.

**Fix:** skip project root tasks when evaluating custom perspectives.

## Verification

Tested against a real custom perspective on a ~3,000-task database: results went from **1 item → the 15 actions shown in the GUI** (plus one genuine inbox item), with project-header rows correctly excluded and no `unknownRuleTypes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)