### PR TITLE
Fix query_omnifocus projects: honor projectId/projectName and return sequential

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -354,6 +354,125 @@ describe('generateFieldMapping - review fields', () => {
 });
 
 // ============================================================
+// generateFilterConditions - projectId filter (projects entity)
+// ============================================================
+describe('generateFilterConditions - projectId (projects)', () => {
+  it('narrows projects by their own id when projectId is set', () => {
+    const result = generateFilterConditions('projects', { projectId: 'kBqqJE3sKPU' });
+    // Must compare the project's OWN primary key, not a containing project.
+    expect(result).toContain('item.id.primaryKey');
+    expect(result).toContain('kBqqJE3sKPU');
+    expect(result).toContain('return false');
+  });
+
+  it('escapes projectId with quotes for projects entity', () => {
+    const result = generateFilterConditions('projects', { projectId: 'id"bad' });
+    expect(result).toContain('id\\"bad');
+  });
+
+  it('still filters tasks by containing project id', () => {
+    const result = generateFilterConditions('tasks', { projectId: 'kBqqJE3sKPU' });
+    expect(result).toContain('item.containingProject');
+    expect(result).toContain('kBqqJE3sKPU');
+  });
+});
+
+// ============================================================
+// generateFilterConditions - projectName filter (projects entity)
+// ============================================================
+describe('generateFilterConditions - projectName (projects)', () => {
+  it('narrows projects by their own name when projectName is set', () => {
+    const result = generateFilterConditions('projects', { projectName: 'Review' });
+    // Must match the project's OWN name (case-insensitive partial), not a containing project.
+    expect(result).toContain('item.name.toLowerCase()');
+    expect(result).toContain('.includes("review")');
+    expect(result).toContain('return false');
+  });
+
+  it('does not reference containingProject for projects entity', () => {
+    const result = generateFilterConditions('projects', { projectName: 'Review' });
+    expect(result).not.toContain('containingProject');
+  });
+
+  it('escapes projectName with quotes for projects entity', () => {
+    const result = generateFilterConditions('projects', { projectName: 'a"b' });
+    expect(result).toContain('a\\"b');
+  });
+
+  it('still filters tasks by containing project name', () => {
+    const result = generateFilterConditions('tasks', { projectName: 'devices' });
+    expect(result).toContain('item.containingProject');
+    expect(result).toContain('devices');
+  });
+});
+
+// ============================================================
+// generateFieldMapping - sequential field
+// ============================================================
+describe('generateFieldMapping - sequential field', () => {
+  it('includes sequential mapping for projects when requested', () => {
+    const result = generateFieldMapping('projects', ['id', 'name', 'sequential']);
+    expect(result).toContain('sequential:');
+    expect(result).toContain('item.sequential');
+    // Coerced to a real boolean so undefined never leaks through.
+    expect(result).toContain('Boolean(item.sequential)');
+  });
+
+  it('includes sequential mapping for tasks when requested', () => {
+    const result = generateFieldMapping('tasks', ['id', 'name', 'sequential']);
+    expect(result).toContain('sequential:');
+    expect(result).toContain('Boolean(item.sequential)');
+  });
+});
+
+// ============================================================
+// formatProjects - sequential display
+// ============================================================
+describe('formatProjects - sequential display', () => {
+  it('shows [sequential] when sequential is true', () => {
+    const result = formatProjects([
+      { name: 'Seq Project', status: 'Active', sequential: true },
+    ]);
+    expect(result).toContain('[sequential]');
+  });
+
+  it('shows [parallel] when sequential is false', () => {
+    const result = formatProjects([
+      { name: 'Par Project', status: 'Active', sequential: false },
+    ]);
+    expect(result).toContain('[parallel]');
+  });
+
+  it('omits sequencing marker when sequential is absent', () => {
+    const result = formatProjects([
+      { name: 'Plain Project', status: 'Active' },
+    ]);
+    expect(result).not.toContain('[sequential]');
+    expect(result).not.toContain('[parallel]');
+  });
+});
+
+// ============================================================
+// formatTasks - sequential display
+// ============================================================
+describe('formatTasks - sequential display', () => {
+  it('shows [sequential] for an action group that is sequential', () => {
+    const result = formatTasks([
+      { name: 'Seq Group', id: 'g1', hasChildren: true, childIds: ['c1'], sequential: true },
+    ]);
+    expect(result).toContain('[sequential]');
+  });
+
+  it('does NOT show sequencing marker for a leaf task without children', () => {
+    const result = formatTasks([
+      { name: 'Leaf', id: 'l1', hasChildren: false, sequential: false },
+    ]);
+    expect(result).not.toContain('[sequential]');
+    expect(result).not.toContain('[parallel]');
+  });
+});
+
+// ============================================================
 // formatFilters - taskName display
 // ============================================================
 describe('formatFilters', () => {

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -232,6 +232,11 @@ function formatTasks(tasks: any[]): string {
       parts.push(`[children: ${task.childIds.join(', ')}]`);
     }
 
+    // Sequencing only matters for action groups (tasks with children).
+    if (task.sequential !== undefined && task.hasChildren) {
+      parts.push(task.sequential ? '[sequential]' : '[parallel]');
+    }
+
     // Metadata dates if requested
     if (task.creationDate) {
       parts.push(`[created: ${formatDate(task.creationDate)}]`);
@@ -266,11 +271,14 @@ function formatProjects(projects: any[]): string {
     const due = project.dueDate ? ` [due: ${formatDate(project.dueDate)}]` : '';
     const review = project.nextReviewDate ? ` [review: ${formatDate(project.nextReviewDate)}]` : '';
     const reviewInterval = project.reviewInterval ? ` [review every: ${project.reviewInterval}]` : '';
+    const sequencing = project.sequential !== undefined
+      ? (project.sequential ? ' [sequential]' : ' [parallel]')
+      : '';
 
     const id = project.id ? ` [${project.id}]` : '';
     const tags = project.tagNames?.length > 0 ? ` <${project.tagNames.join(',')}>` : '';
 
-    let result = `P: ${flagged}${project.name}${id}${status}${due}${review}${reviewInterval}${folder}${taskCount}${tags}`;
+    let result = `P: ${flagged}${project.name}${id}${status}${due}${review}${reviewInterval}${sequencing}${folder}${taskCount}${tags}`;
 
     // Add note on a new line if present
     if (project.note) {

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -424,6 +424,24 @@ function generateFilterConditions(entity: string, filters: any): string {
   }
   
   if (entity === 'projects') {
+    if (filters.projectId) {
+      const safeId = escapeJXA(filters.projectId);
+      conditions.push(`
+        if (item.id.primaryKey !== "${safeId}") {
+          return false;
+        }
+      `);
+    }
+
+    if (filters.projectName) {
+      const safeName = escapeJXA(filters.projectName.toLowerCase());
+      conditions.push(`
+        if (!item.name.toLowerCase().includes("${safeName}")) {
+          return false;
+        }
+      `);
+    }
+
     if (filters.folderId) {
       conditions.push(`
         {
@@ -649,6 +667,10 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
       return `isRepeating: item.repetitionRule !== null`;
     } else if (field === 'repetitionRule') {
       return `repetitionRule: item.repetitionRule ? item.repetitionRule.toString() : null`;
+    } else if (field === 'sequential') {
+      // Both Task and Project expose a `sequential` Boolean in OmniJS. Coerce so an
+      // unexpected null/undefined surfaces as false rather than leaking through.
+      return `sequential: Boolean(item.sequential)`;
     } else if (field === 'estimatedMinutes') {
       return `estimatedMinutes: item.estimatedMinutes || null`;
     } else if (field === 'nextReviewDate') {


### PR DESCRIPTION
## Summary

`query_omnifocus` had three bugs around projects:

- The `sequential` field was never returned — callers saw it as `undefined`/absent on both projects and tasks, even though the value exists in OmniFocus.
- The `projectId` filter was ignored for `entity: "projects"` — passing it returned every project instead of the one.
- The `projectName` filter was ignored for `entity: "projects"` — same class of bug as `projectId`, returning every project instead of matching ones.

These block routing logic that needs to distinguish sequential vs. parallel projects and fetch projects cheaply by id or name.

## Root cause

**`sequential` (two layers):** In `generateFieldMapping`, `sequential` had no explicit case and fell through to the generic default branch. More importantly, the human-readable formatters (`formatProjects`/`formatTasks`) — which produce the text the tool actually returns — never rendered it, so any projected value was dropped before reaching the caller.

**`projectId`/`projectName` on projects:** `generateFilterConditions` only handled these filters in the `entity === 'tasks'` branch (matching `containingProject`). The `projects` branch had no case for either, so both filters were silently discarded.

## Changes

- `primitives/queryOmnifocus.ts`: explicit `sequential: Boolean(item.sequential)` projection (tasks and projects); new `projects` filter cases matching the project's own `id.primaryKey` and its own name (case-insensitive partial match), both with `escapeJXA` injection safety.
- `definitions/queryOmnifocus.ts`: render ` [sequential]`/` [parallel]` for projects, and for tasks only on action groups (tasks with children).
- `__tests__/queryOmnifocus.test.ts`: new tests covering the projection, the projects `projectId` and `projectName` filters, and formatter display.

## Verification

Full suite green (213/213). Verified live against OmniFocus (127 projects): `sequential` now reports `true`/`false` instead of `undefined`; `projectId` narrows to a single project; `projectName` narrows correctly — a nonexistent name returns 0 (previously all 127), a real partial token returns the matching project(s), and matching is case-insensitive.