### PR TITLE
Limit published package to dist and cli.cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "bin": {
     "omnifocus-mcp": "cli.cjs"
   },
+  "files": [
+    "dist",
+    "cli.cjs"
+  ],
   "scripts": {
     "build": "tsc && npm run copy-files && chmod 755 dist/server.js",
     "copy-files": "mkdir -p dist/utils/omnifocusScripts && cp src/utils/omnifocusScripts/*.js dist/utils/omnifocusScripts/",


### PR DESCRIPTION
## Summary
- Adds a `files` field (`["dist", "cli.cjs"]`) to package.json. Without it, npm fell back to .gitignore-based exclusion and shipped `src/`, `assets/` screenshots, and other dev files: **2.1 MB / 117 files**. With it: **54.1 kB packed / 245.9 kB unpacked / 49 files** (~97% smaller).
- README.md and package.json are auto-included by npm; package.json in the tarball is required by the new runtime version read from #74 and is present.
- `prepublishOnly` already runs the build, so `dist/` (including the copied `omnifocusScripts/*.js`) is always fresh at publish time.

Closes #73

## Test plan
- [x] `npm pack --dry-run`: verified `cli.cjs` (bin target), `dist/server.js`, `dist/utils/omnifocusScripts/*.js`, README.md, and package.json are all in the tarball
- [x] No `src/` or `assets/` files in the listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)