### PR TITLE
Add droppedOn/droppedWithin filters and dropDate field to query tool

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -178,6 +178,74 @@ describe('formatTasks - hierarchy fields display', () => {
 });
 
 // ============================================================
+// generateFilterConditions - droppedOn / droppedWithin filters
+// ============================================================
+describe('generateFilterConditions - dropped date filters (tasks)', () => {
+  it('generates dropDate check for droppedOn', () => {
+    const result = generateFilterConditions('tasks', { droppedOn: 0 });
+    expect(result).toContain('checkSameDay(item.dropDate, 0)');
+  });
+
+  it('generates dropDate check for droppedOn with negative values', () => {
+    const result = generateFilterConditions('tasks', { droppedOn: -3 });
+    expect(result).toContain('checkSameDay(item.dropDate, -3)');
+  });
+
+  it('generates dropDate check for droppedWithin', () => {
+    const result = generateFilterConditions('tasks', { droppedWithin: 7 });
+    expect(result).toContain('item.dropDate');
+    expect(result).toContain('checkDateWithinPast(item.dropDate, 7)');
+  });
+
+  it('does NOT reference completionDate for dropped filters', () => {
+    const result = generateFilterConditions('tasks', { droppedOn: 0, droppedWithin: 7 });
+    expect(result).not.toContain('completionDate');
+  });
+});
+
+describe('generateFilterConditions - dropped date filters (projects)', () => {
+  it('generates dropDate check for droppedOn on projects', () => {
+    const result = generateFilterConditions('projects', { droppedOn: 0 });
+    expect(result).toContain('checkSameDay(item.dropDate, 0)');
+  });
+
+  it('generates dropDate check for droppedWithin on projects', () => {
+    const result = generateFilterConditions('projects', { droppedWithin: 14 });
+    expect(result).toContain('item.dropDate');
+    expect(result).toContain('checkDateWithinPast(item.dropDate, 14)');
+  });
+});
+
+// ============================================================
+// generateFieldMapping - dropDate field
+// ============================================================
+describe('generateFieldMapping - dropDate', () => {
+  it('includes dropDate mapping when requested (tasks)', () => {
+    const result = generateFieldMapping('tasks', ['dropDate']);
+    expect(result).toContain('dropDate');
+    expect(result).toContain('item.dropDate');
+    expect(result).toContain('formatDate');
+  });
+
+  it('includes effectiveDropDate mapping when requested', () => {
+    const result = generateFieldMapping('tasks', ['effectiveDropDate']);
+    expect(result).toContain('effectiveDropDate');
+    expect(result).toContain('item.effectiveDropDate');
+  });
+
+  it('returns null (not error) when dropDate is missing', () => {
+    const result = generateFieldMapping('tasks', ['dropDate']);
+    expect(result).toContain('item.dropDate ? formatDate(item.dropDate) : null');
+  });
+
+  it('includes dropDate mapping for projects', () => {
+    const result = generateFieldMapping('projects', ['dropDate']);
+    expect(result).toContain('dropDate');
+    expect(result).toContain('item.dropDate');
+  });
+});
+
+// ============================================================
 // generateFilterConditions - reviewDue filter (projects)
 // ============================================================
 describe('generateFilterConditions - reviewDue', () => {
@@ -273,5 +341,31 @@ describe('formatFilters', () => {
   it('displays reviewDue filter', () => {
     const result = formatFilters({ reviewDue: true });
     expect(result).toBe('review due: true');
+  });
+
+  it('displays droppedOn filter', () => {
+    const result = formatFilters({ droppedOn: 0 });
+    expect(result).toBe('dropped on day 0');
+  });
+
+  it('displays droppedWithin filter', () => {
+    const result = formatFilters({ droppedWithin: 7 });
+    expect(result).toBe('dropped within 7 days');
+  });
+});
+
+describe('formatTasks - dropDate display', () => {
+  it('shows dropDate when present', () => {
+    const result = formatTasks([
+      { name: 'Abandoned task', id: 't1', dropDate: '2026-04-20T12:00:00.000Z' },
+    ]);
+    expect(result).toContain('[dropped: 2026-04-20]');
+  });
+
+  it('does NOT show dropped section when dropDate is absent', () => {
+    const result = formatTasks([
+      { name: 'Plain task', id: 't1' },
+    ]);
+    expect(result).not.toContain('[dropped');
   });
 });

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -25,12 +25,14 @@ export const schema = z.object({
     addedWithin: z.number().optional().describe("Returns items added (created) within the last N days. Example: 7 = items added in the last week"),
     addedOn: z.number().optional().describe("Returns items added (created) on exactly this day. 0 = today, 1 = tomorrow, -1 = yesterday. Negative values look backward"),
     isRepeating: z.boolean().optional().describe("Filter by repeating status. true = only repeating tasks, false = only non-repeating tasks"),
-    completedWithin: z.number().optional().describe("Returns items completed or dropped within the last N days (uses completionDate which OmniFocus sets for both). Example: 7 = items completed in the last week. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true"),
-    completedOn: z.number().optional().describe("Returns items completed or dropped on exactly this day (uses completionDate which OmniFocus sets for both). 0 = today, -1 = yesterday. Negative values look backward. Combine with status: ['Dropped'] to find only dropped items. Note: use with includeCompleted: true"),
+    completedWithin: z.number().optional().describe("Returns items completed within the last N days (uses completionDate, which OmniFocus only sets for truly completed items, not dropped ones). Example: 7 = items completed in the last week. For dropped items, use droppedWithin. Note: use with includeCompleted: true"),
+    completedOn: z.number().optional().describe("Returns items completed on exactly this day (uses completionDate, which OmniFocus only sets for truly completed items, not dropped ones). 0 = today, -1 = yesterday. Negative values look backward. For dropped items, use droppedOn. Note: use with includeCompleted: true"),
+    droppedWithin: z.number().optional().describe("Returns items dropped within the last N days (uses dropDate). Example: 7 = items dropped in the last week. Typically combined with status: ['Dropped']. Note: use with includeCompleted: true"),
+    droppedOn: z.number().optional().describe("Returns items dropped on exactly this day (uses dropDate). 0 = today, -1 = yesterday. Negative values look backward. Typically combined with status: ['Dropped']. Note: use with includeCompleted: true"),
     reviewDue: z.boolean().optional().describe("Filter projects by review status. true = only projects whose next review date is today or in the past (due for review). false = only projects not yet due for review. Only applies to 'projects' entity")
   }).optional().describe("Optional filters to narrow results. ALL filters combine with AND logic (must match all). Within array filters (tags, status) OR logic applies"),
   
-  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completedByChildren, containsSingletonActions, taskCount, tasks, nextReviewDate, reviewInterval, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
+  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, dropDate, effectiveDropDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completionDate, dropDate, effectiveDropDate, completedByChildren, containsSingletonActions, taskCount, tasks, nextReviewDate, reviewInterval, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
   
   limit: z.number().optional().describe("Maximum number of items to return. Useful for large result sets. Default: no limit"),
   
@@ -159,6 +161,8 @@ function formatFilters(filters: any): string {
   if (filters.isRepeating !== undefined) parts.push(`repeating: ${filters.isRepeating}`);
   if (filters.completedWithin !== undefined) parts.push(`completed within ${filters.completedWithin} days`);
   if (filters.completedOn !== undefined) parts.push(`completed on day ${filters.completedOn}`);
+  if (filters.droppedWithin !== undefined) parts.push(`dropped within ${filters.droppedWithin} days`);
+  if (filters.droppedOn !== undefined) parts.push(`dropped on day ${filters.droppedOn}`);
   if (filters.reviewDue !== undefined) parts.push(`review due: ${filters.reviewDue}`);
   return parts.join(', ');
 }
@@ -237,6 +241,9 @@ function formatTasks(tasks: any[]): string {
     }
     if (task.completionDate) {
       parts.push(`[completed: ${formatDate(task.completionDate)}]`);
+    }
+    if (task.dropDate) {
+      parts.push(`[dropped: ${formatDate(task.dropDate)}]`);
     }
 
     let result = parts.join(' ');

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -33,6 +33,8 @@ export interface QueryOmnifocusParams {
     isRepeating?: boolean;
     completedWithin?: number;
     completedOn?: number;
+    droppedWithin?: number;
+    droppedOn?: number;
     reviewDue?: boolean;
   };
   fields?: string[];
@@ -381,6 +383,18 @@ function generateFilterConditions(entity: string, filters: any): string {
       conditions.push(`if (!checkSameDay(item.completionDate, ${filters.completedOn})) return false;`);
     }
 
+    if (filters.droppedWithin !== undefined) {
+      conditions.push(`
+        if (!item.dropDate || !checkDateWithinPast(item.dropDate, ${filters.droppedWithin})) {
+          return false;
+        }
+      `);
+    }
+
+    if (filters.droppedOn !== undefined) {
+      conditions.push(`if (!checkSameDay(item.dropDate, ${filters.droppedOn})) return false;`);
+    }
+
     if (filters.hasNote !== undefined) {
       conditions.push(`
         const hasNote = item.note && item.note.trim().length > 0;
@@ -439,6 +453,18 @@ function generateFilterConditions(entity: string, filters: any): string {
 
     if (filters.completedOn !== undefined) {
       conditions.push(`if (!checkSameDay(item.completionDate, ${filters.completedOn})) return false;`);
+    }
+
+    if (filters.droppedWithin !== undefined) {
+      conditions.push(`
+        if (!item.dropDate || !checkDateWithinPast(item.dropDate, ${filters.droppedWithin})) {
+          return false;
+        }
+      `);
+    }
+
+    if (filters.droppedOn !== undefined) {
+      conditions.push(`if (!checkSameDay(item.dropDate, ${filters.droppedOn})) return false;`);
     }
 
     if (filters.reviewDue !== undefined) {
@@ -560,6 +586,10 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
       return `creationDate: formatDate(item.added)`;
     } else if (field === 'completionDate') {
       return `completionDate: item.completionDate ? formatDate(item.completionDate) : null`;
+    } else if (field === 'dropDate') {
+      return `dropDate: item.dropDate ? formatDate(item.dropDate) : null`;
+    } else if (field === 'effectiveDropDate') {
+      return `effectiveDropDate: item.effectiveDropDate ? formatDate(item.effectiveDropDate) : null`;
     } else if (field === 'dueDate') {
       return `dueDate: formatDate(item.dueDate)`;
     } else if (field === 'deferDate') {


### PR DESCRIPTION
## Summary

OmniFocus only sets `completionDate` for truly *completed* items — dropped tasks and projects use a separate `dropDate` field. The existing `completedOn`/`completedWithin` filters claimed to cover both but silently returned zero results for dropped items, because `completionDate` is null on a dropped item.

This adds parallel `droppedOn`/`droppedWithin` filters (for both tasks and projects) backed by `dropDate`, and exposes `dropDate`/`effectiveDropDate` as returnable fields. It also corrects the misleading `completedOn`/`completedWithin` docstrings to reflect that they only match completed items, pointing users to the new dropped filters instead.

## Changes

- `src/tools/definitions/queryOmnifocus.ts` — add `droppedWithin`/`droppedOn` filter params, add `dropDate`/`effectiveDropDate` to the documented returnable fields, fix the `completedOn`/`completedWithin` docstrings, and render a `[dropped: …]` segment in task output.
- `src/tools/primitives/queryOmnifocus.ts` — add the `droppedWithin`/`droppedOn` filter conditions (using `dropDate`) for tasks and projects, and add `dropDate`/`effectiveDropDate` field mappings.
- `src/tools/__tests__/queryOmnifocus.test.ts` — cover the new dropped-date filters, field mappings, filter-summary formatting, and `[dropped: …]` task display.