### PR TITLE
Fix project dropped/completed status to use mark verbs instead of set status

### DIFF
--- a/src/tools/primitives/editItem.test.ts
+++ b/src/tools/primitives/editItem.test.ts
@@ -244,7 +244,7 @@ describe('editItem generateAppleScript', () => {
       expect(script).toContain('set sequential of foundItem to true');
     });
 
-    it('generates project status update', () => {
+    it('generates project status update for onHold', () => {
       const script = generateAppleScript({
         itemType: 'project',
         name: 'P',

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -379,15 +379,26 @@ export function generateAppleScript(params: EditItemParams): string {
     // Update project status. OmniFocus rejects setting status to done/dropped
     // directly — those transitions require the mark complete/mark dropped verbs.
     if (params.newProjectStatus !== undefined) {
-      const statusAction = params.newProjectStatus === 'completed' ? 'mark complete foundItem' :
-                           params.newProjectStatus === 'dropped' ? 'mark dropped foundItem' :
-                           params.newProjectStatus === 'active' ? 'set status of foundItem to active status' :
-                           'set status of foundItem to on hold status';
-      script += `
-        -- Update project status
-        ${statusAction}
-        set end of changedProperties to "status"
+      if (params.newProjectStatus === 'dropped') {
+        script += `
+        -- Mark project as dropped (must use verb, not set status)
+        mark dropped foundItem
+        set end of changedProperties to "status (dropped)"
 `;
+      } else if (params.newProjectStatus === 'completed') {
+        script += `
+        -- Mark project as completed (must use verb, not set status)
+        mark complete foundItem
+        set end of changedProperties to "status (completed)"
+`;
+      } else {
+        const statusValue = params.newProjectStatus === 'active' ? 'active status' : 'on hold status';
+        script += `
+        -- Update project status
+        set status of foundItem to ${statusValue}
+        set end of changedProperties to "status (${params.newProjectStatus})"
+`;
+      }
     }
     
     // Mark project as reviewed


### PR DESCRIPTION
## Summary

OmniFocus rejects setting a project's status to `done` or `dropped` directly via `set status` — those transitions require the `mark complete` / `mark dropped` verbs. This refactors the project status update logic in `editItem.ts` to branch explicitly:

- `dropped` → `mark dropped foundItem`
- `completed` → `mark complete foundItem`
- `active` / `onHold` → `set status of foundItem to <value>`

Each branch now also records a more specific changed-property string (e.g. `status (dropped)`) so the result reflects the exact transition.

## Changes

- `src/tools/primitives/editItem.ts` — replace the single `statusAction` ternary with explicit branches for dropped/completed (verb-based) vs. active/onHold (set-based).
- `src/tools/primitives/editItem.test.ts` — rename the existing status test to `generates project status update for onHold` to reflect the case it covers.