### PR TITLE
Fix #63, #64, #65: project id, project tagging, and project tag read-back

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -3,7 +3,7 @@ import { _testExports as primitives } from '../primitives/queryOmnifocus.js';
 import { _testExports as definitions } from '../definitions/queryOmnifocus.js';
 
 const { escapeJXA, generateFilterConditions, generateFieldMapping } = primitives;
-const { formatTasks, formatFilters } = definitions;
+const { formatTasks, formatProjects, formatFolders, formatFilters } = definitions;
 
 // ============================================================
 // escapeJXA
@@ -174,6 +174,45 @@ describe('formatTasks - hierarchy fields display', () => {
     ]);
     expect(result).not.toContain('[parent');
     expect(result).not.toContain('[children');
+  });
+});
+
+// ============================================================
+// formatProjects - id display (regression: #63)
+// ============================================================
+describe('formatProjects - id display', () => {
+  it('shows the project id when present', () => {
+    const result = formatProjects([
+      { name: 'Sample Project', id: 'p1a2b3c', status: 'Active' },
+    ]);
+    expect(result).toContain('[p1a2b3c]');
+  });
+
+  it('does NOT show an id section when id is absent', () => {
+    const result = formatProjects([
+      { name: 'No ID Project', status: 'Active' },
+    ]);
+    expect(result).not.toContain('[undefined]');
+    expect(result).not.toMatch(/\[\]/);
+  });
+});
+
+// ============================================================
+// formatFolders - id display (regression: #63)
+// ============================================================
+describe('formatFolders - id display', () => {
+  it('shows the folder id when present', () => {
+    const result = formatFolders([
+      { name: 'Sample Folder', id: 'f9z8y7', projectCount: 2 },
+    ]);
+    expect(result).toContain('[f9z8y7]');
+  });
+
+  it('does NOT show an id section when id is absent', () => {
+    const result = formatFolders([
+      { name: 'No ID Folder', projectCount: 0 },
+    ]);
+    expect(result).not.toContain('[undefined]');
   });
 });
 

--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -195,6 +195,21 @@ describe('formatProjects - id display', () => {
     expect(result).not.toContain('[undefined]');
     expect(result).not.toMatch(/\[\]/);
   });
+
+  // Regression: #65 — project tags were never displayed even when present.
+  it('shows project tags when present', () => {
+    const result = formatProjects([
+      { name: 'Tagged Project', id: 'p1a2b3c', status: 'Active', tagNames: ['Work', 'Home'] },
+    ]);
+    expect(result).toContain('<Work,Home>');
+  });
+
+  it('does NOT show a tag section when there are no tags', () => {
+    const result = formatProjects([
+      { name: 'Untagged Project', id: 'p1a2b3c', status: 'Active', tagNames: [] },
+    ]);
+    expect(result).not.toContain('<');
+  });
 });
 
 // ============================================================
