### PR TITLE
Fix #77: project ids now usable across query and edit/remove tools

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -365,6 +365,12 @@ describe('generateFilterConditions - projectId (projects)', () => {
     expect(result).toContain('return false');
   });
 
+  it('accepts both AppleScript (root task) and OmniJS project ids (issue #77)', () => {
+    const result = generateFilterConditions('projects', { projectId: 'kBqqJE3sKPU' });
+    expect(result).toContain('item.task.id.primaryKey !== "kBqqJE3sKPU"');
+    expect(result).toContain('item.id.primaryKey !== "kBqqJE3sKPU"');
+  });
+
   it('escapes projectId with quotes for projects entity', () => {
     const result = generateFilterConditions('projects', { projectId: 'id"bad' });
     expect(result).toContain('id\\"bad');
@@ -374,6 +380,49 @@ describe('generateFilterConditions - projectId (projects)', () => {
     const result = generateFilterConditions('tasks', { projectId: 'kBqqJE3sKPU' });
     expect(result).toContain('item.containingProject');
     expect(result).toContain('kBqqJE3sKPU');
+  });
+
+  it('task filter accepts both id namespaces for the containing project (issue #77)', () => {
+    const result = generateFilterConditions('tasks', { projectId: 'kBqqJE3sKPU' });
+    expect(result).toContain('item.containingProject.task.id.primaryKey !== "kBqqJE3sKPU"');
+    expect(result).toContain('item.containingProject.id.primaryKey !== "kBqqJE3sKPU"');
+  });
+});
+
+// ============================================================
+// generateFieldMapping - project ids use AppleScript namespace (issue #77)
+// ============================================================
+describe('generateFieldMapping - project id namespace', () => {
+  it('default project fields emit the root task id', () => {
+    const result = generateFieldMapping('projects');
+    expect(result).toContain('id: item.task.id.primaryKey');
+    expect(result).not.toContain('id: item.id.primaryKey');
+  });
+
+  it('explicit id field for projects emits the root task id', () => {
+    const result = generateFieldMapping('projects', ['id']);
+    expect(result).toContain('id: item.task.id.primaryKey');
+  });
+
+  it('explicit id field for tasks is unchanged', () => {
+    const result = generateFieldMapping('tasks', ['id']);
+    expect(result).toContain('id: item.id.primaryKey');
+    expect(result).not.toContain('item.task.id.primaryKey');
+  });
+
+  it('explicit id field for folders is unchanged', () => {
+    const result = generateFieldMapping('folders', ['id']);
+    expect(result).toContain('id: item.id.primaryKey');
+  });
+
+  it('projectId field on tasks emits the containing project root task id', () => {
+    const result = generateFieldMapping('tasks', ['projectId']);
+    expect(result).toContain('item.containingProject.task.id.primaryKey');
+  });
+
+  it('projects field on folders emits root task ids', () => {
+    const result = generateFieldMapping('folders', ['projects']);
+    expect(result).toContain('item.projects.map(p => p.task.id.primaryKey)');
   });
 });
 

