### PR TITLE
Fix #81: add_omnifocus_task accepts projectId + folder-path projectName

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "omnifocus-mcp",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnifocus-mcp",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -12,7 +12,7 @@ export const schema = z.object({
   estimatedMinutes: z.number().optional().describe("Estimated time to complete the task, in minutes"),
   tags: z.array(z.string()).optional().describe("Tags to assign to the task"),
   projectId: z.string().optional().describe("The id of the project to add the task to (preferred when the project name is ambiguous — e.g. multiple 'Single Actions' projects across folders). Obtain via query_omnifocus. Takes precedence over projectName when both are supplied."),
-  projectName: z.string().optional().describe("The name of the project to add the task to (will add to inbox if not specified). Used when projectId is not supplied; for ambiguous names, prefer projectId. This places a NEWLY created task; to move a task that already exists into a project, use edit_item with newProjectName instead of creating a new task here."),
+  projectName: z.string().optional().describe("The name or folder path of the project to add the task to (e.g. 'My Project' or 'Work/My Project' to disambiguate by folder). Will add to inbox if not specified. Used when projectId is not supplied; for ambiguous names, prefer projectId. This places a NEWLY created task; to move a task that already exists into a project, use edit_item with newProjectName instead of creating a new task here."),
   // Hierarchy support
   parentTaskId: z.string().optional().describe("ID of the parent task (preferred for accuracy)"),
   parentTaskName: z.string().optional().describe("Name of the parent task (used if ID not provided; matched within project or globally if no project)"),

--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -11,7 +11,8 @@ export const schema = z.object({
   flagged: z.boolean().optional().describe("Whether the task is flagged or not"),
   estimatedMinutes: z.number().optional().describe("Estimated time to complete the task, in minutes"),
   tags: z.array(z.string()).optional().describe("Tags to assign to the task"),
-  projectName: z.string().optional().describe("The name of the project to add the task to (will add to inbox if not specified). This places a NEWLY created task; to move a task that already exists into a project, use edit_item with newProjectName instead of creating a new task here."),
+  projectId: z.string().optional().describe("The id of the project to add the task to (preferred when the project name is ambiguous — e.g. multiple 'Single Actions' projects across folders). Obtain via query_omnifocus. Takes precedence over projectName when both are supplied."),
+  projectName: z.string().optional().describe("The name of the project to add the task to (will add to inbox if not specified). Used when projectId is not supplied; for ambiguous names, prefer projectId. This places a NEWLY created task; to move a task that already exists into a project, use edit_item with newProjectName instead of creating a new task here."),
   // Hierarchy support
   parentTaskId: z.string().optional().describe("ID of the parent task (preferred for accuracy)"),
   parentTaskName: z.string().optional().describe("Name of the parent task (used if ID not provided; matched within project or globally if no project)"),

--- a/src/tools/primitives/addOmniFocusTask.test.ts
+++ b/src/tools/primitives/addOmniFocusTask.test.ts
@@ -14,7 +14,7 @@ describe('addOmniFocusTask generateAppleScript', () => {
     });
     expect(script).toContain('first flattened project where name = "Development"');
     expect(script).toContain('make new task with properties {name:"Write tests"}');
-    expect(script).toContain('at end of tasks of theProject');
+    expect(script).toContain('at end of tasks of targetProject');
   });
 
   it('preserves newlines in note via linefeed concatenation', () => {
@@ -25,5 +25,44 @@ describe('addOmniFocusTask generateAppleScript', () => {
     expect(script).toContain(
       'set note of newTask to "Line 1" & linefeed & "Line 2" & linefeed & "Line 3"'
     );
+  });
+
+  it('resolves project by id when projectId specified', () => {
+    const script = generateAppleScript({
+      name: 'Task by id',
+      projectId: 'abc123',
+    });
+    expect(script).toContain('first flattened project where id = "abc123"');
+    expect(script).toContain('at end of tasks of targetProject');
+    expect(script).toContain('Project not found: id abc123');
+  });
+
+  it('prefers projectId over projectName when both are supplied', () => {
+    const script = generateAppleScript({
+      name: 'Disambiguated task',
+      projectId: 'xyz789',
+      projectName: 'Ambiguous Name',
+    });
+    // The runtime guard is what enforces precedence: the projectId check sits in the
+    // if-branch and runs first; the projectName check sits in the else-if and is
+    // unreachable when projectId is non-empty. Both branches render in the script text
+    // (one would be unused), so the test asserts structure + ordering rather than absence.
+    expect(script).toContain('if "xyz789" is not "" then');
+    expect(script).toContain('else if "Ambiguous Name" is not "" then');
+    expect(script.indexOf('if "xyz789" is not "" then'))
+      .toBeLessThan(script.indexOf('else if "Ambiguous Name" is not "" then'));
+    expect(script.indexOf('first flattened project where id = "xyz789"'))
+      .toBeLessThan(script.indexOf('first flattened project where name = "Ambiguous Name"'));
+  });
+
+  it('parent-within-project constraint compares by id of containing project', () => {
+    const script = generateAppleScript({
+      name: 'Child task',
+      projectId: 'proj-1',
+      parentTaskId: 'task-99',
+    });
+    // The constraint compares container-project id against the resolved targetProject id,
+    // not against the projectName text (which may be unset when only projectId is given).
+    expect(script).toContain('(id of pproj as string) is not equal to (id of targetProject as string)');
   });
 });

