### PR TITLE
Fix temp-file race breaking parallel queries + stats lastModified

### DIFF
--- a/src/resources/today.ts
+++ b/src/resources/today.ts
@@ -11,6 +11,10 @@ export async function readToday(logger: Logger): Promise<ReadResourceResult> {
     queryOmnifocus({ entity: 'tasks', filters: { status: ['Overdue'] }, fields: ['id', 'name', 'flagged', 'dueDate', 'projectName', 'tagNames', 'taskStatus'] })
   ]);
 
+  for (const [label, result] of [['dueToday', dueResult], ['plannedToday', plannedResult], ['overdue', overdueResult]] as const) {
+    if (!result.success) logger.warning("resource:today", `${label} query failed: ${result.error}`);
+  }
+
   const data = {
     dueToday: dueResult.success ? dueResult.items ?? [] : [],
     plannedToday: plannedResult.success ? plannedResult.items ?? [] : [],

--- a/src/tests/integration/helpers.ts
+++ b/src/tests/integration/helpers.ts
@@ -9,7 +9,7 @@ const execAsync = promisify(exec);
 export const TEST_PREFIX = 'TEST:';
 
 export async function execAppleScript(script: string): Promise<string> {
-  const tempFile = join(tmpdir(), `test_omnifocus_${Date.now()}.applescript`);
+  const tempFile = join(tmpdir(), `test_omnifocus_${crypto.randomUUID()}.applescript`);
   try {
     writeFileSync(tempFile, script);
     const { stdout } = await execAsync(`osascript "${tempFile}"`);

--- a/src/tools/dumpDatabaseOptimized.ts
+++ b/src/tools/dumpDatabaseOptimized.ts
@@ -85,11 +85,12 @@ export async function getDatabaseStats(): Promise<{
         
         const inboxCount = activeTasks.filter(task => task.inInbox).length;
         
-        // Get latest modification time
+        // Get latest modification time (OmniJS property is "modified",
+        // not the AppleScript name "modificationDate")
         let lastModified = new Date(0);
         allTasks.forEach(task => {
-          if (task.modificationDate && task.modificationDate > lastModified) {
-            lastModified = task.modificationDate;
+          if (task.modified && task.modified > lastModified) {
+            lastModified = task.modified;
           }
         });
         
@@ -117,7 +118,7 @@ export async function getDatabaseStats(): Promise<{
   
   // Write script to temp file and execute
   const fs = await import('fs');
-  const tempFile = `/tmp/omnifocus_stats_${Date.now()}.js`;
+  const tempFile = `/tmp/omnifocus_stats_${crypto.randomUUID()}.js`;
   fs.writeFileSync(tempFile, script);
   
   const result = await executeOmniFocusScript(tempFile);
@@ -217,7 +218,7 @@ export async function getChangesSince(since: Date): Promise<{
   
   // Write script to temp file and execute
   const fs = await import('fs');
-  const tempFile = `/tmp/omnifocus_changes_${Date.now()}.js`;
+  const tempFile = `/tmp/omnifocus_changes_${crypto.randomUUID()}.js`;
   fs.writeFileSync(tempFile, script);
   
   const result = await executeOmniFocusScript(tempFile);

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -221,7 +221,7 @@ export async function addOmniFocusTask(params: AddOmniFocusTaskParams): Promise<
     console.error("Executing AppleScript via temp file...");
 
     // Write to a temporary AppleScript file to avoid shell escaping issues
-    const tempFile = join(tmpdir(), `omnifocus_add_${Date.now()}.applescript`);
+    const tempFile = join(tmpdir(), `omnifocus_add_${crypto.randomUUID()}.applescript`);
     writeFileSync(tempFile, script, { encoding: 'utf8' });
 
     // Execute AppleScript from file

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -130,7 +130,7 @@ export async function addProject(params: AddProjectParams): Promise<{success: bo
     console.error("Executing AppleScript via temp file...");
 
     // Write to a temporary AppleScript file to avoid shell escaping issues
-    tempFile = join(tmpdir(), `add_project_${Date.now()}.applescript`);
+    tempFile = join(tmpdir(), `add_project_${crypto.randomUUID()}.applescript`);
     writeFileSync(tempFile, script, { encoding: 'utf8' });
 
     // Execute AppleScript from file

--- a/src/tools/primitives/createTag.ts
+++ b/src/tools/primitives/createTag.ts
@@ -75,7 +75,7 @@ export async function createTag(params: CreateTagParams): Promise<{success: bool
   try {
     const script = generateAppleScript(params);
 
-    tempFile = join(tmpdir(), `create_tag_${Date.now()}.applescript`);
+    tempFile = join(tmpdir(), `create_tag_${crypto.randomUUID()}.applescript`);
     writeFileSync(tempFile, script, { encoding: 'utf8' });
 
     const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -478,7 +478,7 @@ export async function editItem(params: EditItemParams): Promise<{
     console.error("AppleScript preview:\n", scriptPreview);
     
     // Write script to temporary file to avoid shell escaping issues
-    tempFile = join(tmpdir(), `edit_omnifocus_${Date.now()}.applescript`);
+    tempFile = join(tmpdir(), `edit_omnifocus_${crypto.randomUUID()}.applescript`);
     writeFileSync(tempFile, script);
     
     // Execute AppleScript from file

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -57,8 +57,9 @@ export async function queryOmnifocus(params: QueryOmnifocusParams): Promise<Quer
     // Create JXA script for the query
     const jxaScript = generateQueryScript(params);
     
-    // Write script to temp file and execute
-    const tempFile = `/tmp/omnifocus_query_${Date.now()}.js`;
+    // randomUUID, not Date.now(): parallel queries (e.g. the today resource)
+    // land in the same millisecond and would clobber each other's temp file
+    const tempFile = `/tmp/omnifocus_query_${crypto.randomUUID()}.js`;
     const fs = await import('fs');
     fs.writeFileSync(tempFile, jxaScript);
     

--- a/src/tools/primitives/queryOmnifocusDebug.ts
+++ b/src/tools/primitives/queryOmnifocusDebug.ts
@@ -129,7 +129,7 @@ export async function queryOmnifocusDebug(entity: 'task' | 'project' | 'folder')
   
   // Write script to temp file and execute
   const fs = await import('fs');
-  const tempFile = `/tmp/omnifocus_debug_${Date.now()}.js`;
+  const tempFile = `/tmp/omnifocus_debug_${crypto.randomUUID()}.js`;
   fs.writeFileSync(tempFile, script);
   
   const result = await executeOmniFocusScript(tempFile);

--- a/src/tools/primitives/removeItem.ts
+++ b/src/tools/primitives/removeItem.ts
@@ -138,7 +138,7 @@ export async function removeItem(params: RemoveItemParams): Promise<{success: bo
     console.error("AppleScript preview:\n", scriptPreview);
 
     // Write script to temporary file to avoid shell escaping issues
-    tempFile = join(tmpdir(), `remove_omnifocus_${Date.now()}.applescript`);
+    tempFile = join(tmpdir(), `remove_omnifocus_${crypto.randomUUID()}.applescript`);
     writeFileSync(tempFile, script);
 
     // Execute AppleScript from file

--- a/src/utils/cacheManager.ts
+++ b/src/utils/cacheManager.ts
@@ -157,7 +157,7 @@ class OmniFocusCacheManager {
       
       // Write to temp file and execute
       const fs = await import('fs');
-      const tempFile = `/tmp/omnifocus_checksum_${Date.now()}.js`;
+      const tempFile = `/tmp/omnifocus_checksum_${crypto.randomUUID()}.js`;
       fs.writeFileSync(tempFile, script);
       
       const result = await executeOmniFocusScript(tempFile);

--- a/src/utils/scriptExecution.ts
+++ b/src/utils/scriptExecution.ts
@@ -22,7 +22,7 @@ export async function executeJXA(script: string): Promise<any[]> {
   const start = Date.now();
   try {
     // Write the script to a temporary file in the system temp directory
-    const tempFile = join(tmpdir(), `jxa_script_${Date.now()}.js`);
+    const tempFile = join(tmpdir(), `jxa_script_${crypto.randomUUID()}.js`);
 
     // Write the script to the temporary file
     writeFileSync(tempFile, script);
@@ -134,7 +134,7 @@ ${scriptContent}`;
     }
 
     // Create a temporary file for our JXA wrapper script
-    const tempFile = join(tmpdir(), `jxa_wrapper_${Date.now()}.js`);
+    const tempFile = join(tmpdir(), `jxa_wrapper_${crypto.randomUUID()}.js`);
 
     // Escape the script content properly for use in JXA
     const escapedScript = escapeContent(wrappedScript);


### PR DESCRIPTION
## Summary
- **Temp-file race:** every script-execution site named its temp file with `Date.now()` (millisecond resolution). Concurrent executions — the `omnifocus://today` resource fires three `queryOmnifocus` calls via `Promise.all`, and MCP clients can issue parallel tool calls — collide on the same filename: each call overwrites the shared file, the first to finish unlinks it, and the rest fail with ENOENT. The `today` resource then silently returned empty arrays (reproduced on essentially every read). All 13 temp-filename sites now use `crypto.randomUUID()`.
- **`stats.lastModified` always epoch:** the stats script read `task.modificationDate` — that's the AppleScript property name; the OmniJS property is `task.modified`, so the value was always `undefined` and `lastModified` never advanced past `1970-01-01`. 
- The `today` resource now logs a warning when an underlying query fails instead of silently rendering `[]`.

## Verification (live against OmniFocus)
- Before: `readToday` returned corrupted/empty buckets nearly every run, with ENOENT unlink errors swallowed as `success: false`.
- After: 5/5 consecutive `readToday` runs return stable, correct results (`overdue=3`, matching `stats.overdueCount` and ground truth); `stats.lastModified` reports the true latest modification time.
- `npx tsc --noEmit` and all 221 unit tests pass.

## Note
`getChangesSince` in `dumpDatabaseOptimized.ts` has the same AppleScript-vs-OmniJS property bug (`creationDate`/`modificationDate` → should be `added`/`modified`), so it always returns empty arrays — but it has no callers anywhere in the codebase. Left untouched here; candidate for deletion or a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)