### PR TITLE
Single-source server version and consolidate AppleScript escaping

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SetLevelRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -21,9 +22,17 @@ import * as getPerspectiveViewTool from './tools/definitions/getPerspectiveView.
 import * as listTagsTool from './tools/definitions/listTags.js';
 import * as createTagTool from './tools/definitions/createTag.js';
 
+// Single-source the version from package.json — the hardcoded string here
+// drifted out of sync with the published version more than once.
+// Works from both src/ (tsx) and dist/ (build): each is one level below the
+// package root.
+const { version } = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8")
+);
+
 // Create an MCP server with instructions
 const server = new McpServer(
-  { name: "OmniFocus MCP", version: "1.9.0" },
+  { name: "OmniFocus MCP", version },
   {
     instructions: `OmniFocus MCP server for macOS task management.
 

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -4,6 +4,7 @@ import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { createDateOutsideTellBlock } from '../../utils/dateFormatting.js';
+import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
 const execAsync = promisify(exec);
 
 // Interface for task creation parameters
@@ -28,19 +29,17 @@ export interface AddOmniFocusTaskParams {
  */
 export function generateAppleScript(params: AddOmniFocusTaskParams): string {
   // Sanitize and prepare parameters for AppleScript
-  const name = params.name.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '); // Escape quotes and backslashes
-  const note = params.note
-    ?.replace(/["\\]/g, '\\$&')
-    .replace(/\r\n|\r|\n/g, '" & linefeed & "') || '';
+  const name = escapeAppleScriptString(params.name);
+  const note = params.note ? escapeAppleScriptString(params.note, { preserveNewlines: true }) : '';
   const dueDate = params.dueDate || '';
   const deferDate = params.deferDate || '';
   const plannedDate = params.plannedDate || '';
   const flagged = params.flagged === true;
   const estimatedMinutes = params.estimatedMinutes?.toString() || '';
   const tags = params.tags || [];
-  const projectName = params.projectName?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
-  const parentTaskId = params.parentTaskId?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
-  const parentTaskName = params.parentTaskName?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
+  const projectName = params.projectName ? escapeAppleScriptString(params.projectName) : '';
+  const parentTaskId = params.parentTaskId ? escapeAppleScriptString(params.parentTaskId) : '';
+  const parentTaskName = params.parentTaskName ? escapeAppleScriptString(params.parentTaskName) : '';
 
   // Generate date constructions outside tell blocks
   let datePreScript = '';
@@ -184,7 +183,7 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
         
         -- Add tags if provided
         ${tags.length > 0 ? tags.map(tag => {
-          const sanitizedTag = tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
+          const sanitizedTag = escapeAppleScriptString(tag);
           return `
           try
             set theTag to first flattened tag where name = "${sanitizedTag}"

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -4,7 +4,7 @@ import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { createDateOutsideTellBlock } from '../../utils/dateFormatting.js';
-import { generateFolderLookupScript } from '../../utils/appleScriptHelpers.js';
+import { generateFolderLookupScript, escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
 const execAsync = promisify(exec);
 
 // Interface for project creation parameters
@@ -25,10 +25,8 @@ export interface AddProjectParams {
  */
 export function generateAppleScript(params: AddProjectParams): string {
   // Sanitize and prepare parameters for AppleScript
-  const name = params.name.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '); // Escape quotes and backslashes
-  const note = params.note
-    ?.replace(/["\\]/g, '\\$&')
-    .replace(/\r\n|\r|\n/g, '" & linefeed & "') || '';
+  const name = escapeAppleScriptString(params.name);
+  const note = params.note ? escapeAppleScriptString(params.note, { preserveNewlines: true }) : '';
   const dueDate = params.dueDate || '';
   const deferDate = params.deferDate || '';
   const flagged = params.flagged === true;
@@ -54,7 +52,7 @@ export function generateAppleScript(params: AddProjectParams): string {
   // Build project creation block — either at root or in a folder
   let projectCreationBlock: string;
   if (params.folderName) {
-    const escapedFolderName = params.folderName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
+    const escapedFolderName = escapeAppleScriptString(params.folderName);
     const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${escapedFolderName}\\\"}`;
     const folderLookup = generateFolderLookupScript(params.folderName, 'theFolder', errorJson);
     projectCreationBlock = `
@@ -91,7 +89,7 @@ export function generateAppleScript(params: AddProjectParams): string {
 
         -- Add tags if provided
         ${tags.length > 0 ? tags.map(tag => {
-          const sanitizedTag = tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
+          const sanitizedTag = escapeAppleScriptString(tag);
           return `
           try
             set theTag to first flattened tag where name = "${sanitizedTag}"

--- a/src/tools/primitives/createTag.ts
+++ b/src/tools/primitives/createTag.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
 const execAsync = promisify(exec);
 
 export interface CreateTagParams {
@@ -11,22 +12,18 @@ export interface CreateTagParams {
   parentTagID?: string;   // ID of an existing tag to nest the new tag under (takes precedence over parentTagName)
 }
 
-function escape(value: string): string {
-  return value.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
-}
-
 /**
  * Generate pure AppleScript for tag creation
  */
 export function generateAppleScript(params: CreateTagParams): string {
-  const name = escape(params.name);
+  const name = escapeAppleScriptString(params.name);
 
   // Resolve the parent tag (by id or name) when nesting is requested.
   let parentLookup = '';
   let creationTarget = 'make new tag with properties {name:"' + name + '"}';
 
   if (params.parentTagID) {
-    const parentId = escape(params.parentTagID);
+    const parentId = escapeAppleScriptString(params.parentTagID);
     const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Parent tag not found: ${parentId}\\\"}`;
     parentLookup = `
         set parentTag to missing value
@@ -38,7 +35,7 @@ export function generateAppleScript(params: CreateTagParams): string {
         end if`;
     creationTarget = 'make new tag with properties {name:"' + name + '"} at end of tags of parentTag';
   } else if (params.parentTagName) {
-    const parentName = escape(params.parentTagName);
+    const parentName = escapeAppleScriptString(params.parentTagName);
     const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Parent tag not found: ${parentName}\\\"}`;
     parentLookup = `
         set parentTag to missing value

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -4,7 +4,7 @@ import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { generateDateAssignmentV2 } from '../../utils/dateFormatting.js';
-import { generateFolderLookupScript, generateProjectLookupScript } from '../../utils/appleScriptHelpers.js';
+import { generateFolderLookupScript, generateProjectLookupScript, escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
 const execAsync = promisify(exec);
 
 // Status options for tasks and projects
@@ -45,8 +45,8 @@ export interface EditItemParams {
  */
 export function generateAppleScript(params: EditItemParams): string {
   // Sanitize and prepare parameters for AppleScript
-  const id = params.id?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || ''; // Escape quotes and backslashes
-  const name = params.name?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
+  const id = params.id ? escapeAppleScriptString(params.id) : '';
+  const name = params.name ? escapeAppleScriptString(params.name) : '';
   const itemType = params.itemType;
   
   // Verify we have at least one identifier
@@ -172,7 +172,7 @@ export function generateAppleScript(params: EditItemParams): string {
   if (params.newName !== undefined) {
     script += `
         -- Update name
-        set name of foundItem to "${params.newName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"
+        set name of foundItem to "${escapeAppleScriptString(params.newName)}"
         set end of changedProperties to "name"
 `;
   }
@@ -180,7 +180,7 @@ export function generateAppleScript(params: EditItemParams): string {
   if (params.newNote !== undefined) {
     script += `
         -- Update note
-        set note of foundItem to "${params.newNote.replace(/["\\]/g, '\\$&').replace(/\r\n|\r|\n/g, '" & linefeed & "')}"
+        set note of foundItem to "${escapeAppleScriptString(params.newNote, { preserveNewlines: true })}"
         set end of changedProperties to "note"
 `;
   }
@@ -229,7 +229,7 @@ export function generateAppleScript(params: EditItemParams): string {
   // Tag operations apply to both tasks and projects (OmniFocus supports tags on
   // projects too). Kept in the common section so project edits aren't a no-op.
   if (params.replaceTags && params.replaceTags.length > 0) {
-    const tagsList = params.replaceTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
+    const tagsList = params.replaceTags.map(tag => `"${escapeAppleScriptString(tag)}"`).join(", ");
     script += `
         -- Replace all tags
         set tagNames to {${tagsList}}
@@ -258,7 +258,7 @@ export function generateAppleScript(params: EditItemParams): string {
   } else {
     // Add tags if specified
     if (params.addTags && params.addTags.length > 0) {
-      const tagsList = params.addTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
+      const tagsList = params.addTags.map(tag => `"${escapeAppleScriptString(tag)}"`).join(", ");
       script += `
         -- Add tags
         set tagNames to {${tagsList}}
@@ -280,7 +280,7 @@ export function generateAppleScript(params: EditItemParams): string {
 
     // Remove tags if specified
     if (params.removeTags && params.removeTags.length > 0) {
-      const tagsList = params.removeTags.map(tag => `"${tag.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ')}"`).join(", ");
+      const tagsList = params.removeTags.map(tag => `"${escapeAppleScriptString(tag)}"`).join(", ");
       script += `
         -- Remove tags
         set tagNames to {${tagsList}}
@@ -352,7 +352,7 @@ export function generateAppleScript(params: EditItemParams): string {
         set end of changedProperties to "project (moved to inbox)"
 `;
       } else {
-        const escapedProjectPath = params.newProjectName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
+        const escapedProjectPath = escapeAppleScriptString(params.newProjectName);
         const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${escapedProjectPath}\\\"}`;
         const projectLookup = generateProjectLookupScript(params.newProjectName, 'destProject', errorJson);
         script += `
@@ -414,7 +414,7 @@ export function generateAppleScript(params: EditItemParams): string {
 
     // Move to a new folder (supports nested paths like "Work/Engineering")
     if (params.newFolderName !== undefined && params.newFolderName !== '') {
-      const escapedFolderName = params.newFolderName.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ');
+      const escapedFolderName = escapeAppleScriptString(params.newFolderName);
       const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${escapedFolderName}\\\"}`;
       const folderLookup = generateFolderLookupScript(params.newFolderName, 'destFolder', errorJson);
       script += `

--- a/src/tools/primitives/removeItem.ts
+++ b/src/tools/primitives/removeItem.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
 const execAsync = promisify(exec);
 
 // Interface for item removal parameters
@@ -17,8 +18,8 @@ export interface RemoveItemParams {
  */
 export function generateAppleScript(params: RemoveItemParams): string {
   // Sanitize and prepare parameters for AppleScript
-  const id = params.id?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || ''; // Escape quotes and backslashes
-  const name = params.name?.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' ') || '';
+  const id = params.id ? escapeAppleScriptString(params.id) : '';
+  const name = params.name ? escapeAppleScriptString(params.name) : '';
   const itemType = params.itemType;
 
   // Verify we have at least one identifier

--- a/src/utils/__tests__/appleScriptHelpers.test.ts
+++ b/src/utils/__tests__/appleScriptHelpers.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { escapeAppleScriptString } from '../appleScriptHelpers.js';
+
+describe('escapeAppleScriptString', () => {
+  it('passes plain strings through unchanged', () => {
+    expect(escapeAppleScriptString('Buy milk')).toBe('Buy milk');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeAppleScriptString('say "hello"')).toBe('say \\"hello\\"');
+  });
+
+  it('escapes backslashes', () => {
+    expect(escapeAppleScriptString('C:\\path')).toBe('C:\\\\path');
+  });
+
+  it('escapes backslash-quote sequences without double-processing', () => {
+    expect(escapeAppleScriptString('a\\"b')).toBe('a\\\\\\"b');
+  });
+
+  it('flattens newlines to spaces by default', () => {
+    expect(escapeAppleScriptString('line1\nline2\rline3\r\nline4')).toBe(
+      'line1 line2 line3  line4'
+    );
+  });
+
+  it('preserves newlines as linefeed splices when requested', () => {
+    expect(escapeAppleScriptString('line1\nline2', { preserveNewlines: true })).toBe(
+      'line1" & linefeed & "line2'
+    );
+  });
+
+  it('treats \\r\\n as a single linefeed splice', () => {
+    expect(escapeAppleScriptString('a\r\nb', { preserveNewlines: true })).toBe(
+      'a" & linefeed & "b'
+    );
+  });
+
+  it('escapes quotes before splicing linefeeds so splices stay intact', () => {
+    expect(escapeAppleScriptString('say "hi"\nbye', { preserveNewlines: true })).toBe(
+      'say \\"hi\\"" & linefeed & "bye'
+    );
+  });
+
+  it('handles empty strings', () => {
+    expect(escapeAppleScriptString('')).toBe('');
+  });
+});

--- a/src/utils/appleScriptHelpers.ts
+++ b/src/utils/appleScriptHelpers.ts
@@ -3,6 +3,23 @@
  */
 
 /**
+ * Escape a value for interpolation inside a double-quoted AppleScript string
+ * literal. Quotes and backslashes are escaped first, then newlines are either
+ * flattened to spaces (default) or preserved via `" & linefeed & "` splices
+ * (for multi-line content like notes). The escape order matters: escaping
+ * quotes/backslashes after splicing in linefeed would corrupt the splice.
+ */
+export function escapeAppleScriptString(
+  value: string,
+  options?: { preserveNewlines?: boolean }
+): string {
+  const escaped = value.replace(/["\\]/g, '\\$&');
+  return options?.preserveNewlines
+    ? escaped.replace(/\r\n|\r|\n/g, '" & linefeed & "')
+    : escaped.replace(/[\r\n]/g, ' ');
+}
+
+/**
  * Generate AppleScript that resolves a folder by path (e.g. "Work/Engineering")
  * or by simple name (e.g. "Work"). Sets `varName` to the found folder object,
  * or returns `errorReturnJson` if not found.
@@ -19,7 +36,7 @@ export function generateFolderLookupScript(
     return `set ${varName} to missing value`;
   }
 
-  const escaped = components.map(c => c.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '));
+  const escaped = components.map(c => escapeAppleScriptString(c));
   const leafName = escaped[escaped.length - 1];
 
   if (components.length === 1) {
@@ -85,7 +102,7 @@ export function generateProjectLookupScript(
     return `set ${varName} to missing value`;
   }
 
-  const escaped = components.map(c => c.replace(/["\\]/g, '\\$&').replace(/[\r\n]/g, ' '));
+  const escaped = components.map(c => escapeAppleScriptString(c));
   const projectName = escaped[escaped.length - 1];
 
   if (components.length === 1) {


### PR DESCRIPTION
## Summary
- Read the MCP server version from package.json at runtime instead of a hardcoded string in server.ts — that string drifted out of sync twice (it was at 1.6.1 when npm was at 1.8.0). Works from both `src/` (tsx) and `dist/` (build), since each sits one level below the package root.
- Add a shared `escapeAppleScriptString(value, { preserveNewlines })` helper in `src/utils/appleScriptHelpers.ts` and replace the ~20 copy-pasted `.replace(/["\\]/g, '\\$&')...` chains across `addOmniFocusTask`, `addProject`, `editItem`, `removeItem`, and `createTag`. The `preserveNewlines` option covers the note-content variant that splices `" & linefeed & "`. Escape order (quotes/backslashes before newline handling) is preserved and now documented in one place.
- No behavior change intended; the helper output is character-identical to the old chains.

Intentionally untouched: `queryOmnifocus.ts` escapes for JXA/JS string context (different rules), and `scriptExecution.ts` escapes for shell/template context.

## Test plan
- [x] 9 new unit tests for the helper (quotes, backslashes, mixed sequences, newline flattening vs. linefeed splices, escape-order invariant)
- [x] Full unit suite: 199 passed
- [x] `tsc --noEmit` clean
- [x] Live integration suite against OmniFocus: 14/14 passed
- [x] Built `dist/server.js` and verified over MCP stdio that `serverInfo.version` reports `1.9.0` from package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)