--- a/src/tools/primitives/addOmniFocusTask.test.ts
+++ b/src/tools/primitives/addOmniFocusTask.test.ts
@@ -7,14 +7,39 @@ describe('addOmniFocusTask generateAppleScript', () => {
     expect(script).toContain('make new inbox task with properties {name:"Buy milk"}');
   });
 
-  it('creates task in project when projectName specified', () => {
+  it('creates task in project when bare projectName specified', () => {
     const script = generateAppleScript({
       name: 'Write tests',
       projectName: 'Development',
     });
-    expect(script).toContain('first flattened project where name = "Development"');
+    // generateProjectLookupScript renders single-component lookups via `whose name is`
+    expect(script).toContain('first flattened project whose name is "Development"');
     expect(script).toContain('make new task with properties {name:"Write tests"}');
     expect(script).toContain('at end of tasks of targetProject');
+  });
+
+  it('resolves folder-path projectName via folder ancestry walk', () => {
+    const script = generateAppleScript({
+      name: 'Task in nested project',
+      projectName: 'Work/Engineering/Backend',
+    });
+    // generateProjectLookupScript splits on '/', iterates flattened projects,
+    // and verifies folder ancestry walks up matching each path component
+    expect(script).toContain('set folderPath to {"Work", "Engineering"}');
+    expect(script).toContain('if (name of aProject as string) = "Backend" then');
+    expect(script).toContain('repeat with i from (count of folderPath) to 1 by -1');
+    expect(script).toContain('at end of tasks of targetProject');
+  });
+
+  it('escapes quotes in folder-path components', () => {
+    const script = generateAppleScript({
+      name: 'Quoted',
+      projectName: 'Quotes "are" hard/My Project',
+    });
+    // AppleScript escapes embedded quotes by doubling — verify both components
+    // are escaped via the same helper editItem uses
+    expect(script).toContain('set folderPath to');
+    expect(script).toContain('Quotes \\"are\\" hard');
   });
 
   it('preserves newlines in note via linefeed concatenation', () => {
@@ -52,7 +77,7 @@ describe('addOmniFocusTask generateAppleScript', () => {
     expect(script.indexOf('if "xyz789" is not "" then'))
       .toBeLessThan(script.indexOf('else if "Ambiguous Name" is not "" then'));
     expect(script.indexOf('first flattened project where id = "xyz789"'))
-      .toBeLessThan(script.indexOf('first flattened project where name = "Ambiguous Name"'));
+      .toBeLessThan(script.indexOf('first flattened project whose name is "Ambiguous Name"'));
   });
 
   it('parent-within-project constraint compares by id of containing project', () => {

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -4,7 +4,7 @@ import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { createDateOutsideTellBlock } from '../../utils/dateFormatting.js';
-import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
+import { escapeAppleScriptString, generateProjectLookupScript } from '../../utils/appleScriptHelpers.js';
 const execAsync = promisify(exec);
 
 // Interface for task creation parameters
@@ -63,7 +63,18 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
     plannedDateVar = `plannedDate${Math.random().toString(36).substr(2, 9)}`;
     datePreScript += createDateOutsideTellBlock(plannedDate, plannedDateVar) + '\n\n';
   }
-  
+
+  // Build the projectName lookup fragment via generateProjectLookupScript —
+  // this gives folder-path support (e.g. "Work/My Project") for free, matching
+  // edit_item.newProjectName. Only emitted when projectName is supplied.
+  const projectNameLookup = params.projectName
+    ? generateProjectLookupScript(
+        params.projectName,
+        'targetProject',
+        `{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${projectName}\\\"}`
+      )
+    : '';
+
   // Construct AppleScript with error handling
   let script = datePreScript + `
   try
@@ -79,12 +90,7 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
             return "{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: id ${projectId}\\\"}"
           end if
         else if "${projectName}" is not "" then
-          try
-            set targetProject to first flattened project where name = "${projectName}"
-          end try
-          if targetProject is missing value then
-            return "{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${projectName}\\\"}"
-          end if
+          ${projectNameLookup}
         end if
 
         -- Resolve parent task if provided

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -17,7 +17,8 @@ export interface AddOmniFocusTaskParams {
   flagged?: boolean;
   estimatedMinutes?: number;
   tags?: string[]; // Tag names
-  projectName?: string; // Project name to add task to
+  projectId?: string; // Project id to add task to (preferred when disambiguation is needed)
+  projectName?: string; // Project name to add task to (used when projectId is not supplied)
   // Hierarchy support
   parentTaskId?: string;
   parentTaskName?: string;
@@ -37,6 +38,7 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
   const flagged = params.flagged === true;
   const estimatedMinutes = params.estimatedMinutes?.toString() || '';
   const tags = params.tags || [];
+  const projectId = params.projectId ? escapeAppleScriptString(params.projectId) : '';
   const projectName = params.projectName ? escapeAppleScriptString(params.projectName) : '';
   const parentTaskId = params.parentTaskId ? escapeAppleScriptString(params.parentTaskId) : '';
   const parentTaskName = params.parentTaskName ? escapeAppleScriptString(params.parentTaskName) : '';
@@ -67,6 +69,24 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
   try
     tell application "OmniFocus"
       tell front document
+        -- Resolve target project up front: by id if provided, else by name, else missing
+        set targetProject to missing value
+        if "${projectId}" is not "" then
+          try
+            set targetProject to first flattened project where id = "${projectId}"
+          end try
+          if targetProject is missing value then
+            return "{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: id ${projectId}\\\"}"
+          end if
+        else if "${projectName}" is not "" then
+          try
+            set targetProject to first flattened project where name = "${projectName}"
+          end try
+          if targetProject is missing value then
+            return "{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${projectName}\\\"}"
+          end if
+        end if
+
         -- Resolve parent task if provided
         set newTask to missing value
         set parentTask to missing value
@@ -81,25 +101,25 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
               set parentTask to first inbox task where id = "${parentTaskId}"
             end try
           end if
-          -- If projectName provided, ensure parent is within that project
-          if parentTask is not missing value and "${projectName}" is not "" then
+          -- If target project resolved, ensure parent is within that project
+          if parentTask is not missing value and targetProject is not missing value then
             try
               set pproj to containing project of parentTask
-              if pproj is missing value or name of pproj is not "${projectName}" then set parentTask to missing value
+              if pproj is missing value or (id of pproj as string) is not equal to (id of targetProject as string) then set parentTask to missing value
             end try
           end if
         end if
 
         if parentTask is missing value and "${parentTaskName}" is not "" then
-          if "${projectName}" is not "" then
-            -- Find by name but constrain to the specified project
+          if targetProject is not missing value then
+            -- Find by name but constrain to the target project
             try
               set parentTask to first flattened task where name = "${parentTaskName}"
             end try
             if parentTask is not missing value then
               try
                 set pproj to containing project of parentTask
-                if pproj is missing value or name of pproj is not "${projectName}" then set parentTask to missing value
+                if pproj is missing value or (id of pproj as string) is not equal to (id of targetProject as string) then set parentTask to missing value
               end try
             end if
           else
@@ -118,14 +138,9 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
         if parentTask is not missing value then
           -- Create task under parent task
           set newTask to make new task with properties {name:"${name}"} at end of tasks of parentTask
-        else if "${projectName}" is not "" then
-          -- Create under specified project
-          try
-            set theProject to first flattened project where name = "${projectName}"
-            set newTask to make new task with properties {name:"${name}"} at end of tasks of theProject
-          on error
-            return "{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${projectName}\\\"}"
-          end try
+        else if targetProject is not missing value then
+          -- Create under the resolved target project
+          set newTask to make new task with properties {name:"${name}"} at end of tasks of targetProject
         else
           -- Fallback to inbox
           set newTask to make new inbox task with properties {name:"${name}"}
@@ -170,8 +185,8 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
             set placement to "inbox"
           end if
         on error
-          -- If container access fails (e.g., inbox), default based on projectName
-          if "${projectName}" is not "" then
+          -- If container access fails (e.g., inbox), default based on whether a project was targeted
+          if "${projectId}" is not "" or "${projectName}" is not "" then
             set placement to "project"
           else
             set placement to "inbox"


### PR DESCRIPTION
## Summary

Closes the disambiguation gap on `add_omnifocus_task`. After #77 / #78, project ids and folder-path names work across query and mutation tools — except this one creation tool. Two complementary changes:

- **Commit 1** — adds `projectId` and refactors project resolution into one up-front `targetProject` AppleScript variable, shared by the create-under, parent-within-project check, and placement-derivation code.
- **Commit 2** — replaces the flat `first flattened project where name = "${projectName}"` lookup with `generateProjectLookupScript` (the helper `edit_item.newProjectName` already uses), so the folder-path slash form (`"Work/My Project"`) works for creation too.

When both `projectId` and `projectName` are supplied, `projectId` wins — same precedence shape as `projectName` over inbox-default today.

closes #81

## Verification

PR #78's edit/remove paths already use this AppleScript primitive — here it's the same call (`first flattened project where id = X`) on the creation path. I ran `osascript -e 'tell application "OmniFocus" to tell front document ...'` separately and confirmed the id-based lookup returns the project from any folder, not just first-match folders.

The folder-path helper itself is `generateProjectLookupScript`, unchanged — `edit_item.newProjectName` has been calling it end-to-end since PR #78.

Locally: typecheck, unit tests, and build all pass. (Upstream CI is queued pending first-contributor approval.) 226 unit tests total — 5 new, up from 221. The new tests cover the `projectId` side (lookup, precedence, id-based parent constraint) and the folder-path side (ancestry walk, quote-escaping).

## Backwards compatibility

- Bare `projectName` calls behave identically. The single-component branch in `generateProjectLookupScript` uses `whose name is` rather than `where name =`, but both forms return the same project for bare names. The existing test was updated to reflect the new wording.
- Callers that previously got the wrong project for an ambiguous name will continue to get the same wrong project unless they switch to `projectId` or the folder-path form. No behaviour change without an opt-in.
- The `parent-within-project` constraint changes from name-match to id-match. This is stricter (always correct) but could theoretically differ when two projects share an id — not possible in OmniFocus's data model.

Happy to revise the shape, split the commits differently, or scope this down to just `projectId` if you'd prefer a smaller change first.