--- a/src/tools/dumpDatabaseOptimized.ts
+++ b/src/tools/dumpDatabaseOptimized.ts
@@ -183,7 +183,7 @@ export async function getChangesSince(since: Date): Promise<{
         const newProjects = allProjects.filter(project =>
           project.creationDate && project.creationDate > sinceDate
         ).map(project => ({
-          id: project.id.primaryKey,
+          id: project.task.id.primaryKey,
           name: project.name,
           creationDate: project.creationDate.toISOString()
         }));
@@ -194,7 +194,7 @@ export async function getChangesSince(since: Date): Promise<{
           project.creationDate &&
           project.creationDate <= sinceDate
         ).map(project => ({
-          id: project.id.primaryKey,
+          id: project.task.id.primaryKey,
           name: project.name,
           modificationDate: project.modificationDate.toISOString()
         }));

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -289,9 +289,12 @@ function generateFilterConditions(entity: string, filters: any): string {
 
     if (filters.projectId) {
       const safeId = escapeJXA(filters.projectId);
+      // Match either the AppleScript-namespace id (project's root task id) or
+      // the OmniJS Project id — the two namespaces differ for projects.
       conditions.push(`
         if (!item.containingProject ||
-            item.containingProject.id.primaryKey !== "${safeId}") {
+            (item.containingProject.task.id.primaryKey !== "${safeId}" &&
+             item.containingProject.id.primaryKey !== "${safeId}")) {
           return false;
         }
       `);
@@ -426,8 +429,11 @@ function generateFilterConditions(entity: string, filters: any): string {
   if (entity === 'projects') {
     if (filters.projectId) {
       const safeId = escapeJXA(filters.projectId);
+      // Match either the AppleScript-namespace id (project's root task id) or
+      // the OmniJS Project id — the two namespaces differ for projects.
       conditions.push(`
-        if (item.id.primaryKey !== "${safeId}") {
+        if (item.task.id.primaryKey !== "${safeId}" &&
+            item.id.primaryKey !== "${safeId}") {
           return false;
         }
       `);
@@ -575,7 +581,7 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
       return `
         const taskArray = item.tasks || [];
         return {
-          id: item.id.primaryKey,
+          id: item.task.id.primaryKey,
           name: item.name || "",
           status: projectStatusMap[item.status] || "Unknown",
           folderName: item.parentFolder ? item.parentFolder.name : null,
@@ -606,7 +612,12 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
   const mappings = fields!.map(field => {
     // Handle special field mappings based on entity type
     if (field === 'id') {
-      return `id: item.id.primaryKey`;
+      // For projects, emit the root task id: it matches the AppleScript project id,
+      // which edit_item/remove_item need (OmniJS Project ids live in a different
+      // namespace — issue #77).
+      return entity === 'projects'
+        ? `id: item.task.id.primaryKey`
+        : `id: item.id.primaryKey`;
     } else if (field === 'taskStatus') {
       return `taskStatus: taskStatusMap[item.taskStatus]`;
     } else if (field === 'status') {
@@ -640,7 +651,7 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
     } else if (field === 'projectName') {
       return `projectName: item.containingProject ? item.containingProject.name : (item.inInbox ? "Inbox" : null)`;
     } else if (field === 'projectId') {
-      return `projectId: item.containingProject ? item.containingProject.id.primaryKey : null`;
+      return `projectId: item.containingProject ? item.containingProject.task.id.primaryKey : null`;
     } else if (field === 'parentId') {
       return `parentId: item.parent ? item.parent.id.primaryKey : null`;
     } else if (field === 'childIds') {
@@ -658,7 +669,7 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
     } else if (field === 'projectCount') {
       return `projectCount: item.projects ? item.projects.length : 0`;
     } else if (field === 'projects') {
-      return `projects: item.projects ? item.projects.map(p => p.id.primaryKey) : []`;
+      return `projects: item.projects ? item.projects.map(p => p.task.id.primaryKey) : []`;
     } else if (field === 'subfolders') {
       return `subfolders: item.folders ? item.folders.map(f => f.id.primaryKey) : []`;
     } else if (field === 'path') {

--- a/src/utils/omnifocusScripts/omnifocusDump.js
+++ b/src/utils/omnifocusScripts/omnifocusDump.js
@@ -81,7 +81,9 @@
         const projectsMap = new Map();
         activeProjects.forEach(project => {
           try {
-            const projectId = project.id.primaryKey;
+            // Use the root task id: it matches the AppleScript project id that
+            // edit_item/remove_item expect (OmniJS Project ids differ — issue #77)
+            const projectId = project.task.id.primaryKey;
             const projectData = {
               id: projectId,
               name: project.name,
@@ -171,7 +173,7 @@
             try {
               // Get task data with minimal processing
               const taskTags = task.tags.map(tag => tag.id.primaryKey);
-              const projectID = task.containingProject ? task.containingProject.id.primaryKey : null;
+              const projectID = task.containingProject ? task.containingProject.task.id.primaryKey : null;
 
               const taskData = {
                 id: task.id.primaryKey,


### PR DESCRIPTION
## Summary
- Fixes #77 — project ids returned by `query_omnifocus` / `dump_database` could not be used with `edit_item` / `remove_item`, because OmniJS `Project.id.primaryKey` lives in a different namespace than the AppleScript `id of project` the mutation tools resolve against.
- The bridge: a project's **root task id** is identical to its AppleScript project id (task ids are shared across both bridges — same trick already used in `getPerspectiveView.js`). All query/dump sites now emit `project.task.id.primaryKey`.
- `projectId` filters (both `tasks` and `projects` entities) accept **either** id form, so previously stored OmniJS ids keep working.

## Changes
- `queryOmnifocus.ts`: project `id` (default + explicit field), task `projectId` field, folder `projects` field → root-task id; both `projectId` filters match either namespace.
- `omnifocusDump.js`: project map keys and task `projectID` → root-task id (key + lookup change together, internal consistency preserved).
- `dumpDatabaseOptimized.ts`: change-tracking project ids aligned for consistency.
- 8 new unit tests pinning the namespace behavior (221 total passing).

## Verification (live against OmniFocus)
- Created a `TEST:` project via AppleScript; confirmed AppleScript id ≠ OmniJS id (`eID0dIXzjWq` vs `pSHreOj-Nhg`), and `query_omnifocus` now emits the AppleScript id.
- `projects` and `tasks` `projectId` filters both match under **either** id form.
- Round trip: queried id → `edit_item` rename succeeded (ground-truthed via osascript) → `remove_item` succeeded.
- `dump_database`: projects keyed by AppleScript id; task `projectID` matches; project→tasks linkage intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)