@@ -259,6 +274,14 @@ describe('generateFieldMapping - review fields', () => {
     const result = generateFieldMapping('projects');
     expect(result).toContain('nextReviewDate');
     expect(result).toContain('reviewInterval');
+  });
+
+  // Regression: #65 — default project mapping omitted tagNames, so queries
+  // without explicit fields returned undefined for project tags.
+  it('default project fields include tagNames', () => {
+    const result = generateFieldMapping('projects');
+    expect(result).toContain('tagNames');
+    expect(result).toContain('item.tags');
   });
 });
 

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -261,8 +261,9 @@ function formatProjects(projects: any[]): string {
     const reviewInterval = project.reviewInterval ? ` [review every: ${project.reviewInterval}]` : '';
 
     const id = project.id ? ` [${project.id}]` : '';
+    const tags = project.tagNames?.length > 0 ? ` <${project.tagNames.join(',')}>` : '';
 
-    let result = `P: ${flagged}${project.name}${id}${status}${due}${review}${reviewInterval}${folder}${taskCount}`;
+    let result = `P: ${flagged}${project.name}${id}${status}${due}${review}${reviewInterval}${folder}${taskCount}${tags}`;
 
     // Add note on a new line if present
     if (project.note) {

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -260,7 +260,9 @@ function formatProjects(projects: any[]): string {
     const review = project.nextReviewDate ? ` [review: ${formatDate(project.nextReviewDate)}]` : '';
     const reviewInterval = project.reviewInterval ? ` [review every: ${project.reviewInterval}]` : '';
 
-    let result = `P: ${flagged}${project.name}${status}${due}${review}${reviewInterval}${folder}${taskCount}`;
+    const id = project.id ? ` [${project.id}]` : '';
+
+    let result = `P: ${flagged}${project.name}${id}${status}${due}${review}${reviewInterval}${folder}${taskCount}`;
 
     // Add note on a new line if present
     if (project.note) {
@@ -273,10 +275,11 @@ function formatProjects(projects: any[]): string {
 
 function formatFolders(folders: any[]): string {
   return folders.map(folder => {
+    const id = folder.id ? ` [${folder.id}]` : '';
     const projectCount = folder.projectCount !== undefined ? ` (${folder.projectCount} projects)` : '';
     const path = folder.path ? ` 📍 ${folder.path}` : '';
-    
-    return `F: ${folder.name}${projectCount}${path}`;
+
+    return `F: ${folder.name}${id}${projectCount}${path}`;
   }).join('\n');
 }
 

--- a/src/tools/primitives/editItem.test.ts
+++ b/src/tools/primitives/editItem.test.ts
@@ -169,6 +169,38 @@ describe('editItem generateAppleScript', () => {
       expect(script).toContain('remove existingTag from tags of foundItem');
       expect(script).toContain('add tagObj to tags of foundItem');
     });
+
+    // Regression: #64 — addTags on a project was a silent no-op because tag
+    // handling was nested inside the task-only block.
+    it('generates tag add script for projects', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'Sample Project',
+        addTags: ['zzTestTag'],
+      });
+      expect(script).toContain('"zzTestTag"');
+      expect(script).toContain('add tagObj to tags of foundItem');
+    });
+
+    it('generates tag remove script for projects', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'Sample Project',
+        removeTags: ['old-tag'],
+      });
+      expect(script).toContain('"old-tag"');
+      expect(script).toContain('remove tagObj from tags of foundItem');
+    });
+
+    it('generates tag replace script for projects', () => {
+      const script = generateAppleScript({
+        itemType: 'project',
+        name: 'Sample Project',
+        replaceTags: ['new-tag'],
+      });
+      expect(script).toContain('"new-tag"');
+      expect(script).toContain('remove existingTag from tags of foundItem');
+    });
   });
 
   describe('item lookup', () => {

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -226,6 +226,75 @@ export function generateAppleScript(params: EditItemParams): string {
 `;
   }
   
+  // Tag operations apply to both tasks and projects (OmniFocus supports tags on
+  // projects too). Kept in the common section so project edits aren't a no-op.
+  if (params.replaceTags && params.replaceTags.length > 0) {
+    const tagsList = params.replaceTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
+    script += `
+        -- Replace all tags
+        set tagNames to {${tagsList}}
+        set existingTags to tags of foundItem
+
+        -- First clear all existing tags
+        repeat with existingTag in existingTags
+          remove existingTag from tags of foundItem
+        end repeat
+
+        -- Then add new tags
+        repeat with tagName in tagNames
+          set tagObj to missing value
+          try
+            set tagObj to first flattened tag where name = (tagName as string)
+          on error
+            -- Tag doesn't exist, create it
+            set tagObj to make new tag with properties {name:(tagName as string)}
+          end try
+          if tagObj is not missing value then
+            add tagObj to tags of foundItem
+          end if
+        end repeat
+        set end of changedProperties to "tags (replaced)"
+`;
+  } else {
+    // Add tags if specified
+    if (params.addTags && params.addTags.length > 0) {
+      const tagsList = params.addTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
+      script += `
+        -- Add tags
+        set tagNames to {${tagsList}}
+        repeat with tagName in tagNames
+          set tagObj to missing value
+          try
+            set tagObj to first flattened tag where name = (tagName as string)
+          on error
+            -- Tag doesn't exist, create it
+            set tagObj to make new tag with properties {name:(tagName as string)}
+          end try
+          if tagObj is not missing value then
+            add tagObj to tags of foundItem
+          end if
+        end repeat
+        set end of changedProperties to "tags (added)"
+`;
+    }
+
+    // Remove tags if specified
+    if (params.removeTags && params.removeTags.length > 0) {
+      const tagsList = params.removeTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
+      script += `
+        -- Remove tags
+        set tagNames to {${tagsList}}
+        repeat with tagName in tagNames
+          try
+            set tagObj to first flattened tag where name = (tagName as string)
+            remove tagObj from tags of foundItem
+          end try
+        end repeat
+        set end of changedProperties to "tags (removed)"
+`;
+    }
+  }
+
   // Task-specific updates
   if (itemType === 'task') {
     // Update task status
@@ -270,74 +339,6 @@ export function generateAppleScript(params: EditItemParams): string {
         -- Mark task as incomplete
         mark incomplete foundItem
         set end of changedProperties to "status (incomplete)"
-`;
-      }
-    }
-    
-    // Handle tag operations
-    if (params.replaceTags && params.replaceTags.length > 0) {
-      const tagsList = params.replaceTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
-      script += `
-        -- Replace all tags
-        set tagNames to {${tagsList}}
-        set existingTags to tags of foundItem
-        
-        -- First clear all existing tags
-        repeat with existingTag in existingTags
-          remove existingTag from tags of foundItem
-        end repeat
-        
-        -- Then add new tags
-        repeat with tagName in tagNames
-          set tagObj to missing value
-          try
-            set tagObj to first flattened tag where name = (tagName as string)
-          on error
-            -- Tag doesn't exist, create it
-            set tagObj to make new tag with properties {name:(tagName as string)}
-          end try
-          if tagObj is not missing value then
-            add tagObj to tags of foundItem
-          end if
-        end repeat
-        set end of changedProperties to "tags (replaced)"
-`;
-    } else {
-      // Add tags if specified
-      if (params.addTags && params.addTags.length > 0) {
-        const tagsList = params.addTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
-        script += `
-        -- Add tags
-        set tagNames to {${tagsList}}
-        repeat with tagName in tagNames
-          set tagObj to missing value
-          try
-            set tagObj to first flattened tag where name = (tagName as string)
-          on error
-            -- Tag doesn't exist, create it
-            set tagObj to make new tag with properties {name:(tagName as string)}
-          end try
-          if tagObj is not missing value then
-            add tagObj to tags of foundItem
-          end if
-        end repeat
-        set end of changedProperties to "tags (added)"
-`;
-      }
-      
-      // Remove tags if specified
-      if (params.removeTags && params.removeTags.length > 0) {
-        const tagsList = params.removeTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
-        script += `
-        -- Remove tags
-        set tagNames to {${tagsList}}
-        repeat with tagName in tagNames
-          try
-            set tagObj to first flattened tag where name = (tagName as string)
-            remove tagObj from tags of foundItem
-          end try
-        end repeat
-        set end of changedProperties to "tags (removed)"
 `;
       }
     }

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -524,6 +524,7 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
           status: projectStatusMap[item.status] || "Unknown",
           folderName: item.parentFolder ? item.parentFolder.name : null,
           taskCount: taskArray.length,
+          tagNames: item.tags ? item.tags.map(t => t.name) : [],
           flagged: item.flagged || false,
           dueDate: formatDate(item.dueDate),
           deferDate: formatDate(item.deferDate),


### PR DESCRIPTION
Three independent project-parity bugs, one commit each. Tasks already behaved correctly in all three cases; projects didn't.

## Fix #63 — `query_omnifocus` returns no id for projects/folders
The query primitive already returned correct ids, but the display layer dropped them: `formatTasks` rendered `[<id>]` while `formatProjects` and `formatFolders` never did. Render the id (when present) in both, mirroring `formatTasks`.

## Fix #64 — `edit_item` `addTags` on a project is a silent no-op
Tag handling (`addTags`/`removeTags`/`replaceTags`) was nested inside the `itemType === 'task'` branch, so a project edit emitted no tag AppleScript yet still returned success. Hoist tag handling into the common section so it runs for tasks and projects (verified OmniFocus accepts `add tagObj to tags of <project>`).

## Fix #65 — `query_omnifocus` drops project tags
Two gaps: the default project field mapping omitted `tagNames` (field-less queries returned `undefined`), and `formatProjects` never rendered tags even when present. Add `tagNames` to the default project mapping and render tags in `formatProjects`, mirroring the task behavior. The explicit-`fields` data path already worked and is unchanged.

## Testing
- `npm run build` clean; full suite green (164 tests), including new regression tests for each fix.
- Verified live against OmniFocus 4.8.11: project/folder ids render, tagging a project applies and persists, and project tags now read back in both default and explicit-field queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)