### PR TITLE
Add GitHub Actions CI: typecheck, unit tests, build on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running on every PR and on pushes to `main`: `npm ci` → `tsc --noEmit` → `npm test` (199 unit tests) → `npm run build`, on Node 20 and 22.
- Unit config already excludes `src/tests/integration/**`, so the suite is safe on Linux runners; integration tests stay local-only (need live OmniFocus on macOS).
- The build step would have caught the recent `bin`-path regression class earlier than publish time.

Closes #72

## Test plan
- [ ] CI runs green on this PR itself (the workflow triggers on `pull_request`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)