### PR TITLE
Add SSH signature dangerous grants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ build/
 logs/
 *.log
 
+# Local OmniFocus database backups created before destructive testing
+OmniFocus-MCP-local-backups/
+
 # Coverage directory used by tools like istanbul
 coverage/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# Agent Context: OmniFocus MCP Fork
+
+Temporary handoff notes for Codex/agent sessions working in this fork.
+
+## Project Goal
+
+This fork adapts `themotionmachine/OmniFocus-MCP` for safer agent access to OmniFocus. The upstream project is already a full Model Context Protocol server for querying, creating, editing, and removing OmniFocus tasks/projects/tags.
+
+## Location Constraint
+
+All project work must stay under `/Users/xh/Workspace/`. This repository is the working fork at:
+
+```text
+/Users/xh/Workspace/OmniFocus-MCP
+```
+
+Do not create project files outside `/Users/xh/Workspace/` unless the user explicitly changes that constraint.
+
+## Relevant Local Repositories
+
+- `/Users/xh/Workspace/OmniFocus-MCP` - user fork, active work target.
+- `/Users/xh/Workspace/OmniFocus-MCP-upstream` - read-only upstream inspection clone.
+- `/Users/xh/Workspace/omnifocus-agent-bridge` - tiny earlier prototype/scratchpad, not the main direction.
+
+## Current Assessment
+
+Forking upstream is preferred over copying pieces into the scratch bridge. Upstream already has:
+
+- MCP stdio server wiring.
+- Zod schemas for tools.
+- Query filters and resource views.
+- Add/edit/remove task and project operations.
+- Tag and perspective support.
+- Unit tests and integration tests.
+- npm packaging via `omnifocus-mcp`.
+
+Important implementation detail: the upstream server is not pure Omni Automation JavaScript. It uses both:
+
+- OmniJS through JXA `Application("OmniFocus").evaluateJavascript(...)`, especially for reads/query/perspectives.
+- Generated AppleScript through `osascript`, especially for mutations.
+
+That pragmatic hybrid is acceptable unless the user later asks to convert mutations to OmniJS.
+
+## Safety Direction
+
+The main desired modification is a stricter safety/profile layer for agent use. The upstream server exposes powerful write tools directly, including destructive tools. Assume MCP client approvals may help, but do not rely on the client as the only safety boundary.
+
+Preferred safety model:
+
+- Read-only by default.
+- Allow safe read tools/resources without friction: `query_omnifocus`, `dump_database`, `list_tags`, `list_perspectives`, `get_perspective_view`, resources.
+- Require explicit opt-in for write tools.
+- Treat these as high-risk and require extra confirmation or disable by default: `remove_item`, `batch_remove_items`, project/task status changes to completed/dropped, bulk edits, and broad batch operations.
+- Prefer creating inbox tasks before moving/editing existing structures.
+- Avoid silent destructive behavior.
+
+## Initial Implementation Ideas
+
+- Add a policy module that classifies tools as read, write, or destructive.
+- Gate tool handlers through the policy before invoking primitives.
+- Use environment variables or config for modes, for example:
+  - `OMNIFOCUS_MCP_MODE=readonly|write|dangerous`
+  - default: `readonly`
+- Return clear MCP errors when a tool is blocked by policy.
+- Add tests for blocked writes and allowed reads.
+- Keep upstream changes small and easy to rebase.
+
+## Commands
+
+```sh
+npm install
+npm test
+npm run build
+```
+
+Integration tests require OmniFocus and can create/remove `TEST:` prefixed items. Do not run integration tests casually without telling the user.
+
+## Research Context
+
+- User is interested in agents talking to OmniFocus 4.8.
+- OmniFocus 4.8.x still has active Omni Automation support based on release notes checked earlier.
+- The upstream README says macOS will request automation permission the first time the server talks to OmniFocus.
+- Upstream latest release observed in the GitHub UI was v1.9.2 on June 11, 2026.
+
+## Next Useful Steps
+
+1. Run unit tests in the fork.
+2. Identify all tool registrations in `src/server.ts`.
+3. Add the safety policy layer with read-only default.
+4. Add tests for safety behavior.
+5. Build and smoke test.
+6. Only after that, consider local OmniFocus integration testing.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Set `OMNIFOCUS_MCP_MODE` only when you want to allow writes:
 
 Recommended flow for agent use: start in read-only mode, inspect first with `query_omnifocus`, then switch to `write` only for planned captures or edits. Avoid `dangerous` unless you are intentionally removing items or marking them completed/dropped, and issue a fresh grant for each destructive operation.
 
-Dangerous grants are compact signed tokens bound to the exact tool name and canonical argument hash. Configure the verifier with a PEM public key, OpenSSH `ssh-ed25519` public key, or OpenSSH `ssh-rsa` public key:
+Dangerous grants are compact signed tokens bound to the exact tool name and canonical argument hash. Configure the verifier with a PEM public key, OpenSSH `ssh-ed25519` public key, or OpenSSH `ssh-rsa` public key. The no-export SSH signature backend requires an OpenSSH public key because verification is delegated to `ssh-keygen -Y verify`.
 
 ```bash
 export OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY='-----BEGIN PUBLIC KEY-----...'
@@ -59,6 +59,20 @@ omnifocus-mcp-grant \
   --reason 'cleanup test data'
 ```
 
+The compatibility signer above reads the private key into the helper process. To keep private key material inside the 1Password SSH agent, use the SSH signature signer and point it at the public key identity instead:
+
+```bash
+omnifocus-mcp-grant \
+  --signer ssh-signature \
+  --tool remove_item \
+  --args-json '{"name":"TEST: old task","itemType":"task"}' \
+  --ssh-signing-key-ref 'op://Private/SSH Key/public key' \
+  --ssh-auth-sock "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" \
+  --reason 'cleanup test data'
+```
+
+This produces an `SSHSIG...` dangerous grant using `ssh-keygen -Y sign`. The helper may read the public key from 1Password, but it rejects private-key material for `--ssh-signing-key-ref` and `--ssh-signing-key-env`. If the key is protected by 1Password, the 1Password SSH agent may request approval during signing.
+
 Check grant key compatibility without performing any OmniFocus action:
 
 ```bash
@@ -67,7 +81,17 @@ omnifocus-mcp-grant doctor \
   --public-key-ref 'op://Private/SSH Key/public key'
 ```
 
-The doctor reports supported key type, signing algorithm, key format, and whether a synthetic sign/verify round trip succeeds. This is useful before live dangerous cleanup.
+For the no-export path:
+
+```bash
+omnifocus-mcp-grant doctor \
+  --signer ssh-signature \
+  --ssh-signing-key-ref 'op://Private/SSH Key/public key' \
+  --ssh-auth-sock "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" \
+  --public-key-ref 'op://Private/SSH Key/public key'
+```
+
+The doctor reports supported key type, signing backend, key format, and whether a synthetic sign/verify round trip succeeds. This is useful before live dangerous cleanup.
 
 To test dangerous grant validation without executing the destructive OmniFocus mutation, set:
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ Set `OMNIFOCUS_MCP_MODE` only when you want to allow writes:
 
 Recommended flow for agent use: start in read-only mode, inspect first with `query_omnifocus`, then switch to `write` only for planned captures or edits. Avoid `dangerous` unless you are intentionally removing items or marking them completed/dropped, and issue a fresh grant for each destructive operation.
 
-Dangerous grants are compact EdDSA-signed tokens bound to the exact tool name and canonical argument hash. Configure the verifier with an Ed25519 public key in PEM or OpenSSH `ssh-ed25519` format:
+Dangerous grants are compact signed tokens bound to the exact tool name and canonical argument hash. Configure the verifier with a PEM public key, OpenSSH `ssh-ed25519` public key, or OpenSSH `ssh-rsa` public key:
 
 ```bash
 export OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY='-----BEGIN PUBLIC KEY-----...'
 export OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY='ssh-ed25519 AAAA...'
+export OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY='ssh-rsa AAAA...'
 export OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY_PATH=/path/to/public-key.pem
 ```
 
@@ -209,6 +210,12 @@ Remove a task or project.
 
 - `id` or `name`: which item to remove
 - `itemType`: `task` or `project`
+
+### `remove_tag`
+
+Remove a tag by ID, or by exact name as a fallback.
+
+- `id` or `name`: which tag to remove
 
 ### `batch_add_items`
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,46 @@ This server bridges AI assistants and your OmniFocus database. Through natural c
 
 The first time the server talks to OmniFocus, macOS will ask you to allow automation access. Grant it once and you're set.
 
+### Safety Modes
+
+The server defaults to read-only mode. With `OMNIFOCUS_MCP_MODE` unset, read tools and resources work, but tools that create, edit, complete, drop, or remove OmniFocus items are blocked before they reach OmniFocus.
+
+Set `OMNIFOCUS_MCP_MODE` only when you want to allow writes:
+
+| Mode | Behavior |
+|---|---|
+| unset or `readonly` | Allows read tools and resources. Blocks all writes. |
+| `write` | Allows ordinary creates and edits. Still blocks removals, completion/drop status changes, and broad batch adds. |
+| `dangerous` | Allows destructive tools only when each destructive call also includes a short-lived signed `dangerousGrant`. Use briefly and deliberately. |
+
+Recommended flow for agent use: start in read-only mode, inspect first with `query_omnifocus`, then switch to `write` only for planned captures or edits. Avoid `dangerous` unless you are intentionally removing items or marking them completed/dropped, and issue a fresh grant for each destructive operation.
+
+Dangerous grants are compact EdDSA-signed tokens bound to the exact tool name and canonical argument hash. Configure the verifier with an Ed25519 public key in PEM or OpenSSH `ssh-ed25519` format:
+
+```bash
+export OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY='-----BEGIN PUBLIC KEY-----...'
+export OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY='ssh-ed25519 AAAA...'
+export OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY_PATH=/path/to/public-key.pem
+```
+
+Generate an exact-operation grant with:
+
+```bash
+omnifocus-mcp-grant \
+  --tool remove_item \
+  --args-json '{"name":"TEST: old task","itemType":"task"}' \
+  --private-key-ref 'op://Private/SSH Key/private key?ssh-format=openssh' \
+  --reason 'cleanup test data'
+```
+
+To test dangerous grant validation without executing the destructive OmniFocus mutation, set:
+
+```bash
+export OMNIFOCUS_MCP_DANGEROUS_DRY_RUN=1
+```
+
+Dangerous responses include a `dangerousAction` JSON object with the tool name, sanitized arguments, canonical argument hash, grant metadata, and whether the mutation handler executed. Dry-run sets `executed: false`; normal dangerous execution appends the same audit object with `executed: true`.
+
 ### Claude Desktop
 
 Add the server to `~/Library/Application Support/Claude/claude_desktop_config.json`:
@@ -41,12 +81,34 @@ Add the server to `~/Library/Application Support/Claude/claude_desktop_config.js
 }
 ```
 
+To enable ordinary writes, add an environment variable:
+
+```json
+{
+  "mcpServers": {
+    "omnifocus": {
+      "command": "npx",
+      "args": ["-y", "omnifocus-mcp"],
+      "env": {
+        "OMNIFOCUS_MCP_MODE": "write"
+      }
+    }
+  }
+}
+```
+
 Then restart Claude Desktop.
 
 ### Claude Code
 
 ```bash
 claude mcp add omnifocus -- npx -y omnifocus-mcp
+```
+
+For ordinary writes:
+
+```bash
+claude mcp add omnifocus --env OMNIFOCUS_MCP_MODE=write -- npx -y omnifocus-mcp
 ```
 
 Other MCP clients work the same way: launch `npx -y omnifocus-mcp` over stdio.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ omnifocus-mcp-grant \
   --reason 'cleanup test data'
 ```
 
+Check grant key compatibility without performing any OmniFocus action:
+
+```bash
+omnifocus-mcp-grant doctor \
+  --private-key-ref 'op://Private/SSH Key/private key?ssh-format=openssh' \
+  --public-key-ref 'op://Private/SSH Key/public key'
+```
+
+The doctor reports supported key type, signing algorithm, key format, and whether a synthetic sign/verify round trip succeeds. This is useful before live dangerous cleanup.
+
 To test dangerous grant validation without executing the destructive OmniFocus mutation, set:
 
 ```bash

--- a/evaluation-notes/README.md
+++ b/evaluation-notes/README.md
@@ -1,0 +1,8 @@
+# Evaluation Notes
+
+Fork-local verification notes for agent-safety work. These files capture what was tested against local OmniFocus data and are not intended to be upstream-facing product documentation.
+
+- [Read evaluation](reads.md)
+- [Write evaluation](writes.md)
+- [Dangerous grant evaluation](grants.md)
+- [Backup notes](backups.md)

--- a/evaluation-notes/README.md
+++ b/evaluation-notes/README.md
@@ -6,3 +6,4 @@ Fork-local verification notes for agent-safety work. These files capture what wa
 - [Write evaluation](writes.md)
 - [Dangerous grant evaluation](grants.md)
 - [Backup notes](backups.md)
+- [Tag deletion notes](tag-deletion.md)

--- a/evaluation-notes/backups.md
+++ b/evaluation-notes/backups.md
@@ -1,0 +1,80 @@
+# Backup Notes
+
+These notes describe the local backup plan for destructive OmniFocus testing in this fork.
+
+## What Counts As A Backup
+
+`dump_database` is useful as a readable audit snapshot, but it is not a proven restorable backup.
+
+For rollback safety, copy OmniFocus's local model directory only after OmniFocus has quit cleanly:
+
+```text
+~/Library/Group Containers/34YW5XSRB7.com.omnigroup.OmniFocus/com.omnigroup.OmniFocus4/com.omnigroup.OmniFocusModel/
+```
+
+This directory contains the active and archive SQLite databases plus their WAL/SHM files.
+
+## Script
+
+Use:
+
+```sh
+scripts/backup-omnifocus-db.sh --quit --reopen
+```
+
+Behavior:
+
+- Refuses to run while OmniFocus is open unless `--quit` is passed.
+- With `--quit`, asks OmniFocus to quit through AppleScript and waits for the process to exit.
+- Copies the full model directory with `ditto`.
+- Writes a manifest containing source path, backup path, current git commit, file sizes, and SHA-256 checksums.
+- With `--reopen`, starts OmniFocus again after the copy.
+
+Default destination:
+
+```text
+~/Workspace/OmniFocus-MCP-local-backups/<timestamp>/
+```
+
+This destination is ignored by git.
+
+## Pre-Destructive Checklist
+
+Before live destructive MCP cleanup:
+
+1. Run `scripts/backup-omnifocus-db.sh --quit --reopen`.
+2. Confirm the script reports a backup path.
+3. Confirm the manifest exists.
+4. Confirm `OmniFocusDatabase.db` in the backup is non-empty.
+5. Optionally run a read-only `dump_database` snapshot for human-readable audit context.
+
+## Verified Backup
+
+The backup script was run successfully on 2026-06-23 before live destructive cleanup.
+
+Backup path:
+
+```text
+~/Workspace/OmniFocus-MCP-local-backups/20260623-005401/
+```
+
+Verified files:
+
+```text
+ArchiveDatabase.db
+ArchiveDatabase.db-shm
+ArchiveDatabase.db-wal
+OmniFocusDatabase.db
+OmniFocusDatabase.db-shm
+OmniFocusDatabase.db-wal
+manifest.txt
+```
+
+Key size checks:
+
+```text
+ArchiveDatabase.db size=3997696
+OmniFocusDatabase.db size=1630208
+```
+
+`OmniFocusDatabase.db-wal` was `0B`, which is expected after a clean quit/checkpoint.

--- a/evaluation-notes/backups.md
+++ b/evaluation-notes/backups.md
@@ -78,3 +78,20 @@ OmniFocusDatabase.db size=1630208
 ```
 
 `OmniFocusDatabase.db-wal` was `0B`, which is expected after a clean quit/checkpoint.
+
+## Tag Cleanup Backup
+
+The backup script was run again on 2026-06-23 before live `remove_tag` cleanup.
+
+Backup path:
+
+```text
+~/Workspace/OmniFocus-MCP-local-backups/20260623-025106/
+```
+
+The script reported:
+
+```text
+Backup created: /Users/xh/Workspace/OmniFocus-MCP-local-backups/20260623-025106
+Manifest: /Users/xh/Workspace/OmniFocus-MCP-local-backups/20260623-025106/manifest.txt
+```

--- a/evaluation-notes/grants.md
+++ b/evaluation-notes/grants.md
@@ -19,7 +19,7 @@ V1 implements exact-operation grants only:
 - one canonicalized argument hash
 - one short expiry
 - one `jti`, accepted once per server process
-- one EdDSA signature from a configured public key
+- one signature from a configured public key
 
 The grant verifier rejects missing, expired, replayed, wrong-tool, wrong-args, wrong-audience, wrong-issuer, unsupported-version, and unsupported-grant-type tokens.
 
@@ -87,7 +87,10 @@ Future `grant_type: "pattern"` grants can reuse `allowed_tools` and `constraints
 
 ## Signing Path
 
-The current helper signs compact EdDSA JWT-style grants and accepts PEM or unencrypted OpenSSH Ed25519 private keys:
+The current helper signs compact JWT-style grants and accepts PEM keys plus unencrypted OpenSSH keys:
+
+- Ed25519 keys sign with `EdDSA`
+- RSA keys sign with `RS256`
 
 ```sh
 omnifocus-mcp-grant \
@@ -97,7 +100,7 @@ omnifocus-mcp-grant \
   --reason 'cleanup test data'
 ```
 
-The `--private-key-ref` mode uses `op read --no-newline` and keeps the private key in process memory only. This is a pragmatic v1 path for standard JWT-style signatures. The verifier accepts PEM or OpenSSH `ssh-ed25519` public keys.
+The `--private-key-ref` mode uses `op read --no-newline` and keeps the private key in process memory only. This is a pragmatic v1 path for standard JWT-style signatures. The verifier accepts PEM public keys, OpenSSH `ssh-ed25519` public keys, and OpenSSH `ssh-rsa` public keys.
 
 The preferred no-export path is still worth investigating: use the 1Password SSH agent with `ssh-keygen -Y sign` so the private key never leaves 1Password. That produces an SSH signature envelope rather than a normal JOSE/JWT signature, so it should be treated as a separate signer/verifier backend.
 
@@ -109,6 +112,7 @@ The preferred no-export path is still worth investigating: use the 1Password SSH
 - Build passes with the grant helper compiled to `dist/grantDangerous.js`.
 - The grant helper was smoke-tested with a temporary generated PEM Ed25519 keypair and produced a three-part compact token.
 - The grant helper and verifier were smoke-tested end-to-end with a temporary `ssh-keygen -t ed25519` OpenSSH private/public keypair.
+- Unit tests cover OpenSSH RSA private/public key signing and verification with `RS256`.
 - The full dangerous dry-run MCP matrix passed with a temporary OpenSSH keypair. Each case returned `dangerousAction.executed: false`, `dangerousAction.dryRun: true`, and matching sanitized args:
   - `remove_item`
   - `batch_remove_items`
@@ -147,8 +151,10 @@ Post-cleanup query for tasks in the project returned:
 No tasks found matching the specified criteria.
 ```
 
-The write-smoke tag remains because the MCP server does not currently expose tag deletion:
+The write-smoke tag remained after the first cleanup because the MCP server did not expose tag deletion at the time:
 
 ```text
 TEST-write-smoke-2026-06-23T06-29-58-260Z
 ```
+
+Issue #1 tracks adding `remove_tag`; follow-up verification is recorded in `tag-deletion.md`.

--- a/evaluation-notes/grants.md
+++ b/evaluation-notes/grants.md
@@ -1,0 +1,154 @@
+# Dangerous Grant Evaluation Notes
+
+These notes record the dangerous-operation grant design in this fork.
+
+## Goal
+
+MCP/client approval prompts are useful UX, but they are not the final safety boundary. The server should require a fresh user-mediated capability before destructive operations reach the OmniFocus mutation primitives.
+
+The implemented v1 design requires both:
+
+- `OMNIFOCUS_MCP_MODE=dangerous`
+- a valid `dangerousGrant` argument on the destructive tool call
+
+## V1 Grant Semantics
+
+V1 implements exact-operation grants only:
+
+- one tool name
+- one canonicalized argument hash
+- one short expiry
+- one `jti`, accepted once per server process
+- one EdDSA signature from a configured public key
+
+The grant verifier rejects missing, expired, replayed, wrong-tool, wrong-args, wrong-audience, wrong-issuer, unsupported-version, and unsupported-grant-type tokens.
+
+The tool gate strips `dangerousGrant` before calling the underlying tool handler so mutation primitives do not receive authorization metadata.
+
+For testing, `OMNIFOCUS_MCP_DANGEROUS_DRY_RUN=1` verifies a valid grant and then stops before calling the destructive handler. This makes MCP-level positive grant tests possible without touching OmniFocus mutation primitives.
+
+Dangerous responses include a machine-checkable `dangerousAction` JSON object. Dry-run sets `executed: false`; normal dangerous execution appends the same object with `executed: true`.
+
+```json
+{
+  "dangerousAction": {
+    "dryRun": true,
+    "tool": "remove_item",
+    "accessLevel": "dangerous",
+    "argsHash": "sha256-of-canonical-args",
+    "args": {
+      "name": "TEST: item",
+      "itemType": "task"
+    },
+    "grant": {
+      "jti": "grant-id",
+      "grantVersion": 1,
+      "grantType": "exact",
+      "scope": "dangerous",
+      "allowedTools": ["remove_item"],
+      "expiresAt": 1782196900,
+      "reason": "cleanup test data"
+    },
+    "executed": false,
+    "message": "Grant verified; OmniFocus mutation was not executed because dangerous dry-run mode is enabled."
+  }
+}
+```
+
+## V2-Ready Payload Shape
+
+The claims schema intentionally leaves room for a future umbrella grant:
+
+```json
+{
+  "iss": "omnifocus-mcp",
+  "aud": "omnifocus-mcp-dangerous-grant",
+  "sub": "user-approved-operation",
+  "iat": 1782196600,
+  "nbf": 1782196600,
+  "exp": 1782196900,
+  "jti": "random-id",
+  "grant_version": 1,
+  "grant_type": "exact",
+  "scope": "dangerous",
+  "allowed_tools": ["remove_item"],
+  "operation": {
+    "tool": "remove_item",
+    "args_sha256": "sha256-of-canonical-args"
+  },
+  "constraints": {
+    "max_operations": 1
+  },
+  "reason": "cleanup test data"
+}
+```
+
+Future `grant_type: "pattern"` grants can reuse `allowed_tools` and `constraints` for short-lived cleanup sessions, for example deleting up to 20 `TEST:` items.
+
+## Signing Path
+
+The current helper signs compact EdDSA JWT-style grants and accepts PEM or unencrypted OpenSSH Ed25519 private keys:
+
+```sh
+omnifocus-mcp-grant \
+  --tool remove_item \
+  --args-json '{"name":"TEST: item","itemType":"task"}' \
+  --private-key-ref 'op://Private/SSH Key - MacBook Pro R9JG4390L4/private key?ssh-format=openssh' \
+  --reason 'cleanup test data'
+```
+
+The `--private-key-ref` mode uses `op read --no-newline` and keeps the private key in process memory only. This is a pragmatic v1 path for standard JWT-style signatures. The verifier accepts PEM or OpenSSH `ssh-ed25519` public keys.
+
+The preferred no-export path is still worth investigating: use the 1Password SSH agent with `ssh-keygen -Y sign` so the private key never leaves 1Password. That produces an SSH signature envelope rather than a normal JOSE/JWT signature, so it should be treated as a separate signer/verifier backend.
+
+## Verified Locally
+
+- Unit tests cover canonical hashing, grant creation, signature verification, expiry, args mismatch, replay rejection, missing public-key config, policy blocking without grants, and policy allowance with valid exact grants.
+- Unit tests cover dangerous audit output for both dry-run and real handler execution.
+- Unit tests cover dangerous dry-run behavior: valid grants are verified, but the destructive handler is not called.
+- Build passes with the grant helper compiled to `dist/grantDangerous.js`.
+- The grant helper was smoke-tested with a temporary generated PEM Ed25519 keypair and produced a three-part compact token.
+- The grant helper and verifier were smoke-tested end-to-end with a temporary `ssh-keygen -t ed25519` OpenSSH private/public keypair.
+- The full dangerous dry-run MCP matrix passed with a temporary OpenSSH keypair. Each case returned `dangerousAction.executed: false`, `dangerousAction.dryRun: true`, and matching sanitized args:
+  - `remove_item`
+  - `batch_remove_items`
+  - `edit_item` with task `newStatus: completed`
+  - `edit_item` with task `newStatus: dropped`
+  - `edit_item` with task `newStatus: skipped`
+  - `edit_item` with project `newProjectStatus: completed`
+  - `edit_item` with project `newProjectStatus: dropped`
+  - `batch_add_items` with 11 items
+
+## Live Cleanup Test
+
+After creating a full local OmniFocus model backup, one live destructive cleanup was performed through MCP with a valid exact grant.
+
+Removed project:
+
+```text
+TEST: OmniFocus MCP write smoke 2026-06-23T06-29-58-260Z
+```
+
+Removed project ID:
+
+```text
+iqF4214Wvsw
+```
+
+The `remove_item` call returned `dangerousAction.executed: true`, `dangerousAction.dryRun: false`, and reason:
+
+```text
+cleanup write-smoke TEST project after backup 20260623-005401
+```
+
+Post-cleanup query for tasks in the project returned:
+
+```text
+No tasks found matching the specified criteria.
+```
+
+The write-smoke tag remains because the MCP server does not currently expose tag deletion:
+
+```text
+TEST-write-smoke-2026-06-23T06-29-58-260Z
+```

--- a/evaluation-notes/grants.md
+++ b/evaluation-notes/grants.md
@@ -87,7 +87,9 @@ Future `grant_type: "pattern"` grants can reuse `allowed_tools` and `constraints
 
 ## Signing Path
 
-The current helper signs compact JWT-style grants and accepts PEM keys plus unencrypted OpenSSH keys:
+The helper supports two signer/verifier backends.
+
+The compatibility backend signs compact JWT-style grants and accepts PEM keys plus unencrypted OpenSSH keys:
 
 - Ed25519 keys sign with `EdDSA`
 - RSA keys sign with `RS256`
@@ -102,7 +104,23 @@ omnifocus-mcp-grant \
 
 The `--private-key-ref` mode uses `op read --no-newline` and keeps the private key in process memory only. This is a pragmatic v1 path for standard JWT-style signatures. The verifier accepts PEM public keys, OpenSSH `ssh-ed25519` public keys, and OpenSSH `ssh-rsa` public keys.
 
-The preferred no-export path is still worth investigating: use the 1Password SSH agent with `ssh-keygen -Y sign` so the private key never leaves 1Password. That produces an SSH signature envelope rather than a normal JOSE/JWT signature, so it should be treated as a separate signer/verifier backend.
+The no-export backend signs the same exact-operation claims with OpenSSH signatures:
+
+```sh
+omnifocus-mcp-grant \
+  --signer ssh-signature \
+  --tool remove_item \
+  --args-json '{"name":"TEST: item","itemType":"task"}' \
+  --ssh-signing-key-ref 'op://Private/SSH Key - MacBook Pro R9JG4390L4/public key' \
+  --ssh-auth-sock "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" \
+  --reason 'cleanup test data'
+```
+
+This backend emits `SSHSIG.<claims>.<signature>` tokens. The claims part is the base64url-encoded canonical JSON claims; the signature part is the base64url-encoded OpenSSH signature envelope created by `ssh-keygen -Y sign -n omnifocus-mcp-dangerous-grant`. The verifier uses `ssh-keygen -Y verify` with the configured OpenSSH public key, the fixed namespace `omnifocus-mcp-dangerous-grant`, and the fixed allowed-signers principal `omnifocus-mcp-dangerous-grant`.
+
+For `--ssh-signing-key-ref` and `--ssh-signing-key-env`, the helper expects public key material and rejects private key material. For `--ssh-signing-key-path`, the path is passed directly to `ssh-keygen`; this supports local test keys and public key identity files backed by an SSH agent. When the path/ref points at a public key identity known to the 1Password SSH agent, private key material never enters the Node process.
+
+On macOS, the default `SSH_AUTH_SOCK` may point at the Apple launchd agent instead of the 1Password agent. Use `--ssh-auth-sock` or set `SSH_AUTH_SOCK` explicitly when testing the no-export path with 1Password.
 
 ## Grant Doctor
 
@@ -114,7 +132,17 @@ omnifocus-mcp-grant doctor \
   --public-key-ref 'op://Private/SSH Key - MacBook Pro R9JG4390L4/public key'
 ```
 
-The doctor reports non-secret compatibility metadata for each key and, when both private and public keys are provided, signs and verifies a synthetic `grant_doctor` token. This would have caught an unsupported signing key before a live cleanup attempt.
+No-export SSH signature diagnostics use a public signing identity:
+
+```sh
+omnifocus-mcp-grant doctor \
+  --signer ssh-signature \
+  --ssh-signing-key-ref 'op://Private/SSH Key - MacBook Pro R9JG4390L4/public key' \
+  --ssh-auth-sock "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" \
+  --public-key-ref 'op://Private/SSH Key - MacBook Pro R9JG4390L4/public key'
+```
+
+The doctor reports non-secret compatibility metadata for each key and, when both a signer and public key are provided, signs and verifies a synthetic `grant_doctor` token. This would have caught an unsupported signing key before a live cleanup attempt.
 
 Verified with the user's 1Password key refs on 2026-06-23:
 
@@ -140,6 +168,33 @@ Verified with the user's 1Password key refs on 2026-06-23:
 }
 ```
 
+Verified with the user's 1Password public key refs and explicit 1Password SSH agent socket on 2026-06-24:
+
+```json
+{
+  "sshSigner": {
+    "supported": true,
+    "backend": "ssh-signature",
+    "noExport": true,
+    "keySource": "ref",
+    "command": "ssh-keygen -Y sign",
+    "namespace": "omnifocus-mcp-dangerous-grant",
+    "authSock": "explicit"
+  },
+  "publicKey": {
+    "supported": true,
+    "keyKind": "public",
+    "keyType": "rsa",
+    "algorithm": "RS256",
+    "format": "openssh"
+  },
+  "roundTrip": {
+    "supported": true,
+    "backend": "ssh-signature"
+  }
+}
+```
+
 ## Verified Locally
 
 - Unit tests cover canonical hashing, grant creation, signature verification, expiry, args mismatch, replay rejection, missing public-key config, policy blocking without grants, and policy allowance with valid exact grants.
@@ -150,7 +205,9 @@ Verified with the user's 1Password key refs on 2026-06-23:
 - The grant helper was smoke-tested with a temporary generated PEM Ed25519 keypair and produced a three-part compact token.
 - The grant helper and verifier were smoke-tested end-to-end with a temporary `ssh-keygen -t ed25519` OpenSSH private/public keypair.
 - Unit tests cover OpenSSH RSA private/public key signing and verification with `RS256`.
+- Unit tests cover SSH signature grant creation and verification with a temporary `ssh-keygen -t ed25519` keypair when `ssh-keygen` is available.
 - The grant doctor was smoke-tested with a temporary Ed25519 keypair and with the user's 1Password RSA key refs.
+- The no-export grant doctor was smoke-tested with the user's 1Password public key refs and explicit 1Password SSH agent socket.
 - The full dangerous dry-run MCP matrix passed with a temporary OpenSSH keypair. Each case returned `dangerousAction.executed: false`, `dangerousAction.dryRun: true`, and matching sanitized args:
   - `remove_item`
   - `batch_remove_items`

--- a/evaluation-notes/grants.md
+++ b/evaluation-notes/grants.md
@@ -104,15 +104,53 @@ The `--private-key-ref` mode uses `op read --no-newline` and keeps the private k
 
 The preferred no-export path is still worth investigating: use the 1Password SSH agent with `ssh-keygen -Y sign` so the private key never leaves 1Password. That produces an SSH signature envelope rather than a normal JOSE/JWT signature, so it should be treated as a separate signer/verifier backend.
 
+## Grant Doctor
+
+The grant helper includes a diagnostic command that performs no OmniFocus action:
+
+```sh
+omnifocus-mcp-grant doctor \
+  --private-key-ref 'op://Private/SSH Key - MacBook Pro R9JG4390L4/private key?ssh-format=openssh' \
+  --public-key-ref 'op://Private/SSH Key - MacBook Pro R9JG4390L4/public key'
+```
+
+The doctor reports non-secret compatibility metadata for each key and, when both private and public keys are provided, signs and verifies a synthetic `grant_doctor` token. This would have caught an unsupported signing key before a live cleanup attempt.
+
+Verified with the user's 1Password key refs on 2026-06-23:
+
+```json
+{
+  "privateKey": {
+    "supported": true,
+    "keyKind": "private",
+    "keyType": "rsa",
+    "algorithm": "RS256",
+    "format": "openssh"
+  },
+  "publicKey": {
+    "supported": true,
+    "keyKind": "public",
+    "keyType": "rsa",
+    "algorithm": "RS256",
+    "format": "openssh"
+  },
+  "roundTrip": {
+    "supported": true
+  }
+}
+```
+
 ## Verified Locally
 
 - Unit tests cover canonical hashing, grant creation, signature verification, expiry, args mismatch, replay rejection, missing public-key config, policy blocking without grants, and policy allowance with valid exact grants.
 - Unit tests cover dangerous audit output for both dry-run and real handler execution.
+- Unit tests cover grant key inspection for supported and unsupported key material.
 - Unit tests cover dangerous dry-run behavior: valid grants are verified, but the destructive handler is not called.
 - Build passes with the grant helper compiled to `dist/grantDangerous.js`.
 - The grant helper was smoke-tested with a temporary generated PEM Ed25519 keypair and produced a three-part compact token.
 - The grant helper and verifier were smoke-tested end-to-end with a temporary `ssh-keygen -t ed25519` OpenSSH private/public keypair.
 - Unit tests cover OpenSSH RSA private/public key signing and verification with `RS256`.
+- The grant doctor was smoke-tested with a temporary Ed25519 keypair and with the user's 1Password RSA key refs.
 - The full dangerous dry-run MCP matrix passed with a temporary OpenSSH keypair. Each case returned `dangerousAction.executed: false`, `dangerousAction.dryRun: true`, and matching sanitized args:
   - `remove_item`
   - `batch_remove_items`

--- a/evaluation-notes/reads.md
+++ b/evaluation-notes/reads.md
@@ -1,0 +1,88 @@
+# Read Evaluation Notes
+
+These notes record read-only verification performed in this fork. They are intentionally separate from `README.md` so upstream-facing product documentation stays focused on general usage.
+
+## Smoke Test
+
+Date: 2026-06-23
+
+Mode: `OMNIFOCUS_MCP_MODE` unset, which defaults to read-only.
+
+The server was launched through the actual MCP stdio protocol. It initialized successfully, advertised all 12 tools, allowed read operations, and blocked every write/destructive tool before it reached OmniFocus.
+
+## Verified Read Surfaces
+
+Tools:
+
+- `query_omnifocus`
+- `dump_database`
+- `list_tags`
+- `list_perspectives`
+- `get_perspective_view`
+
+Fixed resources:
+
+- `omnifocus://inbox`
+- `omnifocus://today`
+- `omnifocus://flagged`
+- `omnifocus://stats`
+
+Template resources:
+
+- `omnifocus://project/{name}`
+- `omnifocus://perspective/{name}`
+
+## Verified Write Blocking
+
+Ordinary writes blocked in read-only mode:
+
+- `add_omnifocus_task`
+- `add_project`
+- `edit_item`
+- `batch_add_items`
+- `create_tag`
+
+Destructive operations blocked in read-only mode:
+
+- `remove_item`
+- `batch_remove_items`
+
+## Live Data Sample
+
+Example database stats from the successful smoke test:
+
+```text
+972 total tasks
+643 active tasks
+106 projects
+97 active projects
+14 folders
+148 tags
+63 overdue tasks
+51 next actions
+8 flagged tasks
+10 inbox tasks
+```
+
+The smoke test also confirmed real read output from inbox, today, flagged, stats, perspective, project, tag, folder, project-query, and database-dump paths.
+
+## Issue Found And Fixed
+
+The read-only sweep caught a template-resource decoding bug: encoded project and perspective names with spaces were passed through literally, so a resource such as `omnifocus://project/Live%20better` returned `[]` even though `query_omnifocus` found tasks for `Live better`.
+
+Fix:
+
+- Decode template resource names before querying in `src/resources/project.ts`.
+- Decode template resource names before querying in `src/resources/perspective.ts`.
+- Add regression coverage in `src/resources/resourceDecoding.test.ts`.
+
+After the fix, `omnifocus://project/Live%20better` returned the expected project tasks through MCP read-only mode.
+
+## Verification Commands
+
+```sh
+npm test
+npm run build
+```
+
+Both commands passed after the read-only policy and resource-decoding changes.

--- a/evaluation-notes/tag-deletion.md
+++ b/evaluation-notes/tag-deletion.md
@@ -1,0 +1,100 @@
+# Tag Deletion Notes
+
+These notes track issue #1: adding a guarded way to remove OmniFocus tags.
+
+## Goal
+
+The write-mode smoke test left one test tag behind:
+
+```text
+TEST-write-smoke-2026-06-23T06-29-58-260Z
+```
+
+The server already supports `create_tag` and `list_tags`, but did not expose a tag deletion tool. Removing tags should use the same destructive-operation boundary as task/project removal.
+
+## Implemented Behavior
+
+Added `remove_tag`:
+
+- accepts `id` or exact `name`
+- prefers `id` when both are provided
+- falls back to `name` if ID lookup fails
+- is classified as `dangerous`
+- requires `OMNIFOCUS_MCP_MODE=dangerous`
+- requires a valid exact `dangerousGrant`
+- supports `OMNIFOCUS_MCP_DANGEROUS_DRY_RUN=1`
+- appends the standard `dangerousAction` audit payload on dry-run and real execution
+- supports cleanup grants signed by the user's existing 1Password OpenSSH RSA key
+
+## Local Verification
+
+Unit tests cover:
+
+- AppleScript generation for remove-by-ID and remove-by-name
+- name fallback when both ID and name are provided
+- missing identifier validation
+- AppleScript string escaping
+- policy classification as dangerous
+- blocked write-mode access
+- missing-grant blocking in dangerous mode
+- dry-run grant verification that skips the handler and returns `dangerousAction.executed: false`
+- OpenSSH RSA private/public grant signing and verification
+
+Commands run:
+
+```sh
+npm test -- src/tools/primitives/removeTag.test.ts src/tools/policy.test.ts
+npm test -- src/tools/dangerousGrant.test.ts
+npm test
+npm run build
+```
+
+Results:
+
+```text
+15 test files passed
+261 tests passed
+build passed
+```
+
+## Live Cleanup
+
+Completed on 2026-06-23 after backup `20260623-025106`.
+
+Confirmed tag before removal:
+
+```json
+{
+  "id": "iGIsJzqYKQO",
+  "name": "TEST-write-smoke-2026-06-23T06-29-58-260Z",
+  "parentTagID": null,
+  "parentName": null,
+  "active": true,
+  "allowsNextAction": true,
+  "taskCount": 0
+}
+```
+
+The first signing attempt failed safely because the user's 1Password key is `ssh-rsa` and the grant layer initially only supported Ed25519. No mutation occurred; the guarded tool returned a missing-grant error.
+
+After adding RSA/`RS256` support, the grant helper signed an exact `remove_tag` grant through:
+
+```text
+op://Private/SSH Key - MacBook Pro R9JG4390L4/private key?ssh-format=openssh
+```
+
+The live `remove_tag` call returned:
+
+```text
+Tag "TEST-write-smoke-2026-06-23T06-29-58-260Z" removed successfully.
+dangerousAction.executed: true
+dangerousAction.dryRun: false
+dangerousAction.tool: remove_tag
+dangerousAction.grant.reason: cleanup leftover write-smoke TEST tag after backup 20260623-025106
+```
+
+Post-cleanup `list_tags` verification returned:
+
+```text
+null
+```

--- a/evaluation-notes/writes.md
+++ b/evaluation-notes/writes.md
@@ -1,0 +1,56 @@
+# Write Evaluation Notes
+
+These notes record write-mode verification performed in this fork. They are intentionally separate from `README.md` so upstream-facing product documentation stays focused on general usage.
+
+## Smoke Test
+
+Date: 2026-06-23
+
+Mode: `OMNIFOCUS_MCP_MODE=write`
+
+The server was launched through the actual MCP stdio protocol. It initialized successfully, allowed ordinary write tools, and continued to block destructive operations before they reached OmniFocus.
+
+## Test Data Created
+
+The smoke test created isolated `TEST:` items so they are easy to find and clean up manually:
+
+```text
+Project: TEST: OmniFocus MCP write smoke 2026-06-23T06-29-58-260Z
+Tag: TEST-write-smoke-2026-06-23T06-29-58-260Z
+Task: TEST: write smoke task edited 2026-06-23T06-29-58-260Z
+Batch task: TEST: write smoke batch one 2026-06-23T06-29-58-260Z
+Batch task: TEST: write smoke batch two 2026-06-23T06-29-58-260Z
+```
+
+## Verified Ordinary Writes
+
+- `add_project`
+- `create_tag`
+- `add_omnifocus_task`
+- `edit_item` for non-destructive fields
+- `batch_add_items` with a small batch
+
+The query-back check found the created project and four active tasks in that project:
+
+```text
+TEST: OmniFocus MCP write smoke 2026-06-23T06-29-58-260Z
+TEST: write smoke task edited 2026-06-23T06-29-58-260Z
+TEST: write smoke batch one 2026-06-23T06-29-58-260Z
+TEST: write smoke batch two 2026-06-23T06-29-58-260Z
+```
+
+## Verified Dangerous Blocking
+
+The following remained blocked in `write` mode:
+
+- `remove_item`
+- `batch_remove_items`
+- `edit_item` with `newStatus: completed`
+- `edit_item` with `newProjectStatus: dropped`
+- `batch_add_items` with more than 10 items
+
+## Cleanup
+
+No cleanup was performed through MCP during this smoke test because removals and destructive status changes intentionally require `OMNIFOCUS_MCP_MODE=dangerous`.
+
+The test data can be removed manually in OmniFocus, or through a later dangerous-mode cleanup test after adding any desired confirmation guard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "omnifocus-mcp",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "omnifocus-mcp",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
         "zod": "^3.22.4"
       },
       "bin": {
-        "omnifocus-mcp": "cli.cjs"
+        "omnifocus-mcp": "cli.cjs",
+        "omnifocus-mcp-grant": "dist/grantDangerous.js"
       },
       "devDependencies": {
         "@types/node": "^20.11.19",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "description": "Model Context Protocol (MCP) server that integrates with OmniFocus for AI assistant interaction",
   "main": "dist/server.js",
   "bin": {
-    "omnifocus-mcp": "cli.cjs"
+    "omnifocus-mcp": "cli.cjs",
+    "omnifocus-mcp-grant": "dist/grantDangerous.js"
   },
   "files": [
     "dist",
     "cli.cjs"
   ],
   "scripts": {
-    "build": "tsc && npm run copy-files && chmod 755 dist/server.js",
+    "build": "tsc && npm run copy-files && chmod 755 dist/server.js dist/grantDangerous.js",
     "copy-files": "mkdir -p dist/utils/omnifocusScripts && cp src/utils/omnifocusScripts/*.js dist/utils/omnifocusScripts/",
     "start": "node dist/server.js",
     "dev": "tsc -w",

--- a/scripts/backup-omnifocus-db.sh
+++ b/scripts/backup-omnifocus-db.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_DIR="${OMNIFOCUS_MODEL_DIR:-$HOME/Library/Group Containers/34YW5XSRB7.com.omnigroup.OmniFocus/com.omnigroup.OmniFocus4/com.omnigroup.OmniFocusModel}"
+BACKUP_ROOT="${OMNIFOCUS_MCP_BACKUP_ROOT:-$HOME/Workspace/OmniFocus-MCP-local-backups}"
+QUIT_FIRST=0
+REOPEN=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/backup-omnifocus-db.sh [--quit] [--reopen] [--backup-root PATH]
+
+Create a timestamped copy of OmniFocus's local model directory. By default the
+script refuses to run while OmniFocus is open. Use --quit to ask OmniFocus to
+quit cleanly first. Use --reopen with --quit to open OmniFocus after the copy.
+
+Environment:
+  OMNIFOCUS_MODEL_DIR       Override the OmniFocus model directory.
+  OMNIFOCUS_MCP_BACKUP_ROOT Override the backup destination root.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quit)
+      QUIT_FIRST=1
+      shift
+      ;;
+    --reopen)
+      REOPEN=1
+      shift
+      ;;
+    --backup-root)
+      if [[ $# -lt 2 ]]; then
+        echo "--backup-root requires a path" >&2
+        exit 2
+      fi
+      BACKUP_ROOT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+is_omnifocus_running() {
+  pgrep -x "OmniFocus" >/dev/null 2>&1
+}
+
+wait_for_omnifocus_to_exit() {
+  local attempts=0
+  while is_omnifocus_running; do
+    attempts=$((attempts + 1))
+    if [[ "$attempts" -gt 60 ]]; then
+      echo "OmniFocus did not quit within 60 seconds." >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+if [[ ! -d "$MODEL_DIR" ]]; then
+  echo "OmniFocus model directory not found: $MODEL_DIR" >&2
+  exit 1
+fi
+
+if is_omnifocus_running; then
+  if [[ "$QUIT_FIRST" -ne 1 ]]; then
+    echo "OmniFocus is running. Re-run with --quit to close it before backup." >&2
+    exit 1
+  fi
+
+  osascript -e 'tell application "OmniFocus" to quit' >/dev/null
+  wait_for_omnifocus_to_exit
+fi
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+backup_dir="$BACKUP_ROOT/$timestamp"
+backup_model_dir="$backup_dir/OmniFocusModel"
+manifest="$backup_dir/manifest.txt"
+
+mkdir -p "$backup_dir"
+ditto "$MODEL_DIR" "$backup_model_dir"
+
+{
+  echo "created_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  echo "source=$MODEL_DIR"
+  echo "backup=$backup_model_dir"
+  echo "git_commit=$(git -C "$(dirname "$0")/.." rev-parse --short HEAD 2>/dev/null || true)"
+  echo
+  echo "files:"
+  find "$backup_model_dir" -maxdepth 1 -type f -print0 \
+    | sort -z \
+    | while IFS= read -r -d '' file; do
+        size="$(stat -f '%z' "$file")"
+        checksum="$(shasum -a 256 "$file" | awk '{print $1}')"
+        echo "  $(basename "$file") size=$size sha256=$checksum"
+      done
+} > "$manifest"
+
+if [[ ! -s "$backup_model_dir/OmniFocusDatabase.db" ]]; then
+  echo "Backup appears invalid: OmniFocusDatabase.db missing or empty." >&2
+  exit 1
+fi
+
+echo "Backup created: $backup_dir"
+echo "Manifest: $manifest"
+
+if [[ "$REOPEN" -eq 1 ]]; then
+  open -a "OmniFocus"
+fi

--- a/src/grantDangerous.ts
+++ b/src/grantDangerous.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'child_process';
-import { readFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import {
+  DANGEROUS_GRANT_SSH_SIGNATURE_NAMESPACE,
   createDangerousGrantToken,
   createExactDangerousGrantClaims,
+  createSshSignatureDangerousGrantToken,
   inspectDangerousGrantPrivateKey,
   inspectDangerousGrantPublicKey,
   resetDangerousGrantReplayCache,
@@ -17,12 +21,17 @@ type CliOptions = {
   privateKeyPath?: string;
   privateKeyEnv?: string;
   privateKeyRef?: string;
+  sshSigningKeyPath?: string;
+  sshSigningKeyEnv?: string;
+  sshSigningKeyRef?: string;
   publicKeyPath?: string;
   publicKeyEnv?: string;
   publicKeyRef?: string;
+  sshAuthSock?: string;
   expiresInSeconds: number;
   reason?: string;
   command: 'create' | 'doctor';
+  signer?: 'jwt' | 'ssh-signature';
 };
 
 function main(): void {
@@ -34,11 +43,10 @@ function main(): void {
   }
 
   if (!options.tool || !options.argsJson) {
-    fail('Usage: omnifocus-mcp-grant --tool <name> --args-json <json> (--private-key-ref <op-ref> | --private-key-path <path> | --private-key-env <env>) [--reason <text>] [--expires-in <seconds>]');
+    fail('Usage: omnifocus-mcp-grant --tool <name> --args-json <json> [(--private-key-ref <op-ref> | --private-key-path <path> | --private-key-env <env>) | --signer ssh-signature (--ssh-signing-key-ref <op-ref> | --ssh-signing-key-path <path> | --ssh-signing-key-env <env>)] [--reason <text>] [--expires-in <seconds>]');
   }
 
   const args = parseJsonObject(options.argsJson);
-  const privateKey = readPrivateKey(options);
   const claims = createExactDangerousGrantClaims({
     toolName: options.tool,
     args,
@@ -46,7 +54,19 @@ function main(): void {
     reason: options.reason,
   });
 
-  process.stdout.write(`${createDangerousGrantToken(claims, privateKey)}\n`);
+  const signer = selectedSigner(options);
+  if (signer === 'jwt') {
+    const privateKey = readPrivateKey(options);
+    process.stdout.write(`${createDangerousGrantToken(claims, privateKey)}\n`);
+    return;
+  }
+
+  const signingKey = resolveSshSigningKeyPath(options);
+  try {
+    process.stdout.write(`${createSshSignatureDangerousGrantToken(claims, signingKey.path, options.sshAuthSock)}\n`);
+  } finally {
+    signingKey.cleanup();
+  }
 }
 
 function parseArgs(argv: string[]): CliOptions {
@@ -87,6 +107,15 @@ function parseArgs(argv: string[]): CliOptions {
       case '--private-key-ref':
         options.privateKeyRef = next();
         break;
+      case '--ssh-signing-key-path':
+        options.sshSigningKeyPath = next();
+        break;
+      case '--ssh-signing-key-env':
+        options.sshSigningKeyEnv = next();
+        break;
+      case '--ssh-signing-key-ref':
+        options.sshSigningKeyRef = next();
+        break;
       case '--public-key-path':
         options.publicKeyPath = next();
         break;
@@ -95,6 +124,9 @@ function parseArgs(argv: string[]): CliOptions {
         break;
       case '--public-key-ref':
         options.publicKeyRef = next();
+        break;
+      case '--ssh-auth-sock':
+        options.sshAuthSock = next();
         break;
       case '--expires-in':
         options.expiresInSeconds = Number(next());
@@ -105,6 +137,14 @@ function parseArgs(argv: string[]): CliOptions {
       case '--reason':
         options.reason = next();
         break;
+      case '--signer': {
+        const value = next();
+        if (value !== 'jwt' && value !== 'ssh-signature') {
+          fail('--signer must be "jwt" or "ssh-signature".');
+        }
+        options.signer = value;
+        break;
+      }
       case '--help':
       case '-h':
         printHelp();
@@ -119,34 +159,61 @@ function parseArgs(argv: string[]): CliOptions {
 
 function runDoctor(options: CliOptions): void {
   const privateSourceCount = countKeySources(options.privateKeyPath, options.privateKeyEnv, options.privateKeyRef);
+  const sshSigningSourceCount = countKeySources(options.sshSigningKeyPath, options.sshSigningKeyEnv, options.sshSigningKeyRef);
   const publicSourceCount = countKeySources(options.publicKeyPath, options.publicKeyEnv, options.publicKeyRef);
   const hasPrivate = privateSourceCount === 1;
+  const hasSshSigningKey = sshSigningSourceCount === 1;
   const hasPublic = publicSourceCount === 1;
 
   if (privateSourceCount > 1) {
     fail('Specify at most one private key source: --private-key-ref, --private-key-path, or --private-key-env.');
   }
+  if (sshSigningSourceCount > 1) {
+    fail('Specify at most one SSH signing key source: --ssh-signing-key-ref, --ssh-signing-key-path, or --ssh-signing-key-env.');
+  }
+  if (hasPrivate && hasSshSigningKey) {
+    fail('Specify either a JWT private key source or an SSH signing key source, not both.');
+  }
   if (publicSourceCount > 1) {
     fail('Specify at most one public key source: --public-key-ref, --public-key-path, or --public-key-env.');
   }
 
-  if (!hasPrivate && !hasPublic) {
-    fail('Usage: omnifocus-mcp-grant doctor [(--private-key-ref <op-ref> | --private-key-path <path> | --private-key-env <env>)] [(--public-key-ref <op-ref> | --public-key-path <path> | --public-key-env <env>)]');
+  if (!hasPrivate && !hasSshSigningKey && !hasPublic) {
+    fail('Usage: omnifocus-mcp-grant doctor [(--private-key-ref <op-ref> | --private-key-path <path> | --private-key-env <env>) | --signer ssh-signature (--ssh-signing-key-ref <op-ref> | --ssh-signing-key-path <path> | --ssh-signing-key-env <env>)] [(--public-key-ref <op-ref> | --public-key-path <path> | --public-key-env <env>)]');
   }
 
   const privateKey = hasPrivate ? readPrivateKey(options) : undefined;
+  const sshSigningKey = hasSshSigningKey ? resolveSshSigningKeyPath(options) : undefined;
   const publicKey = hasPublic ? readPublicKey(options) : undefined;
   const privateKeyInfo = privateKey ? inspectDangerousGrantPrivateKey(privateKey) : undefined;
+  const sshSignerInfo = sshSigningKey ? {
+    supported: true,
+    backend: 'ssh-signature',
+    noExport: true,
+    keySource: sshSigningKey.source,
+    command: 'ssh-keygen -Y sign',
+    namespace: DANGEROUS_GRANT_SSH_SIGNATURE_NAMESPACE,
+    authSock: options.sshAuthSock ? 'explicit' : 'environment',
+  } : undefined;
   const publicKeyInfo = publicKey ? inspectDangerousGrantPublicKey(publicKey) : undefined;
-  const roundTrip = privateKey && publicKey
-    ? runDoctorRoundTrip(privateKey, publicKey)
-    : undefined;
+  let roundTrip: Record<string, unknown> | undefined;
 
-  process.stdout.write(`${JSON.stringify({
-    privateKey: privateKeyInfo,
-    publicKey: publicKeyInfo,
-    roundTrip,
-  }, null, 2)}\n`);
+  try {
+    roundTrip = privateKey && publicKey
+      ? runDoctorRoundTrip(privateKey, publicKey)
+      : sshSigningKey && publicKey
+        ? runDoctorSshRoundTrip(sshSigningKey.path, publicKey, options.sshAuthSock)
+        : undefined;
+
+    process.stdout.write(`${JSON.stringify({
+      privateKey: privateKeyInfo,
+      sshSigner: sshSignerInfo,
+      publicKey: publicKeyInfo,
+      roundTrip,
+    }, null, 2)}\n`);
+  } finally {
+    sshSigningKey?.cleanup();
+  }
 }
 
 function runDoctorRoundTrip(privateKey: string, publicKey: string): Record<string, unknown> {
@@ -178,6 +245,37 @@ function runDoctorRoundTrip(privateKey: string, publicKey: string): Record<strin
   }
 }
 
+function runDoctorSshRoundTrip(signingKeyPath: string, publicKey: string, sshAuthSock?: string): Record<string, unknown> {
+  const args = { doctor: true };
+  try {
+    resetDangerousGrantReplayCache();
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'grant_doctor',
+      args,
+      expiresInSeconds: 60,
+      reason: 'grant doctor SSH signature compatibility check',
+    });
+    const token = createSshSignatureDangerousGrantToken(claims, signingKeyPath, sshAuthSock);
+    const result = validateDangerousGrant(
+      'grant_doctor',
+      { ...args, dangerousGrant: token },
+      { OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY: publicKey },
+    );
+
+    return {
+      supported: result.valid,
+      backend: 'ssh-signature',
+      reason: result.reason,
+    };
+  } catch (error) {
+    return {
+      supported: false,
+      backend: 'ssh-signature',
+      reason: (error as Error).message,
+    };
+  }
+}
+
 function parseJsonObject(json: string): Record<string, unknown> {
   try {
     const value = JSON.parse(json);
@@ -201,6 +299,52 @@ function readPrivateKey(options: CliOptions): string {
     ref: options.privateKeyRef,
     envLabel: 'private',
   });
+}
+
+function selectedSigner(options: CliOptions): 'jwt' | 'ssh-signature' {
+  const privateSourceCount = countKeySources(options.privateKeyPath, options.privateKeyEnv, options.privateKeyRef);
+  const sshSigningSourceCount = countKeySources(options.sshSigningKeyPath, options.sshSigningKeyEnv, options.sshSigningKeyRef);
+
+  if (privateSourceCount > 0 && sshSigningSourceCount > 0) {
+    fail('Specify either a JWT private key source or an SSH signing key source, not both.');
+  }
+
+  const signer = options.signer ?? (sshSigningSourceCount > 0 ? 'ssh-signature' : 'jwt');
+  if (signer === 'jwt' && sshSigningSourceCount > 0) {
+    fail('--signer jwt cannot be used with --ssh-signing-key-* options.');
+  }
+  if (signer === 'ssh-signature' && privateSourceCount > 0) {
+    fail('--signer ssh-signature cannot be used with --private-key-* options.');
+  }
+
+  return signer;
+}
+
+function resolveSshSigningKeyPath(options: CliOptions): { path: string; source: 'path' | 'env' | 'ref'; cleanup: () => void } {
+  if (!hasExactlyOneKeySource(options.sshSigningKeyPath, options.sshSigningKeyEnv, options.sshSigningKeyRef)) {
+    fail('Specify exactly one SSH signing key source: --ssh-signing-key-ref, --ssh-signing-key-path, or --ssh-signing-key-env.');
+  }
+
+  if (options.sshSigningKeyPath) {
+    return { path: options.sshSigningKeyPath, source: 'path', cleanup: () => undefined };
+  }
+
+  const key = readKeyFromSource({
+    env: options.sshSigningKeyEnv,
+    ref: options.sshSigningKeyRef,
+    envLabel: 'SSH signing',
+  });
+  assertNoPrivateKeyMaterial(key, '--ssh-signing-key-ref/--ssh-signing-key-env');
+
+  const directory = mkdtempSync(join(tmpdir(), 'omnifocus-mcp-grant-signer-'));
+  const path = join(directory, 'signing-key.pub');
+  writeFileSync(path, key.endsWith('\n') ? key : `${key}\n`, { mode: 0o600 });
+
+  return {
+    path,
+    source: options.sshSigningKeyEnv ? 'env' : 'ref',
+    cleanup: () => rmSync(directory, { recursive: true, force: true }),
+  };
 }
 
 function readPublicKey(options: CliOptions): string {
@@ -253,6 +397,12 @@ function readKeyFromSource(source: {
   fail(`Missing ${source.envLabel} key source.`);
 }
 
+function assertNoPrivateKeyMaterial(value: string, label: string): void {
+  if (/-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(value)) {
+    fail(`${label} appears to contain private key material. For no-export SSH signing, point it at a public key field; for compatibility JWT signing, use --private-key-ref instead.`);
+  }
+}
+
 function hasExactlyOneKeySource(...sources: Array<string | undefined>): boolean {
   return countKeySources(...sources) === 1;
 }
@@ -271,13 +421,29 @@ Examples:
     --private-key-ref 'op://Private/SSH Key/private key?ssh-format=openssh' \\
     --reason 'cleanup test data'
 
+  omnifocus-mcp-grant \\
+    --signer ssh-signature \\
+    --tool remove_item \\
+    --args-json '{"name":"TEST: item","itemType":"task"}' \\
+    --ssh-signing-key-ref 'op://Private/SSH Key/public key' \\
+    --ssh-auth-sock "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" \\
+    --reason 'cleanup test data'
+
 The args JSON must match the destructive MCP tool arguments exactly, excluding
 the dangerousGrant field that this command creates. Ed25519 keys sign with
-EdDSA; RSA keys sign with RS256.
+EdDSA; RSA keys sign with RS256. The ssh-signature signer uses ssh-keygen -Y
+sign and can use a public key identity backed by the 1Password SSH agent, so
+private key material does not enter the Node process.
 
 Diagnostics:
   omnifocus-mcp-grant doctor \\
     --private-key-ref 'op://Private/SSH Key/private key?ssh-format=openssh' \\
+    --public-key-ref 'op://Private/SSH Key/public key'
+
+  omnifocus-mcp-grant doctor \\
+    --signer ssh-signature \\
+    --ssh-signing-key-ref 'op://Private/SSH Key/public key' \\
+    --ssh-auth-sock "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" \\
     --public-key-ref 'op://Private/SSH Key/public key'
 `);
 }

--- a/src/grantDangerous.ts
+++ b/src/grantDangerous.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
+import {
+  createDangerousGrantToken,
+  createExactDangerousGrantClaims,
+} from './tools/dangerousGrant.js';
+
+type CliOptions = {
+  tool?: string;
+  argsJson?: string;
+  privateKeyPath?: string;
+  privateKeyEnv?: string;
+  privateKeyRef?: string;
+  expiresInSeconds: number;
+  reason?: string;
+};
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (!options.tool || !options.argsJson) {
+    fail('Usage: omnifocus-mcp-grant --tool <name> --args-json <json> (--private-key-ref <op-ref> | --private-key-path <path> | --private-key-env <env>) [--reason <text>] [--expires-in <seconds>]');
+  }
+
+  const args = parseJsonObject(options.argsJson);
+  const privateKey = readPrivateKey(options);
+  const claims = createExactDangerousGrantClaims({
+    toolName: options.tool,
+    args,
+    expiresInSeconds: options.expiresInSeconds,
+    reason: options.reason,
+  });
+
+  process.stdout.write(`${createDangerousGrantToken(claims, privateKey)}\n`);
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    expiresInSeconds: 300,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      const value = argv[index + 1];
+      if (!value) {
+        fail(`Missing value for ${arg}`);
+      }
+      index += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '--tool':
+        options.tool = next();
+        break;
+      case '--args-json':
+        options.argsJson = next();
+        break;
+      case '--private-key-path':
+        options.privateKeyPath = next();
+        break;
+      case '--private-key-env':
+        options.privateKeyEnv = next();
+        break;
+      case '--private-key-ref':
+        options.privateKeyRef = next();
+        break;
+      case '--expires-in':
+        options.expiresInSeconds = Number(next());
+        if (!Number.isInteger(options.expiresInSeconds) || options.expiresInSeconds <= 0) {
+          fail('--expires-in must be a positive integer.');
+        }
+        break;
+      case '--reason':
+        options.reason = next();
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+      default:
+        fail(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function parseJsonObject(json: string): Record<string, unknown> {
+  try {
+    const value = JSON.parse(json);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      fail('--args-json must be a JSON object.');
+    }
+    return value;
+  } catch (error) {
+    fail(`Invalid --args-json: ${(error as Error).message}`);
+  }
+}
+
+function readPrivateKey(options: CliOptions): string {
+  const sources = [
+    options.privateKeyPath,
+    options.privateKeyEnv,
+    options.privateKeyRef,
+  ].filter(Boolean);
+
+  if (sources.length !== 1) {
+    fail('Specify exactly one private key source: --private-key-ref, --private-key-path, or --private-key-env.');
+  }
+
+  if (options.privateKeyPath) {
+    return readFileSync(options.privateKeyPath, 'utf-8');
+  }
+
+  if (options.privateKeyEnv) {
+    const value = process.env[options.privateKeyEnv];
+    if (!value) {
+      fail(`Environment variable ${options.privateKeyEnv} is empty or unset.`);
+    }
+    return value;
+  }
+
+  if (options.privateKeyRef) {
+    return execFileSync('op', [
+      'read',
+      '--no-newline',
+      options.privateKeyRef,
+    ], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+  }
+
+  fail('Missing private key source.');
+}
+
+function printHelp(): void {
+  process.stdout.write(`Create a short-lived dangerous-operation grant.
+
+Examples:
+  omnifocus-mcp-grant \\
+    --tool remove_item \\
+    --args-json '{"name":"TEST: item","itemType":"task"}' \\
+    --private-key-ref 'op://Private/SSH Key/private key?ssh-format=openssh' \\
+    --reason 'cleanup test data'
+
+The args JSON must match the destructive MCP tool arguments exactly, excluding
+the dangerousGrant field that this command creates.
+`);
+}
+
+function fail(message: string): never {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+main();

--- a/src/grantDangerous.ts
+++ b/src/grantDangerous.ts
@@ -5,6 +5,10 @@ import { readFileSync } from 'fs';
 import {
   createDangerousGrantToken,
   createExactDangerousGrantClaims,
+  inspectDangerousGrantPrivateKey,
+  inspectDangerousGrantPublicKey,
+  resetDangerousGrantReplayCache,
+  validateDangerousGrant,
 } from './tools/dangerousGrant.js';
 
 type CliOptions = {
@@ -13,12 +17,21 @@ type CliOptions = {
   privateKeyPath?: string;
   privateKeyEnv?: string;
   privateKeyRef?: string;
+  publicKeyPath?: string;
+  publicKeyEnv?: string;
+  publicKeyRef?: string;
   expiresInSeconds: number;
   reason?: string;
+  command: 'create' | 'doctor';
 };
 
 function main(): void {
   const options = parseArgs(process.argv.slice(2));
+
+  if (options.command === 'doctor') {
+    runDoctor(options);
+    return;
+  }
 
   if (!options.tool || !options.argsJson) {
     fail('Usage: omnifocus-mcp-grant --tool <name> --args-json <json> (--private-key-ref <op-ref> | --private-key-path <path> | --private-key-env <env>) [--reason <text>] [--expires-in <seconds>]');
@@ -38,8 +51,14 @@ function main(): void {
 
 function parseArgs(argv: string[]): CliOptions {
   const options: CliOptions = {
+    command: 'create',
     expiresInSeconds: 300,
   };
+
+  if (argv[0] === 'doctor') {
+    options.command = 'doctor';
+    argv = argv.slice(1);
+  }
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -68,6 +87,15 @@ function parseArgs(argv: string[]): CliOptions {
       case '--private-key-ref':
         options.privateKeyRef = next();
         break;
+      case '--public-key-path':
+        options.publicKeyPath = next();
+        break;
+      case '--public-key-env':
+        options.publicKeyEnv = next();
+        break;
+      case '--public-key-ref':
+        options.publicKeyRef = next();
+        break;
       case '--expires-in':
         options.expiresInSeconds = Number(next());
         if (!Number.isInteger(options.expiresInSeconds) || options.expiresInSeconds <= 0) {
@@ -89,6 +117,67 @@ function parseArgs(argv: string[]): CliOptions {
   return options;
 }
 
+function runDoctor(options: CliOptions): void {
+  const privateSourceCount = countKeySources(options.privateKeyPath, options.privateKeyEnv, options.privateKeyRef);
+  const publicSourceCount = countKeySources(options.publicKeyPath, options.publicKeyEnv, options.publicKeyRef);
+  const hasPrivate = privateSourceCount === 1;
+  const hasPublic = publicSourceCount === 1;
+
+  if (privateSourceCount > 1) {
+    fail('Specify at most one private key source: --private-key-ref, --private-key-path, or --private-key-env.');
+  }
+  if (publicSourceCount > 1) {
+    fail('Specify at most one public key source: --public-key-ref, --public-key-path, or --public-key-env.');
+  }
+
+  if (!hasPrivate && !hasPublic) {
+    fail('Usage: omnifocus-mcp-grant doctor [(--private-key-ref <op-ref> | --private-key-path <path> | --private-key-env <env>)] [(--public-key-ref <op-ref> | --public-key-path <path> | --public-key-env <env>)]');
+  }
+
+  const privateKey = hasPrivate ? readPrivateKey(options) : undefined;
+  const publicKey = hasPublic ? readPublicKey(options) : undefined;
+  const privateKeyInfo = privateKey ? inspectDangerousGrantPrivateKey(privateKey) : undefined;
+  const publicKeyInfo = publicKey ? inspectDangerousGrantPublicKey(publicKey) : undefined;
+  const roundTrip = privateKey && publicKey
+    ? runDoctorRoundTrip(privateKey, publicKey)
+    : undefined;
+
+  process.stdout.write(`${JSON.stringify({
+    privateKey: privateKeyInfo,
+    publicKey: publicKeyInfo,
+    roundTrip,
+  }, null, 2)}\n`);
+}
+
+function runDoctorRoundTrip(privateKey: string, publicKey: string): Record<string, unknown> {
+  const args = { doctor: true };
+  try {
+    resetDangerousGrantReplayCache();
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'grant_doctor',
+      args,
+      expiresInSeconds: 60,
+      reason: 'grant doctor compatibility check',
+    });
+    const token = createDangerousGrantToken(claims, privateKey);
+    const result = validateDangerousGrant(
+      'grant_doctor',
+      { ...args, dangerousGrant: token },
+      { OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY: publicKey },
+    );
+
+    return {
+      supported: result.valid,
+      reason: result.reason,
+    };
+  } catch (error) {
+    return {
+      supported: false,
+      reason: (error as Error).message,
+    };
+  }
+}
+
 function parseJsonObject(json: string): Record<string, unknown> {
   try {
     const value = JSON.parse(json);
@@ -102,40 +191,74 @@ function parseJsonObject(json: string): Record<string, unknown> {
 }
 
 function readPrivateKey(options: CliOptions): string {
-  const sources = [
-    options.privateKeyPath,
-    options.privateKeyEnv,
-    options.privateKeyRef,
-  ].filter(Boolean);
-
-  if (sources.length !== 1) {
+  if (!hasExactlyOneKeySource(options.privateKeyPath, options.privateKeyEnv, options.privateKeyRef)) {
     fail('Specify exactly one private key source: --private-key-ref, --private-key-path, or --private-key-env.');
   }
 
-  if (options.privateKeyPath) {
-    return readFileSync(options.privateKeyPath, 'utf-8');
+  return readKeyFromSource({
+    path: options.privateKeyPath,
+    env: options.privateKeyEnv,
+    ref: options.privateKeyRef,
+    envLabel: 'private',
+  });
+}
+
+function readPublicKey(options: CliOptions): string {
+  if (!hasExactlyOneKeySource(options.publicKeyPath, options.publicKeyEnv, options.publicKeyRef)) {
+    fail('Specify exactly one public key source: --public-key-ref, --public-key-path, or --public-key-env.');
   }
 
-  if (options.privateKeyEnv) {
-    const value = process.env[options.privateKeyEnv];
+  return readKeyFromSource({
+    path: options.publicKeyPath,
+    env: options.publicKeyEnv,
+    ref: options.publicKeyRef,
+    envLabel: 'public',
+  });
+}
+
+function readKeyFromSource(source: {
+  path?: string;
+  env?: string;
+  ref?: string;
+  envLabel: string;
+}): string {
+  if (source.path) {
+    return readFileSync(source.path, 'utf-8');
+  }
+
+  if (source.env) {
+    const value = process.env[source.env];
     if (!value) {
-      fail(`Environment variable ${options.privateKeyEnv} is empty or unset.`);
+      fail(`Environment variable ${source.env} is empty or unset.`);
     }
     return value;
   }
 
-  if (options.privateKeyRef) {
-    return execFileSync('op', [
-      'read',
-      '--no-newline',
-      options.privateKeyRef,
-    ], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'inherit'],
-    });
+  if (source.ref) {
+    try {
+      return execFileSync('op', [
+        'read',
+        '--no-newline',
+        source.ref,
+      ], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      const stderr = (error as { stderr?: Buffer }).stderr?.toString().trim();
+      fail(`Failed to read ${source.envLabel} key from 1Password${stderr ? `: ${stderr}` : '.'}`);
+    }
   }
 
-  fail('Missing private key source.');
+  fail(`Missing ${source.envLabel} key source.`);
+}
+
+function hasExactlyOneKeySource(...sources: Array<string | undefined>): boolean {
+  return countKeySources(...sources) === 1;
+}
+
+function countKeySources(...sources: Array<string | undefined>): number {
+  return sources.filter(Boolean).length;
 }
 
 function printHelp(): void {
@@ -151,6 +274,11 @@ Examples:
 The args JSON must match the destructive MCP tool arguments exactly, excluding
 the dangerousGrant field that this command creates. Ed25519 keys sign with
 EdDSA; RSA keys sign with RS256.
+
+Diagnostics:
+  omnifocus-mcp-grant doctor \\
+    --private-key-ref 'op://Private/SSH Key/private key?ssh-format=openssh' \\
+    --public-key-ref 'op://Private/SSH Key/public key'
 `);
 }
 

--- a/src/grantDangerous.ts
+++ b/src/grantDangerous.ts
@@ -149,7 +149,8 @@ Examples:
     --reason 'cleanup test data'
 
 The args JSON must match the destructive MCP tool arguments exactly, excluding
-the dangerousGrant field that this command creates.
+the dangerousGrant field that this command creates. Ed25519 keys sign with
+EdDSA; RSA keys sign with RS256.
 `);
 }
 

--- a/src/resources/perspective.ts
+++ b/src/resources/perspective.ts
@@ -3,9 +3,10 @@ import { Variables } from "@modelcontextprotocol/sdk/shared/uriTemplate.js";
 import { getPerspectiveView } from '../tools/primitives/getPerspectiveView.js';
 import { listPerspectives } from '../tools/primitives/listPerspectives.js';
 import { Logger } from '../utils/logger.js';
+import { decodeResourceName } from './uri.js';
 
 export async function readPerspective(uri: URL, variables: Variables, logger: Logger): Promise<ReadResourceResult> {
-  const name = String(variables.name);
+  const name = decodeResourceName(variables.name);
   logger.debug("resource:perspective", `Reading perspective: ${name}`);
 
   const result = await getPerspectiveView({ perspectiveName: name });

--- a/src/resources/project.ts
+++ b/src/resources/project.ts
@@ -2,9 +2,10 @@ import { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { Variables } from "@modelcontextprotocol/sdk/shared/uriTemplate.js";
 import { queryOmnifocus } from '../tools/primitives/queryOmnifocus.js';
 import { Logger } from '../utils/logger.js';
+import { decodeResourceName } from './uri.js';
 
 export async function readProject(uri: URL, variables: Variables, logger: Logger): Promise<ReadResourceResult> {
-  const name = String(variables.name);
+  const name = decodeResourceName(variables.name);
   logger.debug("resource:project", `Reading project: ${name}`);
 
   const result = await queryOmnifocus({

--- a/src/resources/resourceDecoding.test.ts
+++ b/src/resources/resourceDecoding.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readPerspective } from './perspective.js';
+import { readProject } from './project.js';
+import { getPerspectiveView } from '../tools/primitives/getPerspectiveView.js';
+import { queryOmnifocus } from '../tools/primitives/queryOmnifocus.js';
+
+vi.mock('../tools/primitives/getPerspectiveView.js', () => ({
+  getPerspectiveView: vi.fn(),
+}));
+
+vi.mock('../tools/primitives/queryOmnifocus.js', () => ({
+  queryOmnifocus: vi.fn(),
+}));
+
+const logger = {
+  debug: vi.fn(),
+} as any;
+
+describe('resource URI decoding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('decodes project names before querying tasks', async () => {
+    vi.mocked(queryOmnifocus).mockResolvedValue({
+      success: true,
+      items: [{ name: 'Do the thing' }],
+    } as any);
+
+    await readProject(
+      new URL('omnifocus://project/Live%20better'),
+      { name: 'Live%20better' },
+      logger
+    );
+
+    expect(queryOmnifocus).toHaveBeenCalledWith(expect.objectContaining({
+      filters: { projectName: 'Live better' },
+    }));
+  });
+
+  it('decodes perspective names before reading the perspective view', async () => {
+    vi.mocked(getPerspectiveView).mockResolvedValue({
+      success: true,
+      items: [],
+    } as any);
+
+    await readPerspective(
+      new URL('omnifocus://perspective/Top%20Bugs'),
+      { name: 'Top%20Bugs' },
+      logger
+    );
+
+    expect(getPerspectiveView).toHaveBeenCalledWith({
+      perspectiveName: 'Top Bugs',
+    });
+  });
+});

--- a/src/resources/uri.ts
+++ b/src/resources/uri.ts
@@ -1,0 +1,9 @@
+export function decodeResourceName(value: unknown): string {
+  const name = String(value);
+
+  try {
+    return decodeURIComponent(name);
+  } catch {
+    return name;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { SetLevelRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { Logger } from './utils/logger.js';
 import { setScriptLogger } from './utils/scriptExecution.js';
 import { registerResources } from './resources/index.js';
+import { getOmniFocusMcpMode, guardToolHandler } from './tools/policy.js';
 
 // Import tool definitions
 import * as dumpDatabaseTool from './tools/definitions/dumpDatabase.js';
@@ -37,6 +38,8 @@ const server = new McpServer(
     instructions: `OmniFocus MCP server for macOS task management.
 
 TOOL GUIDANCE:
+- Safety mode defaults to read-only; set OMNIFOCUS_MCP_MODE=write for ordinary writes
+- Destructive operations require OMNIFOCUS_MCP_MODE=dangerous plus a fresh signed dangerousGrant bound to the exact tool arguments
 - Prefer query_omnifocus over dump_database for targeted lookups (85-95% context savings)
 - Use the "fields" parameter to request only needed fields
 - Use "summary: true" for quick counts without full data
@@ -81,85 +84,87 @@ server.tool(
   "dump_database",
   "Gets the current state of your OmniFocus database",
   dumpDatabaseTool.schema.shape,
-  dumpDatabaseTool.handler
+  guardToolHandler("dump_database", dumpDatabaseTool.handler)
 );
 
 server.tool(
   "add_omnifocus_task",
   "Create a NEW task in OmniFocus. Use this ONLY when the task does not already exist. If a matching task already exists (e.g. an item already in the Inbox, or one referenced earlier in the conversation) and the goal is to file/place/move it into a project or the inbox, do NOT create a duplicate here — use edit_item with newProjectName to MOVE the existing task instead. When unsure whether a matching task already exists, search with query_omnifocus first and prefer moving over creating.",
   addOmniFocusTaskTool.schema.shape,
-  addOmniFocusTaskTool.handler
+  guardToolHandler("add_omnifocus_task", addOmniFocusTaskTool.handler)
 );
 
 server.tool(
   "add_project",
   "Add a new project to OmniFocus",
   addProjectTool.schema.shape,
-  addProjectTool.handler
+  guardToolHandler("add_project", addProjectTool.handler)
 );
 
 server.tool(
   "remove_item",
   "Remove a task or project from OmniFocus",
   removeItemTool.schema.shape,
-  removeItemTool.handler
+  guardToolHandler("remove_item", removeItemTool.handler)
 );
 
 server.tool(
   "edit_item",
   "Edit an existing task or project in OmniFocus. This is also how you MOVE/reassign an existing task: set newProjectName to a project name/path to move it into that project, or to \"\" / \"inbox\" to move it to the inbox. Whenever a task already exists, prefer moving it with this tool over creating a new one via add_omnifocus_task, so you never create duplicates.",
   editItemTool.schema.shape,
-  editItemTool.handler
+  guardToolHandler("edit_item", editItemTool.handler)
 );
 
 server.tool(
   "batch_add_items",
   "Add multiple tasks or projects to OmniFocus in a single operation",
   batchAddItemsTool.schema.shape,
-  batchAddItemsTool.handler
+  guardToolHandler("batch_add_items", batchAddItemsTool.handler)
 );
 
 server.tool(
   "batch_remove_items",
   "Remove multiple tasks or projects from OmniFocus in a single operation",
   batchRemoveItemsTool.schema.shape,
-  batchRemoveItemsTool.handler
+  guardToolHandler("batch_remove_items", batchRemoveItemsTool.handler)
 );
 
 server.tool(
   "query_omnifocus",
   "Efficiently query OmniFocus database with powerful filters. Get specific tasks, projects, or folders without loading the entire database. Supports filtering by project, tags, status, due dates, and more. Much faster than dump_database for targeted queries.",
   queryOmniFocusTool.schema.shape,
-  queryOmniFocusTool.handler
+  guardToolHandler("query_omnifocus", queryOmniFocusTool.handler)
 );
 
 server.tool(
   "list_perspectives",
   "List all available perspectives in OmniFocus, including built-in perspectives (Inbox, Projects, Tags, etc.) and custom perspectives (Pro feature)",
   listPerspectivesTool.schema.shape,
-  listPerspectivesTool.handler
+  guardToolHandler("list_perspectives", listPerspectivesTool.handler)
 );
 
 server.tool(
   "get_perspective_view",
   "Get the items visible in a specific OmniFocus perspective. Shows what tasks and projects are displayed when viewing that perspective",
   getPerspectiveViewTool.schema.shape,
-  getPerspectiveViewTool.handler
+  guardToolHandler("get_perspective_view", getPerspectiveViewTool.handler)
 );
 
 server.tool(
   "list_tags",
   "List all tags in OmniFocus with their hierarchy. Useful for discovering available tags before creating or editing tasks.",
   listTagsTool.schema.shape,
-  listTagsTool.handler
+  guardToolHandler("list_tags", listTagsTool.handler)
 );
 
 server.tool(
   "create_tag",
   "Create a new tag in OmniFocus, optionally nested under an existing parent tag",
   createTagTool.schema.shape,
-  createTagTool.handler
+  guardToolHandler("create_tag", createTagTool.handler)
 );
+
+logger.info("server", `OmniFocus MCP safety mode: ${getOmniFocusMcpMode()}`);
 
 // Start the MCP server
 const transport = new StdioServerTransport();

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import * as dumpDatabaseTool from './tools/definitions/dumpDatabase.js';
 import * as addOmniFocusTaskTool from './tools/definitions/addOmniFocusTask.js';
 import * as addProjectTool from './tools/definitions/addProject.js';
 import * as removeItemTool from './tools/definitions/removeItem.js';
+import * as removeTagTool from './tools/definitions/removeTag.js';
 import * as editItemTool from './tools/definitions/editItem.js';
 import * as batchAddItemsTool from './tools/definitions/batchAddItems.js';
 import * as batchRemoveItemsTool from './tools/definitions/batchRemoveItems.js';
@@ -106,6 +107,13 @@ server.tool(
   "Remove a task or project from OmniFocus",
   removeItemTool.schema.shape,
   guardToolHandler("remove_item", removeItemTool.handler)
+);
+
+server.tool(
+  "remove_tag",
+  "Remove a tag from OmniFocus by ID or exact name",
+  removeTagTool.schema.shape,
+  guardToolHandler("remove_tag", removeTagTool.handler)
 );
 
 server.tool(

--- a/src/tools/dangerousGrant.test.ts
+++ b/src/tools/dangerousGrant.test.ts
@@ -5,6 +5,8 @@ import {
   createDangerousGrantToken,
   createExactDangerousGrantClaims,
   dangerousArgsHash,
+  inspectDangerousGrantPrivateKey,
+  inspectDangerousGrantPublicKey,
   resetDangerousGrantReplayCache,
   validateDangerousGrant,
 } from './dangerousGrant.js';
@@ -12,6 +14,11 @@ import {
 const { privateKey, publicKey } = generateKeyPairSync('ed25519');
 const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
 const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+const { privateKey: ecPrivateKey, publicKey: ecPublicKey } = generateKeyPairSync('ec', {
+  namedCurve: 'P-256',
+});
+const ecPrivateKeyPem = ecPrivateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+const ecPublicKeyPem = ecPublicKey.export({ type: 'spki', format: 'pem' }).toString();
 const env = {
   OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY: publicKeyPem,
 };
@@ -130,6 +137,51 @@ describe('dangerous grants', () => {
 
     expect(token.startsWith('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.')).toBe(true);
     expect(result.valid).toBe(true);
+  });
+
+  it('inspects supported private and public key algorithms', () => {
+    expect(inspectDangerousGrantPrivateKey(openSshPrivateKey)).toMatchObject({
+      supported: true,
+      keyKind: 'private',
+      keyType: 'ed25519',
+      algorithm: 'EdDSA',
+      format: 'openssh',
+    });
+    expect(inspectDangerousGrantPublicKey(openSshRsaPublicKey)).toMatchObject({
+      supported: true,
+      keyKind: 'public',
+      keyType: 'rsa',
+      algorithm: 'RS256',
+      format: 'openssh',
+    });
+  });
+
+  it('reports unsupported key material without exposing it', () => {
+    expect(inspectDangerousGrantPrivateKey('not a key')).toMatchObject({
+      supported: false,
+      keyKind: 'private',
+      reason: 'Unsupported private key format.',
+    });
+    expect(inspectDangerousGrantPublicKey('not a key')).toMatchObject({
+      supported: false,
+      keyKind: 'public',
+      reason: 'Unsupported public key format.',
+    });
+  });
+
+  it('reports unsupported PEM key algorithms', () => {
+    expect(inspectDangerousGrantPrivateKey(ecPrivateKeyPem)).toMatchObject({
+      supported: false,
+      keyKind: 'private',
+      format: 'pem',
+      reason: 'Unsupported private key format.',
+    });
+    expect(inspectDangerousGrantPublicKey(ecPublicKeyPem)).toMatchObject({
+      supported: false,
+      keyKind: 'public',
+      format: 'pem',
+      reason: 'Unsupported public key format.',
+    });
   });
 
   it('rejects missing grants', () => {

--- a/src/tools/dangerousGrant.test.ts
+++ b/src/tools/dangerousGrant.test.ts
@@ -1,9 +1,14 @@
+import { execFileSync } from 'child_process';
 import { generateKeyPairSync } from 'crypto';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   canonicalJson,
   createDangerousGrantToken,
   createExactDangerousGrantClaims,
+  createSshSignatureDangerousGrantToken,
   dangerousArgsHash,
   inspectDangerousGrantPrivateKey,
   inspectDangerousGrantPublicKey,
@@ -58,6 +63,14 @@ PqeC6OJEtNEWUrhlxLozraeIGezwaYxqgovgLhyEfXcHhpXKSyBj/XfsqSEAdZDnrtI7Oo
 2X9FI415GFeTn+cAAAAab21uaWZvY3VzLW1jcC1yc2EtdGVzdC1rZXkB
 -----END OPENSSH PRIVATE KEY-----`;
 const openSshRsaPublicKey = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDvk3e+fiM19gOV1Y83NeR7UbLlAijonrAEG3m8gyA9sa+0jXTmfDtieplUtU73kCm5TC1YzEn9U6WyZEf68ncl90SJyojQ6xGMuWBX15iBntJFYHZ9IFyQqdXFo/sq1igtqe1kRQjXgQibZbdblNUH08egtxh6o4ltSLkAtQP656llbsUgsPwq4XyZK02qGhw/D7G/YyO/X5ab3oaMVSyynAU190nbuTP0FSXfZ7CGsPcufvuJf1dxFxqNe3ylfpJzKMIaS5litgr99ZMNSOfxOv8+ZluNumNZNnFiUyVR42bnZ+AOuH4qZG1Prwqc2G20WV16RhVMvWi6rXkTBMnl omnifocus-mcp-rsa-test-key';
+const sshKeygenAvailable = (() => {
+  try {
+    execFileSync('ssh-keygen', ['-Y', 'check-novalidate'], { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ENOENT';
+  }
+})();
 
 describe('dangerous grants', () => {
   beforeEach(() => {
@@ -137,6 +150,49 @@ describe('dangerous grants', () => {
 
     expect(token.startsWith('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.')).toBe(true);
     expect(result.valid).toBe(true);
+  });
+
+  (sshKeygenAvailable ? it : it.skip)('supports SSH signature grants created by ssh-keygen', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omnifocus-mcp-grant-test-'));
+    const keyPath = join(directory, 'id_ed25519');
+
+    try {
+      execFileSync('ssh-keygen', [
+        '-q',
+        '-t',
+        'ed25519',
+        '-N',
+        '',
+        '-C',
+        'omnifocus-mcp-sshsig-test',
+        '-f',
+        keyPath,
+      ]);
+
+      const publicKey = readFileSync(`${keyPath}.pub`, 'utf-8');
+      const args = { name: 'TEST: remove me', itemType: 'task' };
+      const claims = createExactDangerousGrantClaims({
+        toolName: 'remove_item',
+        args,
+        nowSeconds: 100,
+        expiresInSeconds: 60,
+        jti: 'sshsig-grant-1',
+      });
+      const token = createSshSignatureDangerousGrantToken(claims, keyPath);
+
+      const result = validateDangerousGrant(
+        'remove_item',
+        { ...args, dangerousGrant: token },
+        { OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY: publicKey },
+        120
+      );
+
+      expect(token.startsWith('SSHSIG.')).toBe(true);
+      expect(result.valid).toBe(true);
+      expect(result.claims?.operation?.args_sha256).toBe(dangerousArgsHash(args));
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it('inspects supported private and public key algorithms', () => {

--- a/src/tools/dangerousGrant.test.ts
+++ b/src/tools/dangerousGrant.test.ts
@@ -1,0 +1,176 @@
+import { generateKeyPairSync } from 'crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  canonicalJson,
+  createDangerousGrantToken,
+  createExactDangerousGrantClaims,
+  dangerousArgsHash,
+  resetDangerousGrantReplayCache,
+  validateDangerousGrant,
+} from './dangerousGrant.js';
+
+const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+const env = {
+  OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY: publicKeyPem,
+};
+const openSshPrivateKey = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACBsUwngrKIL8LLOe5Z4s3IxgGEXCoMeDFh4Hyfsp8vQcwAAAKCcPGQ8nDxk
+PAAAAAtzc2gtZWQyNTUxOQAAACBsUwngrKIL8LLOe5Z4s3IxgGEXCoMeDFh4Hyfsp8vQcw
+AAAECUNj9uL/QwAt2inp9C3vTQqhbGwjV3sWFXVKuTyK63GWxTCeCsogvwss57lnizcjGA
+YRcKgx4MWHgfJ+yny9BzAAAAFm9tbmlmb2N1cy1tY3AtdGVzdC1rZXkBAgMEBQYH
+-----END OPENSSH PRIVATE KEY-----`;
+const openSshPublicKey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGxTCeCsogvwss57lnizcjGAYRcKgx4MWHgfJ+yny9Bz omnifocus-mcp-test-key';
+
+describe('dangerous grants', () => {
+  beforeEach(() => {
+    resetDangerousGrantReplayCache();
+  });
+
+  it('canonicalizes object keys before hashing args', () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: 3 } })).toBe('{"a":{"c":3,"d":2},"b":1}');
+    expect(dangerousArgsHash({ b: 1, a: 2 })).toBe(dangerousArgsHash({ a: 2, b: 1 }));
+  });
+
+  it('excludes dangerousGrant from the args hash', () => {
+    expect(dangerousArgsHash({ name: 'A', dangerousGrant: 'one' }))
+      .toBe(dangerousArgsHash({ name: 'A', dangerousGrant: 'two' }));
+  });
+
+  it('validates a fresh exact grant for the matching tool and args', () => {
+    const args = { name: 'TEST: remove me', itemType: 'task' };
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'remove_item',
+      args,
+      nowSeconds: 100,
+      expiresInSeconds: 60,
+      jti: 'grant-1',
+    });
+    const token = createDangerousGrantToken(claims, privateKeyPem);
+
+    const result = validateDangerousGrant(
+      'remove_item',
+      { ...args, dangerousGrant: token },
+      env,
+      120
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.claims?.operation?.args_sha256).toBe(dangerousArgsHash(args));
+  });
+
+  it('supports OpenSSH Ed25519 private and public keys', () => {
+    const args = { name: 'TEST: remove me', itemType: 'task' };
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'remove_item',
+      args,
+      nowSeconds: 100,
+      expiresInSeconds: 60,
+      jti: 'openssh-grant-1',
+    });
+    const token = createDangerousGrantToken(claims, openSshPrivateKey);
+
+    const result = validateDangerousGrant(
+      'remove_item',
+      { ...args, dangerousGrant: token },
+      { OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY: openSshPublicKey },
+      120
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects missing grants', () => {
+    const result = validateDangerousGrant('remove_item', { name: 'A' }, env, 100);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Missing dangerousGrant');
+  });
+
+  it('rejects expired grants', () => {
+    const args = { name: 'TEST: remove me', itemType: 'task' };
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'remove_item',
+      args,
+      nowSeconds: 100,
+      expiresInSeconds: 60,
+      jti: 'grant-2',
+    });
+    const token = createDangerousGrantToken(claims, privateKeyPem);
+
+    const result = validateDangerousGrant(
+      'remove_item',
+      { ...args, dangerousGrant: token },
+      env,
+      161
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('expired');
+  });
+
+  it('rejects grants for different args', () => {
+    const args = { name: 'TEST: remove me', itemType: 'task' };
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'remove_item',
+      args,
+      nowSeconds: 100,
+      expiresInSeconds: 60,
+      jti: 'grant-3',
+    });
+    const token = createDangerousGrantToken(claims, privateKeyPem);
+
+    const result = validateDangerousGrant(
+      'remove_item',
+      { name: 'Different', itemType: 'task', dangerousGrant: token },
+      env,
+      120
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('args hash');
+  });
+
+  it('rejects replayed grants', () => {
+    const args = { name: 'TEST: remove me', itemType: 'task' };
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'remove_item',
+      args,
+      nowSeconds: 100,
+      expiresInSeconds: 60,
+      jti: 'grant-4',
+    });
+    const token = createDangerousGrantToken(claims, privateKeyPem);
+
+    expect(validateDangerousGrant('remove_item', { ...args, dangerousGrant: token }, env, 120).valid)
+      .toBe(true);
+    const replay = validateDangerousGrant('remove_item', { ...args, dangerousGrant: token }, env, 120);
+
+    expect(replay.valid).toBe(false);
+    expect(replay.reason).toContain('already been used');
+  });
+
+  it('rejects grants when no public key is configured', () => {
+    const args = { name: 'TEST: remove me', itemType: 'task' };
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'remove_item',
+      args,
+      nowSeconds: 100,
+      expiresInSeconds: 60,
+      jti: 'grant-5',
+    });
+    const token = createDangerousGrantToken(claims, privateKeyPem);
+
+    const result = validateDangerousGrant(
+      'remove_item',
+      { ...args, dangerousGrant: token },
+      {},
+      120
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Missing OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY');
+  });
+});

--- a/src/tools/dangerousGrant.test.ts
+++ b/src/tools/dangerousGrant.test.ts
@@ -23,6 +23,34 @@ AAAECUNj9uL/QwAt2inp9C3vTQqhbGwjV3sWFXVKuTyK63GWxTCeCsogvwss57lnizcjGA
 YRcKgx4MWHgfJ+yny9BzAAAAFm9tbmlmb2N1cy1tY3AtdGVzdC1rZXkBAgMEBQYH
 -----END OPENSSH PRIVATE KEY-----`;
 const openSshPublicKey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGxTCeCsogvwss57lnizcjGAYRcKgx4MWHgfJ+yny9Bz omnifocus-mcp-test-key';
+const openSshRsaPrivateKey = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
+NhAAAAAwEAAQAAAQEA75N3vn4jNfYDldWPNzXke1Gy5QIo6J6wBBt5vIMgPbGvtI105nw7
+YnqZVLVO95ApuUwtWMxJ/VOlsmRH+vJ3JfdEicqI0OsRjLlgV9eYgZ7SRWB2fSBckKnVxa
+P7KtYoLantZEUI14EIm2W3W5TVB9PHoLcYeqOJbUi5ALUD+uepZW7FILD8KuF8mStNqhoc
+Pw+xv2Mjv1+Wm96GjFUsspwFNfdJ27kz9BUl32ewhrD3Ln77iX9XcRcajXt8pX6ScyjCGk
+uZYrYK/fWTDUjn8Tr/PmZbjbpjWTZxYlMlUeNm52fgDrh+KmRtT68KnNhttFldekYVTL1o
+uq15EwTJ5QAAA9BDL9z4Qy/c+AAAAAdzc2gtcnNhAAABAQDvk3e+fiM19gOV1Y83NeR7Ub
+LlAijonrAEG3m8gyA9sa+0jXTmfDtieplUtU73kCm5TC1YzEn9U6WyZEf68ncl90SJyojQ
+6xGMuWBX15iBntJFYHZ9IFyQqdXFo/sq1igtqe1kRQjXgQibZbdblNUH08egtxh6o4ltSL
+kAtQP656llbsUgsPwq4XyZK02qGhw/D7G/YyO/X5ab3oaMVSyynAU190nbuTP0FSXfZ7CG
+sPcufvuJf1dxFxqNe3ylfpJzKMIaS5litgr99ZMNSOfxOv8+ZluNumNZNnFiUyVR42bnZ+
+AOuH4qZG1Prwqc2G20WV16RhVMvWi6rXkTBMnlAAAAAwEAAQAAAQAbMaMC9XBrvJwVkuMp
+wi1ILjLfOcqI9RJHtRKxajTrq9Kk7PWa//kBqabj7ZykDzIdPV9cV/wCDE+fmzBsdL8/iP
+y3o0y6YiRg093yup8t/2ggxd1NQLIhHZYNVBq7dwmifUpb+lYRmCzw7q/Mbm1r8QcU4BOg
+QBXmWL3fLazg+tiJzs6yns7j2vt5odXupHz3+MUzFaCaDAytrHMUV1N0257EW3+i/jzt8D
+uW5vKmphrOWycB9MLLUgkzq3/TYSWlKkEEKANAi7mLvJSq07so/iU5yNoRi+KXb+MZ+HXd
+N4IFu6zMH7nzN7M0DzldtEm8Z2sqLgNE6hx3n0H8fUsVAAAAgGfXHGKFVPfu8IugYbaaG/
+wBhDBW4dCFYDxojo4tqMC/jQsKVu74zyRsQq2loWIGJXSm0QR4HiDm4e79Fg5DsZjXgxoI
+PU6Xls7/j3DoUJG7A6ZKxqvD/zWOZTiQ+2IaR9/9ImjwSgZRK2q8gWFSYIVLwlCjry2U96
+r3zpg4iOOPAAAAgQD+3RgBElCHR4hGaMZIqhYkzC1USRCnRWDi2QTS47QP+ciilNavNk1g
+30Yqu9QAZGJBli/iyXZlYLfR3iM9z+GMITkwebGSHfMJpuTyYrhOA3PBe7OPVgZ0jgEfDo
+SbKo3u44cdl6OhjuK+ayaiYqWONX6MYaPBtP0pNTKrsWI+UwAAAIEA8KTspwf1YSV+vsEF
+0CjH3C17U3P0Is6Pa1SwcuZ0ueF/4JUkdWTmlEVk+FjLsZffF3NIIfgaIFjRYVW+Md1kRs
+PqeC6OJEtNEWUrhlxLozraeIGezwaYxqgovgLhyEfXcHhpXKSyBj/XfsqSEAdZDnrtI7Oo
+2X9FI415GFeTn+cAAAAab21uaWZvY3VzLW1jcC1yc2EtdGVzdC1rZXkB
+-----END OPENSSH PRIVATE KEY-----`;
+const openSshRsaPublicKey = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDvk3e+fiM19gOV1Y83NeR7UbLlAijonrAEG3m8gyA9sa+0jXTmfDtieplUtU73kCm5TC1YzEn9U6WyZEf68ncl90SJyojQ6xGMuWBX15iBntJFYHZ9IFyQqdXFo/sq1igtqe1kRQjXgQibZbdblNUH08egtxh6o4ltSLkAtQP656llbsUgsPwq4XyZK02qGhw/D7G/YyO/X5ab3oaMVSyynAU190nbuTP0FSXfZ7CGsPcufvuJf1dxFxqNe3ylfpJzKMIaS5litgr99ZMNSOfxOv8+ZluNumNZNnFiUyVR42bnZ+AOuH4qZG1Prwqc2G20WV16RhVMvWi6rXkTBMnl omnifocus-mcp-rsa-test-key';
 
 describe('dangerous grants', () => {
   beforeEach(() => {
@@ -79,6 +107,28 @@ describe('dangerous grants', () => {
       120
     );
 
+    expect(result.valid).toBe(true);
+  });
+
+  it('supports OpenSSH RSA private and public keys', () => {
+    const args = { name: 'TEST: remove me', itemType: 'task' };
+    const claims = createExactDangerousGrantClaims({
+      toolName: 'remove_item',
+      args,
+      nowSeconds: 100,
+      expiresInSeconds: 60,
+      jti: 'openssh-rsa-grant-1',
+    });
+    const token = createDangerousGrantToken(claims, openSshRsaPrivateKey);
+
+    const result = validateDangerousGrant(
+      'remove_item',
+      { ...args, dangerousGrant: token },
+      { OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY: openSshRsaPublicKey },
+      120
+    );
+
+    expect(token.startsWith('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.')).toBe(true);
     expect(result.valid).toBe(true);
   });
 

--- a/src/tools/dangerousGrant.ts
+++ b/src/tools/dangerousGrant.ts
@@ -1,0 +1,409 @@
+import { JsonWebKey, KeyObject, createHash, createPrivateKey, createPublicKey, randomUUID, sign, verify } from 'crypto';
+import { readFileSync } from 'fs';
+
+export const DANGEROUS_GRANT_AUDIENCE = 'omnifocus-mcp-dangerous-grant';
+export const DANGEROUS_GRANT_ISSUER = 'omnifocus-mcp';
+
+export type DangerousGrantType = 'exact' | 'pattern';
+
+export type DangerousGrantClaims = {
+  iss: string;
+  aud: string;
+  sub?: string;
+  iat: number;
+  nbf?: number;
+  exp: number;
+  jti: string;
+  grant_version: number;
+  grant_type: DangerousGrantType;
+  scope: 'dangerous' | 'write';
+  allowed_tools: string[];
+  operation?: {
+    tool: string;
+    args_sha256: string;
+  };
+  constraints?: {
+    name_prefix?: string;
+    max_operations?: number;
+    allow_completed?: boolean;
+  };
+  reason?: string;
+};
+
+export type DangerousGrantValidationResult = {
+  valid: boolean;
+  reason?: string;
+  claims?: DangerousGrantClaims;
+};
+
+type DangerousGrantHeader = {
+  typ: 'JWT';
+  alg: 'EdDSA';
+};
+
+const usedGrantIds = new Set<string>();
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function dangerousArgsHash(args: Record<string, unknown>): string {
+  const { dangerousGrant, ...grantlessArgs } = args;
+  return createHash('sha256')
+    .update(canonicalJson(grantlessArgs))
+    .digest('hex');
+}
+
+export function resetDangerousGrantReplayCache(): void {
+  usedGrantIds.clear();
+}
+
+export function createDangerousGrantToken(
+  claims: DangerousGrantClaims,
+  privateKeyPem: string
+): string {
+  const header: DangerousGrantHeader = {
+    typ: 'JWT',
+    alg: 'EdDSA',
+  };
+  const signingInput = [
+    base64UrlEncode(JSON.stringify(header)),
+    base64UrlEncode(JSON.stringify(claims)),
+  ].join('.');
+  const signature = sign(null, Buffer.from(signingInput), createSigningPrivateKey(privateKeyPem));
+
+  return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
+export function createExactDangerousGrantClaims(params: {
+  toolName: string;
+  args: Record<string, unknown>;
+  expiresInSeconds?: number;
+  reason?: string;
+  nowSeconds?: number;
+  jti?: string;
+}): DangerousGrantClaims {
+  const now = params.nowSeconds ?? Math.floor(Date.now() / 1000);
+
+  return {
+    iss: DANGEROUS_GRANT_ISSUER,
+    aud: DANGEROUS_GRANT_AUDIENCE,
+    sub: 'user-approved-operation',
+    iat: now,
+    nbf: now,
+    exp: now + (params.expiresInSeconds ?? 300),
+    jti: params.jti ?? randomUUID(),
+    grant_version: 1,
+    grant_type: 'exact',
+    scope: 'dangerous',
+    allowed_tools: [params.toolName],
+    operation: {
+      tool: params.toolName,
+      args_sha256: dangerousArgsHash(params.args),
+    },
+    constraints: {
+      max_operations: 1,
+    },
+    reason: params.reason,
+  };
+}
+
+export function validateDangerousGrant(
+  toolName: string,
+  args: Record<string, unknown>,
+  env = process.env,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): DangerousGrantValidationResult {
+  const token = args.dangerousGrant;
+  if (typeof token !== 'string' || token.length === 0) {
+    return { valid: false, reason: 'Missing dangerousGrant for destructive operation.' };
+  }
+
+  const publicKey = readDangerousGrantPublicKey(env);
+  if (!publicKey) {
+    return {
+      valid: false,
+      reason: 'Missing OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY or OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY_PATH.',
+    };
+  }
+
+  const parsed = parseDangerousGrant(token);
+  if (!parsed.valid || !parsed.header || !parsed.claims || !parsed.signature || !parsed.signingInput) {
+    return { valid: false, reason: parsed.reason };
+  }
+
+  if (parsed.header.typ !== 'JWT' || parsed.header.alg !== 'EdDSA') {
+    return { valid: false, reason: 'Unsupported dangerous grant header.' };
+  }
+
+  let signatureValid = false;
+  try {
+    signatureValid = verify(
+      null,
+      Buffer.from(parsed.signingInput),
+      createVerificationPublicKey(publicKey),
+      parsed.signature
+    );
+  } catch {
+    return { valid: false, reason: 'Dangerous grant public key is invalid.' };
+  }
+
+  if (!signatureValid) {
+    return { valid: false, reason: 'Dangerous grant signature is invalid.' };
+  }
+
+  return validateDangerousGrantClaims(parsed.claims, toolName, args, nowSeconds);
+}
+
+function validateDangerousGrantClaims(
+  claims: DangerousGrantClaims,
+  toolName: string,
+  args: Record<string, unknown>,
+  nowSeconds: number
+): DangerousGrantValidationResult {
+  if (claims.iss !== DANGEROUS_GRANT_ISSUER) {
+    return { valid: false, reason: 'Dangerous grant issuer is invalid.' };
+  }
+  if (claims.aud !== DANGEROUS_GRANT_AUDIENCE) {
+    return { valid: false, reason: 'Dangerous grant audience is invalid.' };
+  }
+  if (claims.grant_version !== 1) {
+    return { valid: false, reason: 'Dangerous grant version is unsupported.' };
+  }
+  if (claims.grant_type !== 'exact') {
+    return { valid: false, reason: 'Only exact dangerous grants are supported.' };
+  }
+  if (claims.scope !== 'dangerous') {
+    return { valid: false, reason: 'Dangerous grant scope is invalid.' };
+  }
+  if (!Array.isArray(claims.allowed_tools) || !claims.allowed_tools.includes(toolName)) {
+    return { valid: false, reason: `Dangerous grant does not allow tool "${toolName}".` };
+  }
+  if (!claims.operation || claims.operation.tool !== toolName) {
+    return { valid: false, reason: 'Dangerous grant operation tool does not match.' };
+  }
+  if (claims.operation.args_sha256 !== dangerousArgsHash(args)) {
+    return { valid: false, reason: 'Dangerous grant args hash does not match.' };
+  }
+  if (claims.nbf !== undefined && nowSeconds < claims.nbf) {
+    return { valid: false, reason: 'Dangerous grant is not active yet.' };
+  }
+  if (nowSeconds >= claims.exp) {
+    return { valid: false, reason: 'Dangerous grant has expired.' };
+  }
+  if (claims.constraints?.max_operations !== undefined && claims.constraints.max_operations !== 1) {
+    return { valid: false, reason: 'Exact dangerous grants must allow exactly one operation.' };
+  }
+  if (usedGrantIds.has(claims.jti)) {
+    return { valid: false, reason: 'Dangerous grant has already been used.' };
+  }
+
+  usedGrantIds.add(claims.jti);
+  return { valid: true, claims };
+}
+
+function parseDangerousGrant(token: string): {
+  valid: boolean;
+  reason?: string;
+  header?: DangerousGrantHeader;
+  claims?: DangerousGrantClaims;
+  signature?: Buffer;
+  signingInput?: string;
+} {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return { valid: false, reason: 'Dangerous grant must have three JWT parts.' };
+  }
+
+  try {
+    const [encodedHeader, encodedClaims, encodedSignature] = parts;
+    return {
+      valid: true,
+      header: JSON.parse(base64UrlDecodeToString(encodedHeader)),
+      claims: JSON.parse(base64UrlDecodeToString(encodedClaims)),
+      signature: base64UrlDecode(encodedSignature),
+      signingInput: `${encodedHeader}.${encodedClaims}`,
+    };
+  } catch {
+    return { valid: false, reason: 'Dangerous grant is not valid JSON/base64url.' };
+  }
+}
+
+function readDangerousGrantPublicKey(env: NodeJS.ProcessEnv): string | undefined {
+  if (env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY) {
+    return env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY;
+  }
+
+  if (env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY_PATH) {
+    return readFileSync(env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY_PATH, 'utf-8');
+  }
+
+  return undefined;
+}
+
+function createSigningPrivateKey(key: string): KeyObject {
+  try {
+    return createPrivateKey(key);
+  } catch {
+    const jwk = parseOpenSshEd25519PrivateKey(key);
+    if (!jwk) {
+      throw new Error('Unsupported private key format.');
+    }
+    return createPrivateKey({ key: jwk, format: 'jwk' });
+  }
+}
+
+function createVerificationPublicKey(key: string): KeyObject {
+  try {
+    return createPublicKey(key);
+  } catch {
+    const jwk = parseOpenSshEd25519PublicKey(key);
+    if (!jwk) {
+      throw new Error('Unsupported public key format.');
+    }
+    return createPublicKey({ key: jwk, format: 'jwk' });
+  }
+}
+
+function parseOpenSshEd25519PublicKey(key: string): JsonWebKey | undefined {
+  const trimmed = key.trim();
+  const parts = trimmed.split(/\s+/);
+  if (parts[0] !== 'ssh-ed25519' || !parts[1]) {
+    return undefined;
+  }
+
+  const reader = new SshBufferReader(Buffer.from(parts[1], 'base64'));
+  const keyType = reader.readString().toString('utf-8');
+  if (keyType !== 'ssh-ed25519') {
+    return undefined;
+  }
+
+  const publicKey = reader.readString();
+  if (publicKey.length !== 32) {
+    return undefined;
+  }
+
+  return {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: base64UrlEncode(publicKey),
+  };
+}
+
+function parseOpenSshEd25519PrivateKey(key: string): JsonWebKey | undefined {
+  const match = key.match(/-----BEGIN OPENSSH PRIVATE KEY-----\s+([\s\S]+?)\s+-----END OPENSSH PRIVATE KEY-----/);
+  if (!match) {
+    return undefined;
+  }
+
+  const decoded = Buffer.from(match[1].replace(/\s+/g, ''), 'base64');
+  const reader = new SshBufferReader(decoded);
+  const magic = reader.readBytes('openssh-key-v1\0'.length).toString('utf-8');
+  if (magic !== 'openssh-key-v1\0') {
+    return undefined;
+  }
+
+  const cipherName = reader.readString().toString('utf-8');
+  const kdfName = reader.readString().toString('utf-8');
+  reader.readString(); // kdf options
+  const keyCount = reader.readUInt32();
+  if (cipherName !== 'none' || kdfName !== 'none' || keyCount !== 1) {
+    return undefined;
+  }
+
+  reader.readString(); // public key blob
+  const privateBlock = new SshBufferReader(reader.readString());
+  const check1 = privateBlock.readUInt32();
+  const check2 = privateBlock.readUInt32();
+  if (check1 !== check2) {
+    return undefined;
+  }
+
+  const keyType = privateBlock.readString().toString('utf-8');
+  if (keyType !== 'ssh-ed25519') {
+    return undefined;
+  }
+
+  const publicKey = privateBlock.readString();
+  const privateKey = privateBlock.readString();
+  if (publicKey.length !== 32 || privateKey.length !== 64) {
+    return undefined;
+  }
+
+  return {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: base64UrlEncode(publicKey),
+    d: base64UrlEncode(privateKey.subarray(0, 32)),
+  };
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((result, key) => {
+        const child = (value as Record<string, unknown>)[key];
+        if (child !== undefined) {
+          result[key] = canonicalize(child);
+        }
+        return result;
+      }, {});
+  }
+
+  return value;
+}
+
+class SshBufferReader {
+  private offset = 0;
+
+  constructor(private readonly buffer: Buffer) {}
+
+  readUInt32(): number {
+    this.ensureAvailable(4);
+    const value = this.buffer.readUInt32BE(this.offset);
+    this.offset += 4;
+    return value;
+  }
+
+  readString(): Buffer {
+    const length = this.readUInt32();
+    return this.readBytes(length);
+  }
+
+  readBytes(length: number): Buffer {
+    this.ensureAvailable(length);
+    const value = this.buffer.subarray(this.offset, this.offset + length);
+    this.offset += length;
+    return value;
+  }
+
+  private ensureAvailable(length: number): void {
+    if (this.offset + length > this.buffer.length) {
+      throw new Error('Unexpected end of SSH key data.');
+    }
+  }
+}
+
+function base64UrlEncode(value: string | Buffer): string {
+  const buffer = typeof value === 'string' ? Buffer.from(value) : value;
+
+  return buffer
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+function base64UrlDecode(value: string): Buffer {
+  const padded = value + '='.repeat((4 - value.length % 4) % 4);
+  return Buffer.from(padded.replaceAll('-', '+').replaceAll('_', '/'), 'base64');
+}
+
+function base64UrlDecodeToString(value: string): string {
+  return base64UrlDecode(value).toString('utf-8');
+}

--- a/src/tools/dangerousGrant.ts
+++ b/src/tools/dangerousGrant.ts
@@ -1,8 +1,13 @@
+import { execFileSync } from 'child_process';
 import { JsonWebKey, KeyObject, createHash, createPrivateKey, createPublicKey, randomUUID, sign, verify } from 'crypto';
-import { readFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 export const DANGEROUS_GRANT_AUDIENCE = 'omnifocus-mcp-dangerous-grant';
 export const DANGEROUS_GRANT_ISSUER = 'omnifocus-mcp';
+export const DANGEROUS_GRANT_SSH_SIGNATURE_NAMESPACE = DANGEROUS_GRANT_AUDIENCE;
+export const DANGEROUS_GRANT_SSH_SIGNATURE_PRINCIPAL = DANGEROUS_GRANT_AUDIENCE;
 
 export type DangerousGrantType = 'exact' | 'pattern';
 
@@ -50,6 +55,7 @@ type DangerousGrantHeader = {
   alg: 'EdDSA' | 'RS256';
 };
 
+const SSH_SIGNATURE_TOKEN_PREFIX = 'SSHSIG';
 const usedGrantIds = new Set<string>();
 
 export function canonicalJson(value: unknown): string {
@@ -83,6 +89,21 @@ export function createDangerousGrantToken(
   const signature = sign(signatureAlgorithmForHeader(header.alg), Buffer.from(signingInput), privateKey);
 
   return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
+export function createSshSignatureDangerousGrantToken(
+  claims: DangerousGrantClaims,
+  signingKeyPath: string,
+  sshAuthSock?: string
+): string {
+  const signedPayload = Buffer.from(canonicalJson(claims));
+  const signature = signSshPayload(signedPayload, signingKeyPath, sshAuthSock);
+
+  return [
+    SSH_SIGNATURE_TOKEN_PREFIX,
+    base64UrlEncode(signedPayload),
+    base64UrlEncode(signature),
+  ].join('.');
 }
 
 export function createExactDangerousGrantClaims(params: {
@@ -138,28 +159,43 @@ export function validateDangerousGrant(
   }
 
   const parsed = parseDangerousGrant(token);
-  if (!parsed.valid || !parsed.header || !parsed.claims || !parsed.signature || !parsed.signingInput) {
+  if (!parsed.valid || !parsed.claims) {
     return { valid: false, reason: parsed.reason };
   }
 
-  if (parsed.header.typ !== 'JWT' || !['EdDSA', 'RS256'].includes(parsed.header.alg)) {
-    return { valid: false, reason: 'Unsupported dangerous grant header.' };
-  }
+  if (parsed.kind === 'jwt') {
+    if (!parsed.header || !parsed.signature || !parsed.signingInput) {
+      return { valid: false, reason: parsed.reason };
+    }
 
-  let signatureValid = false;
-  try {
-    signatureValid = verify(
-      signatureAlgorithmForHeader(parsed.header.alg),
-      Buffer.from(parsed.signingInput),
-      createVerificationPublicKey(publicKey),
-      parsed.signature
-    );
-  } catch {
-    return { valid: false, reason: 'Dangerous grant public key is invalid.' };
-  }
+    if (parsed.header.typ !== 'JWT' || !['EdDSA', 'RS256'].includes(parsed.header.alg)) {
+      return { valid: false, reason: 'Unsupported dangerous grant header.' };
+    }
 
-  if (!signatureValid) {
-    return { valid: false, reason: 'Dangerous grant signature is invalid.' };
+    let signatureValid = false;
+    try {
+      signatureValid = verify(
+        signatureAlgorithmForHeader(parsed.header.alg),
+        Buffer.from(parsed.signingInput),
+        createVerificationPublicKey(publicKey),
+        parsed.signature
+      );
+    } catch {
+      return { valid: false, reason: 'Dangerous grant public key is invalid.' };
+    }
+
+    if (!signatureValid) {
+      return { valid: false, reason: 'Dangerous grant signature is invalid.' };
+    }
+  } else {
+    if (!parsed.signature || !parsed.signedPayload) {
+      return { valid: false, reason: parsed.reason };
+    }
+
+    const signatureResult = verifySshSignature(parsed.signedPayload, parsed.signature, publicKey);
+    if (!signatureResult.valid) {
+      return { valid: false, reason: signatureResult.reason };
+    }
   }
 
   return validateDangerousGrantClaims(parsed.claims, toolName, args, nowSeconds);
@@ -257,12 +293,34 @@ function validateDangerousGrantClaims(
 function parseDangerousGrant(token: string): {
   valid: boolean;
   reason?: string;
+  kind?: 'jwt' | 'ssh-signature';
   header?: DangerousGrantHeader;
   claims?: DangerousGrantClaims;
   signature?: Buffer;
   signingInput?: string;
+  signedPayload?: Buffer;
 } {
   const parts = token.split('.');
+  if (parts[0] === SSH_SIGNATURE_TOKEN_PREFIX) {
+    if (parts.length !== 3) {
+      return { valid: false, reason: 'Dangerous SSH signature grant must have three parts.' };
+    }
+
+    try {
+      const [, encodedClaims, encodedSignature] = parts;
+      const signedPayload = base64UrlDecode(encodedClaims);
+      return {
+        valid: true,
+        kind: 'ssh-signature',
+        claims: JSON.parse(signedPayload.toString('utf-8')),
+        signature: base64UrlDecode(encodedSignature),
+        signedPayload,
+      };
+    } catch {
+      return { valid: false, reason: 'Dangerous SSH signature grant is not valid JSON/base64url.' };
+    }
+  }
+
   if (parts.length !== 3) {
     return { valid: false, reason: 'Dangerous grant must have three JWT parts.' };
   }
@@ -271,6 +329,7 @@ function parseDangerousGrant(token: string): {
     const [encodedHeader, encodedClaims, encodedSignature] = parts;
     return {
       valid: true,
+      kind: 'jwt',
       header: JSON.parse(base64UrlDecodeToString(encodedHeader)),
       claims: JSON.parse(base64UrlDecodeToString(encodedClaims)),
       signature: base64UrlDecode(encodedSignature),
@@ -336,6 +395,88 @@ function createVerificationPublicKey(key: string): KeyObject {
       throw new Error('Unsupported public key format.');
     }
     return assertSupportedVerificationKey(createPublicKey({ key: jwk, format: 'jwk' }));
+  }
+}
+
+function signSshPayload(payload: Buffer, signingKeyPath: string, sshAuthSock?: string): Buffer {
+  const directory = mkdtempSync(join(tmpdir(), 'omnifocus-mcp-grant-'));
+  const payloadPath = join(directory, 'claims.json');
+  const signaturePath = `${payloadPath}.sig`;
+
+  try {
+    writeFileSync(payloadPath, payload);
+    execFileSync('ssh-keygen', [
+      '-q',
+      '-Y',
+      'sign',
+      '-f',
+      signingKeyPath,
+      '-n',
+      DANGEROUS_GRANT_SSH_SIGNATURE_NAMESPACE,
+      payloadPath,
+    ], {
+      encoding: 'utf-8',
+      env: sshAuthSock ? { ...process.env, SSH_AUTH_SOCK: sshAuthSock } : process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    return readFileSync(signaturePath);
+  } catch (error) {
+    const stderr = (error as { stderr?: Buffer | string; code?: string }).stderr?.toString().trim();
+    const message = (error as { code?: string }).code === 'ENOENT'
+      ? 'ssh-keygen was not found.'
+      : stderr || (error as Error).message;
+    throw new Error(`Failed to create SSH signature dangerous grant: ${message}`);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function verifySshSignature(payload: Buffer, signature: Buffer, publicKey: string): { valid: boolean; reason?: string } {
+  const publicKeyLine = publicKey.trim().split(/\r?\n/)[0];
+  if (!publicKeyLine.startsWith('ssh-ed25519 ') && !publicKeyLine.startsWith('ssh-rsa ')) {
+    return {
+      valid: false,
+      reason: 'Dangerous SSH signature grants require an OpenSSH ssh-ed25519 or ssh-rsa public key.',
+    };
+  }
+
+  const directory = mkdtempSync(join(tmpdir(), 'omnifocus-mcp-grant-'));
+  const allowedSignersPath = join(directory, 'allowed_signers');
+  const signaturePath = join(directory, 'grant.sig');
+
+  try {
+    writeFileSync(allowedSignersPath, `${DANGEROUS_GRANT_SSH_SIGNATURE_PRINCIPAL} ${publicKeyLine}\n`);
+    writeFileSync(signaturePath, signature);
+    execFileSync('ssh-keygen', [
+      '-Y',
+      'verify',
+      '-f',
+      allowedSignersPath,
+      '-I',
+      DANGEROUS_GRANT_SSH_SIGNATURE_PRINCIPAL,
+      '-n',
+      DANGEROUS_GRANT_SSH_SIGNATURE_NAMESPACE,
+      '-s',
+      signaturePath,
+    ], {
+      input: payload,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    return { valid: true };
+  } catch (error) {
+    const stderr = (error as { stderr?: Buffer | string; code?: string }).stderr?.toString().trim();
+    const message = (error as { code?: string }).code === 'ENOENT'
+      ? 'ssh-keygen was not found.'
+      : stderr || 'Dangerous grant SSH signature is invalid.';
+    return {
+      valid: false,
+      reason: `Dangerous grant SSH signature is invalid: ${message}`,
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
   }
 }
 

--- a/src/tools/dangerousGrant.ts
+++ b/src/tools/dangerousGrant.ts
@@ -36,6 +36,15 @@ export type DangerousGrantValidationResult = {
   claims?: DangerousGrantClaims;
 };
 
+export type DangerousGrantKeyInfo = {
+  supported: boolean;
+  keyKind: 'private' | 'public';
+  keyType?: 'ed25519' | 'rsa';
+  algorithm?: DangerousGrantHeader['alg'];
+  format?: 'pem' | 'openssh';
+  reason?: string;
+};
+
 type DangerousGrantHeader = {
   typ: 'JWT';
   alg: 'EdDSA' | 'RS256';
@@ -156,6 +165,48 @@ export function validateDangerousGrant(
   return validateDangerousGrantClaims(parsed.claims, toolName, args, nowSeconds);
 }
 
+export function inspectDangerousGrantPrivateKey(key: string): DangerousGrantKeyInfo {
+  try {
+    const privateKey = createSigningPrivateKey(key);
+    const algorithm = privateKey.asymmetricKeyType === 'rsa' ? 'RS256' : 'EdDSA';
+    return {
+      supported: true,
+      keyKind: 'private',
+      keyType: keyTypeForAsymmetricKey(privateKey),
+      algorithm,
+      format: keyFormat(key),
+    };
+  } catch (error) {
+    return {
+      supported: false,
+      keyKind: 'private',
+      format: keyFormat(key),
+      reason: (error as Error).message,
+    };
+  }
+}
+
+export function inspectDangerousGrantPublicKey(key: string): DangerousGrantKeyInfo {
+  try {
+    const publicKey = createVerificationPublicKey(key);
+    const algorithm = publicKey.asymmetricKeyType === 'rsa' ? 'RS256' : 'EdDSA';
+    return {
+      supported: true,
+      keyKind: 'public',
+      keyType: keyTypeForAsymmetricKey(publicKey),
+      algorithm,
+      format: keyFormat(key),
+    };
+  } catch (error) {
+    return {
+      supported: false,
+      keyKind: 'public',
+      format: keyFormat(key),
+      reason: (error as Error).message,
+    };
+  }
+}
+
 function validateDangerousGrantClaims(
   claims: DangerousGrantClaims,
   toolName: string,
@@ -244,13 +295,13 @@ function readDangerousGrantPublicKey(env: NodeJS.ProcessEnv): string | undefined
 
 function createSigningPrivateKey(key: string): KeyObject {
   try {
-    return createPrivateKey(key);
+    return assertSupportedSigningKey(createPrivateKey(key));
   } catch {
     const jwk = parseOpenSshEd25519PrivateKey(key) ?? parseOpenSshRsaPrivateKey(key);
     if (!jwk) {
       throw new Error('Unsupported private key format.');
     }
-    return createPrivateKey({ key: jwk, format: 'jwk' });
+    return assertSupportedSigningKey(createPrivateKey({ key: jwk, format: 'jwk' }));
   }
 }
 
@@ -258,16 +309,48 @@ function signatureAlgorithmForHeader(alg: DangerousGrantHeader['alg']): string |
   return alg === 'RS256' ? 'RSA-SHA256' : null;
 }
 
+function keyTypeForAsymmetricKey(key: KeyObject): DangerousGrantKeyInfo['keyType'] {
+  if (key.asymmetricKeyType === 'ed25519') {
+    return 'ed25519';
+  }
+  if (key.asymmetricKeyType === 'rsa') {
+    return 'rsa';
+  }
+  return undefined;
+}
+
+function keyFormat(key: string): DangerousGrantKeyInfo['format'] {
+  return key.trim().startsWith('-----BEGIN OPENSSH PRIVATE KEY-----')
+    || key.trim().startsWith('ssh-ed25519 ')
+    || key.trim().startsWith('ssh-rsa ')
+    ? 'openssh'
+    : 'pem';
+}
+
 function createVerificationPublicKey(key: string): KeyObject {
   try {
-    return createPublicKey(key);
+    return assertSupportedVerificationKey(createPublicKey(key));
   } catch {
     const jwk = parseOpenSshEd25519PublicKey(key) ?? parseOpenSshRsaPublicKey(key);
     if (!jwk) {
       throw new Error('Unsupported public key format.');
     }
-    return createPublicKey({ key: jwk, format: 'jwk' });
+    return assertSupportedVerificationKey(createPublicKey({ key: jwk, format: 'jwk' }));
   }
+}
+
+function assertSupportedSigningKey(key: KeyObject): KeyObject {
+  if (key.asymmetricKeyType !== 'ed25519' && key.asymmetricKeyType !== 'rsa') {
+    throw new Error('Unsupported private key format.');
+  }
+  return key;
+}
+
+function assertSupportedVerificationKey(key: KeyObject): KeyObject {
+  if (key.asymmetricKeyType !== 'ed25519' && key.asymmetricKeyType !== 'rsa') {
+    throw new Error('Unsupported public key format.');
+  }
+  return key;
 }
 
 function parseOpenSshEd25519PublicKey(key: string): JsonWebKey | undefined {

--- a/src/tools/dangerousGrant.ts
+++ b/src/tools/dangerousGrant.ts
@@ -38,7 +38,7 @@ export type DangerousGrantValidationResult = {
 
 type DangerousGrantHeader = {
   typ: 'JWT';
-  alg: 'EdDSA';
+  alg: 'EdDSA' | 'RS256';
 };
 
 const usedGrantIds = new Set<string>();
@@ -62,15 +62,16 @@ export function createDangerousGrantToken(
   claims: DangerousGrantClaims,
   privateKeyPem: string
 ): string {
+  const privateKey = createSigningPrivateKey(privateKeyPem);
   const header: DangerousGrantHeader = {
     typ: 'JWT',
-    alg: 'EdDSA',
+    alg: privateKey.asymmetricKeyType === 'rsa' ? 'RS256' : 'EdDSA',
   };
   const signingInput = [
     base64UrlEncode(JSON.stringify(header)),
     base64UrlEncode(JSON.stringify(claims)),
   ].join('.');
-  const signature = sign(null, Buffer.from(signingInput), createSigningPrivateKey(privateKeyPem));
+  const signature = sign(signatureAlgorithmForHeader(header.alg), Buffer.from(signingInput), privateKey);
 
   return `${signingInput}.${base64UrlEncode(signature)}`;
 }
@@ -132,14 +133,14 @@ export function validateDangerousGrant(
     return { valid: false, reason: parsed.reason };
   }
 
-  if (parsed.header.typ !== 'JWT' || parsed.header.alg !== 'EdDSA') {
+  if (parsed.header.typ !== 'JWT' || !['EdDSA', 'RS256'].includes(parsed.header.alg)) {
     return { valid: false, reason: 'Unsupported dangerous grant header.' };
   }
 
   let signatureValid = false;
   try {
     signatureValid = verify(
-      null,
+      signatureAlgorithmForHeader(parsed.header.alg),
       Buffer.from(parsed.signingInput),
       createVerificationPublicKey(publicKey),
       parsed.signature
@@ -245,7 +246,7 @@ function createSigningPrivateKey(key: string): KeyObject {
   try {
     return createPrivateKey(key);
   } catch {
-    const jwk = parseOpenSshEd25519PrivateKey(key);
+    const jwk = parseOpenSshEd25519PrivateKey(key) ?? parseOpenSshRsaPrivateKey(key);
     if (!jwk) {
       throw new Error('Unsupported private key format.');
     }
@@ -253,11 +254,15 @@ function createSigningPrivateKey(key: string): KeyObject {
   }
 }
 
+function signatureAlgorithmForHeader(alg: DangerousGrantHeader['alg']): string | null {
+  return alg === 'RS256' ? 'RSA-SHA256' : null;
+}
+
 function createVerificationPublicKey(key: string): KeyObject {
   try {
     return createPublicKey(key);
   } catch {
-    const jwk = parseOpenSshEd25519PublicKey(key);
+    const jwk = parseOpenSshEd25519PublicKey(key) ?? parseOpenSshRsaPublicKey(key);
     if (!jwk) {
       throw new Error('Unsupported public key format.');
     }
@@ -287,6 +292,29 @@ function parseOpenSshEd25519PublicKey(key: string): JsonWebKey | undefined {
     kty: 'OKP',
     crv: 'Ed25519',
     x: base64UrlEncode(publicKey),
+  };
+}
+
+function parseOpenSshRsaPublicKey(key: string): JsonWebKey | undefined {
+  const trimmed = key.trim();
+  const parts = trimmed.split(/\s+/);
+  if (parts[0] !== 'ssh-rsa' || !parts[1]) {
+    return undefined;
+  }
+
+  const reader = new SshBufferReader(Buffer.from(parts[1], 'base64'));
+  const keyType = reader.readString().toString('utf-8');
+  if (keyType !== 'ssh-rsa') {
+    return undefined;
+  }
+
+  const e = readUnsignedMpint(reader);
+  const n = readUnsignedMpint(reader);
+
+  return {
+    kty: 'RSA',
+    n: base64UrlEncode(n),
+    e: base64UrlEncode(e),
   };
 }
 
@@ -336,6 +364,99 @@ function parseOpenSshEd25519PrivateKey(key: string): JsonWebKey | undefined {
     x: base64UrlEncode(publicKey),
     d: base64UrlEncode(privateKey.subarray(0, 32)),
   };
+}
+
+function parseOpenSshRsaPrivateKey(key: string): JsonWebKey | undefined {
+  const privateBlock = readOpenSshPrivateBlock(key);
+  if (!privateBlock) {
+    return undefined;
+  }
+
+  const keyType = privateBlock.readString().toString('utf-8');
+  if (keyType !== 'ssh-rsa') {
+    return undefined;
+  }
+
+  const n = readUnsignedMpint(privateBlock);
+  const e = readUnsignedMpint(privateBlock);
+  const d = readUnsignedMpint(privateBlock);
+  const iqmp = readUnsignedMpint(privateBlock);
+  const p = readUnsignedMpint(privateBlock);
+  const q = readUnsignedMpint(privateBlock);
+
+  const dValue = bufferToBigInt(d);
+  const pValue = bufferToBigInt(p);
+  const qValue = bufferToBigInt(q);
+  const dp = bigIntToBuffer(dValue % (pValue - 1n));
+  const dq = bigIntToBuffer(dValue % (qValue - 1n));
+
+  return {
+    kty: 'RSA',
+    n: base64UrlEncode(n),
+    e: base64UrlEncode(e),
+    d: base64UrlEncode(d),
+    p: base64UrlEncode(p),
+    q: base64UrlEncode(q),
+    dp: base64UrlEncode(dp),
+    dq: base64UrlEncode(dq),
+    qi: base64UrlEncode(iqmp),
+  };
+}
+
+function readOpenSshPrivateBlock(key: string): SshBufferReader | undefined {
+  const match = key.match(/-----BEGIN OPENSSH PRIVATE KEY-----\s+([\s\S]+?)\s+-----END OPENSSH PRIVATE KEY-----/);
+  if (!match) {
+    return undefined;
+  }
+
+  const decoded = Buffer.from(match[1].replace(/\s+/g, ''), 'base64');
+  const reader = new SshBufferReader(decoded);
+  const magic = reader.readBytes('openssh-key-v1\0'.length).toString('utf-8');
+  if (magic !== 'openssh-key-v1\0') {
+    return undefined;
+  }
+
+  const cipherName = reader.readString().toString('utf-8');
+  const kdfName = reader.readString().toString('utf-8');
+  reader.readString(); // kdf options
+  const keyCount = reader.readUInt32();
+  if (cipherName !== 'none' || kdfName !== 'none' || keyCount !== 1) {
+    return undefined;
+  }
+
+  reader.readString(); // public key blob
+  const privateBlock = new SshBufferReader(reader.readString());
+  const check1 = privateBlock.readUInt32();
+  const check2 = privateBlock.readUInt32();
+  if (check1 !== check2) {
+    return undefined;
+  }
+
+  return privateBlock;
+}
+
+function readUnsignedMpint(reader: SshBufferReader): Buffer {
+  const value = reader.readString();
+  let offset = 0;
+  while (offset < value.length - 1 && value[offset] === 0) {
+    offset += 1;
+  }
+  return value.subarray(offset);
+}
+
+function bufferToBigInt(value: Buffer): bigint {
+  if (value.length === 0) {
+    return 0n;
+  }
+  return BigInt(`0x${value.toString('hex')}`);
+}
+
+function bigIntToBuffer(value: bigint): Buffer {
+  if (value === 0n) {
+    return Buffer.from([0]);
+  }
+  const hex = value.toString(16);
+  return Buffer.from(hex.length % 2 === 0 ? hex : `0${hex}`, 'hex');
 }
 
 function canonicalize(value: unknown): unknown {

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -27,7 +27,8 @@ export const schema = z.object({
     sequential: z.boolean().optional().describe("For projects: Whether tasks in the project should be sequential")
   })).describe("Array of items (tasks or projects) to add")
   ,
-  createSequentially: z.boolean().optional().describe("Process parents before children; when false, best-effort order will still try to resolve parents first")
+  createSequentially: z.boolean().optional().describe("Process parents before children; when false, best-effort order will still try to resolve parents first"),
+  dangerousGrant: z.string().optional().describe("Short-lived signed grant authorizing this exact destructive operation when adding a broad batch")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/batchRemoveItems.ts
+++ b/src/tools/definitions/batchRemoveItems.ts
@@ -7,7 +7,8 @@ export const schema = z.object({
     id: z.string().optional().describe("The ID of the task or project to remove"),
     name: z.string().optional().describe("The name of the task or project to remove (as fallback if ID not provided)"),
     itemType: z.enum(['task', 'project']).describe("Type of item to remove ('task' or 'project')")
-  })).describe("Array of items (tasks or projects) to remove")
+  })).describe("Array of items (tasks or projects) to remove"),
+  dangerousGrant: z.string().optional().describe("Short-lived signed grant authorizing this exact destructive operation")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -27,7 +27,8 @@ export const schema = z.object({
   newSequential: z.boolean().optional().describe("Whether the project should be sequential"),
   newFolderName: z.string().optional().describe("New folder to move the project to"),
   newProjectStatus: z.enum(['active', 'completed', 'dropped', 'onHold']).optional().describe("New status for projects"),
-  markReviewed: z.boolean().optional().describe("Mark the project as reviewed (projects only). Sets the next review date to now + the project's review interval. Only works when set to true.")
+  markReviewed: z.boolean().optional().describe("Mark the project as reviewed (projects only). Sets the next review date to now + the project's review interval. Only works when set to true."),
+  dangerousGrant: z.string().optional().describe("Short-lived signed grant authorizing this exact destructive operation when completing, dropping, or skipping items")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/removeItem.ts
+++ b/src/tools/definitions/removeItem.ts
@@ -5,7 +5,8 @@ import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.j
 export const schema = z.object({
   id: z.string().optional().describe("The ID of the task or project to remove"),
   name: z.string().optional().describe("The name of the task or project to remove (as fallback if ID not provided)"),
-  itemType: z.enum(['task', 'project']).describe("Type of item to remove ('task' or 'project')")
+  itemType: z.enum(['task', 'project']).describe("Type of item to remove ('task' or 'project')"),
+  dangerousGrant: z.string().optional().describe("Short-lived signed grant authorizing this exact destructive operation")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/removeTag.ts
+++ b/src/tools/definitions/removeTag.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import { removeTag } from '../primitives/removeTag.js';
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+
+export const schema = z.object({
+  id: z.string().optional().describe("The ID of the tag to remove"),
+  name: z.string().optional().describe("The exact name of the tag to remove (as fallback if ID not provided)"),
+  dangerousGrant: z.string().optional().describe("Short-lived signed grant authorizing this exact destructive operation")
+});
+
+export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {
+  try {
+    if (!args.id && !args.name) {
+      return {
+        content: [{
+          type: "text" as const,
+          text: "Either id or name must be provided to remove a tag."
+        }],
+        isError: true
+      };
+    }
+
+    const result = await removeTag({
+      id: args.id,
+      name: args.name
+    });
+
+    if (result.success) {
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ Tag "${result.name}" removed successfully.`
+        }]
+      };
+    }
+
+    let errorMsg = 'Failed to remove tag';
+    if (result.error) {
+      if (result.error.includes("Tag not found")) {
+        errorMsg = 'Tag not found';
+        if (args.id) errorMsg += ` with ID "${args.id}"`;
+        if (args.name) errorMsg += `${args.id ? ' or' : ' with'} name "${args.name}"`;
+        errorMsg += '.';
+      } else {
+        errorMsg += `: ${result.error}`;
+      }
+    }
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: errorMsg
+      }],
+      isError: true
+    };
+  } catch (err: unknown) {
+    const error = err as Error;
+    console.error(`Tool execution error: ${error.message}`);
+
+    return {
+      content: [{
+        type: "text" as const,
+        text: `Error removing tag: ${error.message}`
+      }],
+      isError: true
+    };
+  }
+}

--- a/src/tools/policy.test.ts
+++ b/src/tools/policy.test.ts
@@ -53,6 +53,7 @@ describe('OmniFocus MCP safety policy', () => {
     it('classifies removals and completion/drop edits as dangerous', () => {
       expect(getToolAccessLevel('remove_item')).toBe('dangerous');
       expect(getToolAccessLevel('batch_remove_items')).toBe('dangerous');
+      expect(getToolAccessLevel('remove_tag')).toBe('dangerous');
       expect(getToolAccessLevel('edit_item', { newStatus: 'completed' })).toBe('dangerous');
       expect(getToolAccessLevel('edit_item', { newProjectStatus: 'dropped' })).toBe('dangerous');
     });
@@ -82,11 +83,13 @@ describe('OmniFocus MCP safety policy', () => {
 
     it('blocks dangerous operations in write mode', () => {
       expect(isToolAllowed('remove_item', { id: 'abc', itemType: 'task' }, 'write')).toBe(false);
+      expect(isToolAllowed('remove_tag', { id: 'abc' }, 'write')).toBe(false);
       expect(isToolAllowed('edit_item', { newStatus: 'completed' }, 'write')).toBe(false);
     });
 
     it('allows dangerous operations only in dangerous mode', () => {
       expect(isToolAllowed('remove_item', { id: 'abc', itemType: 'task' }, 'dangerous')).toBe(true);
+      expect(isToolAllowed('remove_tag', { id: 'abc' }, 'dangerous')).toBe(true);
     });
 
     it('detects dangerous dry-run mode', () => {
@@ -144,6 +147,30 @@ describe('OmniFocus MCP safety policy', () => {
 
       try {
         const result = await guardedHandler({ name: 'Draft', itemType: 'task' }, {} as any);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('requires a valid dangerousGrant');
+      } finally {
+        if (originalMode === undefined) {
+          delete process.env.OMNIFOCUS_MCP_MODE;
+        } else {
+          process.env.OMNIFOCUS_MCP_MODE = originalMode;
+        }
+      }
+    });
+
+    it('blocks remove_tag without a grant even in dangerous mode', async () => {
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'removed' }],
+      });
+      const guardedHandler = guardToolHandler('remove_tag', handler);
+
+      const originalMode = process.env.OMNIFOCUS_MCP_MODE;
+      process.env.OMNIFOCUS_MCP_MODE = 'dangerous';
+
+      try {
+        const result = await guardedHandler({ name: 'Old Tag' }, {} as any);
 
         expect(handler).not.toHaveBeenCalled();
         expect(result.isError).toBe(true);
@@ -238,6 +265,57 @@ describe('OmniFocus MCP safety policy', () => {
         expect(payload.dryRun).toBe(true);
         expect(payload.grant.jti).toBe('policy-grant-dry-run-1');
         expect(payload.grant.reason).toBeUndefined();
+      } finally {
+        if (originalMode === undefined) {
+          delete process.env.OMNIFOCUS_MCP_MODE;
+        } else {
+          process.env.OMNIFOCUS_MCP_MODE = originalMode;
+        }
+        if (originalPublicKey === undefined) {
+          delete process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY;
+        } else {
+          process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY = originalPublicKey;
+        }
+        if (originalDryRun === undefined) {
+          delete process.env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN;
+        } else {
+          process.env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN = originalDryRun;
+        }
+      }
+    });
+
+    it('verifies remove_tag grants but skips the handler in dry-run mode', async () => {
+      resetDangerousGrantReplayCache();
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'removed' }],
+      });
+      const guardedHandler = guardToolHandler('remove_tag', handler);
+      const args = { name: 'Old Tag' };
+      const claims = createExactDangerousGrantClaims({
+        toolName: 'remove_tag',
+        args,
+        expiresInSeconds: 60,
+        jti: 'policy-remove-tag-dry-run-1',
+      });
+      const dangerousGrant = createDangerousGrantToken(claims, privateKeyPem);
+
+      const originalMode = process.env.OMNIFOCUS_MCP_MODE;
+      const originalPublicKey = process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY;
+      const originalDryRun = process.env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN;
+      process.env.OMNIFOCUS_MCP_MODE = 'dangerous';
+      process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY = publicKeyPem;
+      process.env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN = '1';
+
+      try {
+        const result = await guardedHandler({ ...args, dangerousGrant }, {} as any);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(result.isError).toBeUndefined();
+        const payload = extractDangerousActionPayload(result);
+        expect(payload.tool).toBe('remove_tag');
+        expect(payload.args).toEqual(args);
+        expect(payload.executed).toBe(false);
+        expect(payload.dryRun).toBe(true);
       } finally {
         if (originalMode === undefined) {
           delete process.env.OMNIFOCUS_MCP_MODE;

--- a/src/tools/policy.test.ts
+++ b/src/tools/policy.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from 'vitest';
+import { generateKeyPairSync } from 'crypto';
+import {
+  createDangerousGrantToken,
+  createExactDangerousGrantClaims,
+  resetDangerousGrantReplayCache,
+} from './dangerousGrant.js';
+import {
+  appendDangerousAuditResult,
+  blockedToolResult,
+  dangerousGrantRequiredResult,
+  dangerousDryRunResult,
+  getOmniFocusMcpMode,
+  getToolAccessLevel,
+  guardToolHandler,
+  isDangerousDryRunEnabled,
+  isToolAllowed,
+} from './policy.js';
+
+const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+describe('OmniFocus MCP safety policy', () => {
+  describe('getOmniFocusMcpMode', () => {
+    it('defaults to readonly', () => {
+      expect(getOmniFocusMcpMode({})).toBe('readonly');
+    });
+
+    it('accepts write and dangerous modes', () => {
+      expect(getOmniFocusMcpMode({ OMNIFOCUS_MCP_MODE: 'write' })).toBe('write');
+      expect(getOmniFocusMcpMode({ OMNIFOCUS_MCP_MODE: 'dangerous' })).toBe('dangerous');
+    });
+
+    it('falls back to readonly for unknown modes', () => {
+      expect(getOmniFocusMcpMode({ OMNIFOCUS_MCP_MODE: 'oops' })).toBe('readonly');
+    });
+  });
+
+  describe('tool access levels', () => {
+    it('classifies query tools as read operations', () => {
+      expect(getToolAccessLevel('query_omnifocus')).toBe('read');
+      expect(getToolAccessLevel('dump_database')).toBe('read');
+      expect(getToolAccessLevel('list_tags')).toBe('read');
+    });
+
+    it('classifies ordinary create and edit tools as writes', () => {
+      expect(getToolAccessLevel('add_omnifocus_task')).toBe('write');
+      expect(getToolAccessLevel('create_tag')).toBe('write');
+      expect(getToolAccessLevel('edit_item', { newName: 'Later' })).toBe('write');
+    });
+
+    it('classifies removals and completion/drop edits as dangerous', () => {
+      expect(getToolAccessLevel('remove_item')).toBe('dangerous');
+      expect(getToolAccessLevel('batch_remove_items')).toBe('dangerous');
+      expect(getToolAccessLevel('edit_item', { newStatus: 'completed' })).toBe('dangerous');
+      expect(getToolAccessLevel('edit_item', { newProjectStatus: 'dropped' })).toBe('dangerous');
+    });
+
+    it('classifies broad batch adds as dangerous', () => {
+      const items = Array.from({ length: 11 }, (_, index) => ({
+        type: 'task',
+        name: `Task ${index}`,
+      }));
+
+      expect(getToolAccessLevel('batch_add_items', { items })).toBe('dangerous');
+    });
+  });
+
+  describe('mode checks', () => {
+    it('allows reads in readonly mode', () => {
+      expect(isToolAllowed('query_omnifocus', {}, 'readonly')).toBe(true);
+    });
+
+    it('blocks writes in readonly mode', () => {
+      expect(isToolAllowed('add_omnifocus_task', { name: 'Draft' }, 'readonly')).toBe(false);
+    });
+
+    it('allows ordinary writes in write mode', () => {
+      expect(isToolAllowed('add_omnifocus_task', { name: 'Draft' }, 'write')).toBe(true);
+    });
+
+    it('blocks dangerous operations in write mode', () => {
+      expect(isToolAllowed('remove_item', { id: 'abc', itemType: 'task' }, 'write')).toBe(false);
+      expect(isToolAllowed('edit_item', { newStatus: 'completed' }, 'write')).toBe(false);
+    });
+
+    it('allows dangerous operations only in dangerous mode', () => {
+      expect(isToolAllowed('remove_item', { id: 'abc', itemType: 'task' }, 'dangerous')).toBe(true);
+    });
+
+    it('detects dangerous dry-run mode', () => {
+      expect(isDangerousDryRunEnabled({})).toBe(false);
+      expect(isDangerousDryRunEnabled({ OMNIFOCUS_MCP_DANGEROUS_DRY_RUN: '1' })).toBe(true);
+      expect(isDangerousDryRunEnabled({ OMNIFOCUS_MCP_DANGEROUS_DRY_RUN: 'true' })).toBe(true);
+    });
+  });
+
+  describe('guardToolHandler', () => {
+    it('does not call blocked handlers', async () => {
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'created' }],
+      });
+      const guardedHandler = guardToolHandler('add_omnifocus_task', handler);
+
+      const originalMode = process.env.OMNIFOCUS_MCP_MODE;
+      delete process.env.OMNIFOCUS_MCP_MODE;
+
+      try {
+        const result = await guardedHandler({ name: 'Draft' }, {} as any);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('blocked by OmniFocus MCP safety policy');
+      } finally {
+        if (originalMode === undefined) {
+          delete process.env.OMNIFOCUS_MCP_MODE;
+        } else {
+          process.env.OMNIFOCUS_MCP_MODE = originalMode;
+        }
+      }
+    });
+
+    it('calls allowed handlers', async () => {
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'queried' }],
+      });
+      const guardedHandler = guardToolHandler('query_omnifocus', handler);
+
+      const result = await guardedHandler({ entity: 'tasks' }, {} as any);
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(result.content[0].text).toBe('queried');
+    });
+
+    it('blocks dangerous handlers without a grant even in dangerous mode', async () => {
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'removed' }],
+      });
+      const guardedHandler = guardToolHandler('remove_item', handler);
+
+      const originalMode = process.env.OMNIFOCUS_MCP_MODE;
+      process.env.OMNIFOCUS_MCP_MODE = 'dangerous';
+
+      try {
+        const result = await guardedHandler({ name: 'Draft', itemType: 'task' }, {} as any);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('requires a valid dangerousGrant');
+      } finally {
+        if (originalMode === undefined) {
+          delete process.env.OMNIFOCUS_MCP_MODE;
+        } else {
+          process.env.OMNIFOCUS_MCP_MODE = originalMode;
+        }
+      }
+    });
+
+    it('calls dangerous handlers with a valid exact grant and strips it from args', async () => {
+      resetDangerousGrantReplayCache();
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'removed' }],
+      });
+      const guardedHandler = guardToolHandler('remove_item', handler);
+      const args = { name: 'Draft', itemType: 'task' };
+      const claims = createExactDangerousGrantClaims({
+        toolName: 'remove_item',
+        args,
+        expiresInSeconds: 60,
+        jti: 'policy-grant-1',
+      });
+      const dangerousGrant = createDangerousGrantToken(claims, privateKeyPem);
+
+      const originalMode = process.env.OMNIFOCUS_MCP_MODE;
+      const originalPublicKey = process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY;
+      process.env.OMNIFOCUS_MCP_MODE = 'dangerous';
+      process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY = publicKeyPem;
+
+      try {
+        const result = await guardedHandler({ ...args, dangerousGrant }, {} as any);
+
+        expect(handler).toHaveBeenCalledWith(args, {});
+        expect(result.content[0].text).toBe('removed');
+        const payload = extractDangerousActionPayload(result);
+        expect(payload.tool).toBe('remove_item');
+        expect(payload.args).toEqual(args);
+        expect(payload.executed).toBe(true);
+        expect(payload.dryRun).toBe(false);
+        expect(payload.grant.jti).toBe('policy-grant-1');
+      } finally {
+        if (originalMode === undefined) {
+          delete process.env.OMNIFOCUS_MCP_MODE;
+        } else {
+          process.env.OMNIFOCUS_MCP_MODE = originalMode;
+        }
+        if (originalPublicKey === undefined) {
+          delete process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY;
+        } else {
+          process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY = originalPublicKey;
+        }
+      }
+    });
+
+    it('verifies grants but skips dangerous handlers in dry-run mode', async () => {
+      resetDangerousGrantReplayCache();
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'removed' }],
+      });
+      const guardedHandler = guardToolHandler('remove_item', handler);
+      const args = { name: 'Draft', itemType: 'task' };
+      const claims = createExactDangerousGrantClaims({
+        toolName: 'remove_item',
+        args,
+        expiresInSeconds: 60,
+        jti: 'policy-grant-dry-run-1',
+      });
+      const dangerousGrant = createDangerousGrantToken(claims, privateKeyPem);
+
+      const originalMode = process.env.OMNIFOCUS_MCP_MODE;
+      const originalPublicKey = process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY;
+      const originalDryRun = process.env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN;
+      process.env.OMNIFOCUS_MCP_MODE = 'dangerous';
+      process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY = publicKeyPem;
+      process.env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN = '1';
+
+      try {
+        const result = await guardedHandler({ ...args, dangerousGrant }, {} as any);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0].text).toContain('Dangerous dry run');
+        expect(result.content[0].text).toContain('no OmniFocus mutation was executed');
+        const payload = extractDangerousActionPayload(result);
+        expect(payload.tool).toBe('remove_item');
+        expect(payload.args).toEqual(args);
+        expect(payload.executed).toBe(false);
+        expect(payload.dryRun).toBe(true);
+        expect(payload.grant.jti).toBe('policy-grant-dry-run-1');
+        expect(payload.grant.reason).toBeUndefined();
+      } finally {
+        if (originalMode === undefined) {
+          delete process.env.OMNIFOCUS_MCP_MODE;
+        } else {
+          process.env.OMNIFOCUS_MCP_MODE = originalMode;
+        }
+        if (originalPublicKey === undefined) {
+          delete process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY;
+        } else {
+          process.env.OMNIFOCUS_MCP_DANGEROUS_GRANT_PUBLIC_KEY = originalPublicKey;
+        }
+        if (originalDryRun === undefined) {
+          delete process.env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN;
+        } else {
+          process.env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN = originalDryRun;
+        }
+      }
+    });
+  });
+
+  describe('blockedToolResult', () => {
+    it('tells callers which mode is required', () => {
+      const result = blockedToolResult('remove_item', {}, 'write');
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('required mode is "dangerous"');
+      expect(result.content[0].text).toContain('OMNIFOCUS_MCP_MODE=dangerous');
+    });
+
+    it('explains missing or invalid grants', () => {
+      const result = dangerousGrantRequiredResult('remove_item', 'Missing dangerousGrant.');
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('requires a valid dangerousGrant');
+      expect(result.content[0].text).toContain('Missing dangerousGrant');
+    });
+
+    it('explains dangerous dry-run skips', () => {
+      const result = dangerousDryRunResult('remove_item', { name: 'Draft', itemType: 'task' }, {
+        iss: 'omnifocus-mcp',
+        aud: 'omnifocus-mcp-dangerous-grant',
+        iat: 100,
+        exp: 200,
+        jti: 'grant-id',
+        grant_version: 1,
+        grant_type: 'exact',
+        scope: 'dangerous',
+        allowed_tools: ['remove_item'],
+        operation: {
+          tool: 'remove_item',
+          args_sha256: 'hash',
+        },
+        reason: 'test',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('grant verified');
+      expect(result.content[0].text).toContain('no OmniFocus mutation was executed');
+      const payload = extractDangerousActionPayload(result);
+      expect(payload).toMatchObject({
+        dryRun: true,
+        tool: 'remove_item',
+        accessLevel: 'dangerous',
+        args: { name: 'Draft', itemType: 'task' },
+        executed: false,
+        grant: {
+          jti: 'grant-id',
+          reason: 'test',
+        },
+      });
+    });
+
+    it('appends dangerous audit logs to real execution results', () => {
+      const result = appendDangerousAuditResult({
+        content: [{ type: 'text', text: 'removed' }],
+      }, 'remove_item', { name: 'Draft', itemType: 'task' }, {
+        iss: 'omnifocus-mcp',
+        aud: 'omnifocus-mcp-dangerous-grant',
+        iat: 100,
+        exp: 200,
+        jti: 'grant-id',
+        grant_version: 1,
+        grant_type: 'exact',
+        scope: 'dangerous',
+        allowed_tools: ['remove_item'],
+        operation: {
+          tool: 'remove_item',
+          args_sha256: 'hash',
+        },
+      }, true);
+
+      expect(result.content[0].text).toBe('removed');
+      const payload = extractDangerousActionPayload(result);
+      expect(payload.executed).toBe(true);
+      expect(payload.dryRun).toBe(false);
+      expect(payload.message).toContain('handler executed');
+    });
+  });
+});
+
+function extractDangerousActionPayload(result: { content: Array<{ type: 'text'; text: string }> }): any {
+  const auditContent = result.content.find((content) => content.text.includes('"dangerousAction"'));
+  expect(auditContent).toBeDefined();
+  const jsonStart = auditContent!.text.indexOf('{');
+  expect(jsonStart).toBeGreaterThanOrEqual(0);
+  return JSON.parse(auditContent!.text.slice(jsonStart)).dangerousAction;
+}

--- a/src/tools/policy.ts
+++ b/src/tools/policy.ts
@@ -33,6 +33,7 @@ const WRITE_TOOLS = new Set([
 const DANGEROUS_TOOLS = new Set([
   'remove_item',
   'batch_remove_items',
+  'remove_tag',
 ]);
 
 const WRITE_MODES: OmniFocusMcpMode[] = ['write', 'dangerous'];

--- a/src/tools/policy.ts
+++ b/src/tools/policy.ts
@@ -1,0 +1,233 @@
+import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import { DangerousGrantClaims, dangerousArgsHash, validateDangerousGrant } from './dangerousGrant.js';
+
+export type OmniFocusMcpMode = 'readonly' | 'write' | 'dangerous';
+export type ToolAccessLevel = 'read' | 'write' | 'dangerous';
+
+export type ToolResult = {
+  content: Array<{
+    type: 'text';
+    text: string;
+  }>;
+  isError?: boolean;
+};
+
+type ToolHandler = (args: any, extra: RequestHandlerExtra) => Promise<ToolResult>;
+
+const READ_TOOLS = new Set([
+  'dump_database',
+  'query_omnifocus',
+  'list_perspectives',
+  'get_perspective_view',
+  'list_tags',
+]);
+
+const WRITE_TOOLS = new Set([
+  'add_omnifocus_task',
+  'add_project',
+  'edit_item',
+  'batch_add_items',
+  'create_tag',
+]);
+
+const DANGEROUS_TOOLS = new Set([
+  'remove_item',
+  'batch_remove_items',
+]);
+
+const WRITE_MODES: OmniFocusMcpMode[] = ['write', 'dangerous'];
+const DANGEROUS_MODES: OmniFocusMcpMode[] = ['dangerous'];
+const BROAD_BATCH_ITEM_LIMIT = 10;
+
+export function getOmniFocusMcpMode(env = process.env): OmniFocusMcpMode {
+  const mode = env.OMNIFOCUS_MCP_MODE;
+
+  if (mode === 'write' || mode === 'dangerous') {
+    return mode;
+  }
+
+  return 'readonly';
+}
+
+export function getToolAccessLevel(toolName: string, args: any = {}): ToolAccessLevel {
+  if (READ_TOOLS.has(toolName)) {
+    return 'read';
+  }
+
+  if (DANGEROUS_TOOLS.has(toolName)) {
+    return 'dangerous';
+  }
+
+  if (toolName === 'edit_item' && isDestructiveEdit(args)) {
+    return 'dangerous';
+  }
+
+  if (toolName === 'batch_add_items' && isBroadBatch(args)) {
+    return 'dangerous';
+  }
+
+  if (WRITE_TOOLS.has(toolName)) {
+    return 'write';
+  }
+
+  return 'dangerous';
+}
+
+export function isToolAllowed(toolName: string, args: any, mode = getOmniFocusMcpMode()): boolean {
+  const accessLevel = getToolAccessLevel(toolName, args);
+
+  if (accessLevel === 'read') {
+    return true;
+  }
+
+  if (accessLevel === 'write') {
+    return WRITE_MODES.includes(mode);
+  }
+
+  return DANGEROUS_MODES.includes(mode);
+}
+
+export function isDangerousDryRunEnabled(env = process.env): boolean {
+  return env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN === '1'
+    || env.OMNIFOCUS_MCP_DANGEROUS_DRY_RUN === 'true';
+}
+
+export function dangerousGrantRequiredResult(toolName: string, reason: string): ToolResult {
+  return {
+    content: [{
+      type: 'text',
+      text: `Tool "${toolName}" requires a valid dangerousGrant for this destructive operation. ${reason}`
+    }],
+    isError: true,
+  };
+}
+
+export function dangerousAuditPayload(
+  toolName: string,
+  args: Record<string, unknown>,
+  claims: DangerousGrantClaims | undefined,
+  executed: boolean
+): Record<string, unknown> {
+  const strippedArgs = stripDangerousGrant(args);
+
+  return {
+    dryRun: !executed,
+    tool: toolName,
+    accessLevel: 'dangerous',
+    argsHash: dangerousArgsHash(args),
+    args: strippedArgs,
+    grant: claims ? {
+      jti: claims.jti,
+      grantVersion: claims.grant_version,
+      grantType: claims.grant_type,
+      scope: claims.scope,
+      allowedTools: claims.allowed_tools,
+      expiresAt: claims.exp,
+      notBefore: claims.nbf,
+      reason: claims.reason,
+    } : undefined,
+    executed,
+    message: executed
+      ? 'Grant verified; OmniFocus mutation handler executed.'
+      : 'Grant verified; OmniFocus mutation was not executed because dangerous dry-run mode is enabled.',
+  };
+}
+
+export function appendDangerousAuditResult(
+  result: ToolResult,
+  toolName: string,
+  args: Record<string, unknown>,
+  claims: DangerousGrantClaims | undefined,
+  executed: boolean
+): ToolResult {
+  const auditText = JSON.stringify({
+    dangerousAction: dangerousAuditPayload(toolName, args, claims, executed),
+  }, null, 2);
+
+  return {
+    ...result,
+    content: [
+      ...result.content,
+      {
+        type: 'text',
+        text: auditText,
+      },
+    ],
+  };
+}
+
+export function dangerousDryRunResult(
+  toolName: string,
+  args: Record<string, unknown>,
+  claims?: DangerousGrantClaims
+): ToolResult {
+  return appendDangerousAuditResult({
+    content: [{
+      type: 'text',
+      text: `Dangerous dry run: grant verified for "${toolName}", but OMNIFOCUS_MCP_DANGEROUS_DRY_RUN is enabled so no OmniFocus mutation was executed.`
+    }]
+  }, toolName, args, claims, false);
+}
+
+export function blockedToolResult(toolName: string, args: any, mode = getOmniFocusMcpMode()): ToolResult {
+  const accessLevel = getToolAccessLevel(toolName, args);
+  const requiredMode = accessLevel === 'dangerous'
+    ? 'dangerous'
+    : 'write or dangerous';
+
+  return {
+    content: [{
+      type: 'text',
+      text: `Tool "${toolName}" is blocked by OmniFocus MCP safety policy. Current mode is "${mode}"; required mode is "${requiredMode}". Set OMNIFOCUS_MCP_MODE=${accessLevel === 'dangerous' ? 'dangerous' : 'write'} to allow this operation.`
+    }],
+    isError: true,
+  };
+}
+
+export function guardToolHandler(toolName: string, handler: ToolHandler): ToolHandler {
+  return async (args: any, extra: RequestHandlerExtra) => {
+    const mode = getOmniFocusMcpMode();
+    const accessLevel = getToolAccessLevel(toolName, args);
+
+    if (!isToolAllowed(toolName, args, mode)) {
+      return blockedToolResult(toolName, args, mode);
+    }
+
+    let dangerousGrantClaims: DangerousGrantClaims | undefined;
+    if (accessLevel === 'dangerous') {
+      const grantResult = validateDangerousGrant(toolName, args);
+      if (!grantResult.valid) {
+        return dangerousGrantRequiredResult(toolName, grantResult.reason ?? 'Grant validation failed.');
+      }
+      dangerousGrantClaims = grantResult.claims;
+      if (isDangerousDryRunEnabled()) {
+        return dangerousDryRunResult(toolName, args, dangerousGrantClaims);
+      }
+    }
+
+    const result = await handler(stripDangerousGrant(args), extra);
+    if (accessLevel === 'dangerous') {
+      return appendDangerousAuditResult(result, toolName, args, dangerousGrantClaims, true);
+    }
+
+    return result;
+  };
+}
+
+function stripDangerousGrant(args: any): any {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) {
+    return args;
+  }
+
+  const { dangerousGrant, ...rest } = args;
+  return rest;
+}
+
+function isDestructiveEdit(args: any): boolean {
+  return ['completed', 'dropped', 'skipped'].includes(args?.newStatus)
+    || ['completed', 'dropped'].includes(args?.newProjectStatus);
+}
+
+function isBroadBatch(args: any): boolean {
+  return Array.isArray(args?.items) && args.items.length > BROAD_BATCH_ITEM_LIMIT;
+}

--- a/src/tools/primitives/removeTag.test.ts
+++ b/src/tools/primitives/removeTag.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { generateAppleScript } from './removeTag.js';
+
+describe('removeTag generateAppleScript', () => {
+  it('generates tag removal by name', () => {
+    const script = generateAppleScript({ name: 'Old Tag' });
+
+    expect(script).toContain('first flattened tag whose name is "Old Tag"');
+    expect(script).toContain('delete foundTag');
+  });
+
+  it('generates tag removal by id', () => {
+    const script = generateAppleScript({ id: 'abc123' });
+
+    expect(script).toContain('first flattened tag whose id is "abc123"');
+    expect(script).toContain('delete foundTag');
+  });
+
+  it('falls back to name when id lookup fails', () => {
+    const script = generateAppleScript({ id: 'abc123', name: 'Old Tag' });
+
+    expect(script).toContain('first flattened tag whose id is "abc123"');
+    expect(script).toContain('if foundTag is missing value then');
+    expect(script).toContain('first flattened tag whose name is "Old Tag"');
+  });
+
+  it('returns error when neither id nor name provided', () => {
+    const script = generateAppleScript({});
+
+    expect(script).toContain('Either id or name must be provided');
+  });
+
+  it('escapes special characters in tag identifiers', () => {
+    const script = generateAppleScript({ name: 'My "Tag"' });
+
+    expect(script).toContain('My \\"Tag\\"');
+  });
+});

--- a/src/tools/primitives/removeTag.ts
+++ b/src/tools/primitives/removeTag.ts
@@ -1,0 +1,115 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
+const execAsync = promisify(exec);
+
+export interface RemoveTagParams {
+  id?: string;
+  name?: string;
+}
+
+export function generateAppleScript(params: RemoveTagParams): string {
+  const id = params.id ? escapeAppleScriptString(params.id) : '';
+  const name = params.name ? escapeAppleScriptString(params.name) : '';
+
+  if (!id && !name) {
+    return `return "{\\\"success\\\":false,\\\"error\\\":\\\"Either id or name must be provided\\\"}"`;
+  }
+
+  let script = `
+  try
+    tell application "OmniFocus"
+      tell front document
+        set foundTag to missing value
+`;
+
+  if (id) {
+    script += `
+        try
+          set foundTag to first flattened tag whose id is "${id}"
+        end try
+`;
+  }
+
+  if (!id && name) {
+    script += `
+        try
+          set foundTag to first flattened tag whose name is "${name}"
+        end try
+`;
+  } else if (id && name) {
+    script += `
+        if foundTag is missing value then
+          try
+            set foundTag to first flattened tag whose name is "${name}"
+          end try
+        end if
+`;
+  }
+
+  script += `
+        if foundTag is not missing value then
+          set tagName to name of foundTag
+          set tagId to id of foundTag as string
+          delete foundTag
+          return "{\\\"success\\\":true,\\\"id\\\":\\"" & tagId & "\\",\\\"name\\\":\\"" & tagName & "\\"}"
+        else
+          return "{\\\"success\\\":false,\\\"error\\\":\\\"Tag not found\\\"}"
+        end if
+      end tell
+    end tell
+  on error errorMessage
+    return "{\\\"success\\\":false,\\\"error\\\":\\"" & errorMessage & "\\"}"
+  end try
+  `;
+
+  return script;
+}
+
+export async function removeTag(params: RemoveTagParams): Promise<{success: boolean, id?: string, name?: string, error?: string}> {
+  let tempFile: string | undefined;
+
+  try {
+    const script = generateAppleScript(params);
+
+    tempFile = join(tmpdir(), `remove_tag_${crypto.randomUUID()}.applescript`);
+    writeFileSync(tempFile, script, { encoding: 'utf8' });
+
+    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
+
+    try { unlinkSync(tempFile); } catch {}
+
+    if (stderr) {
+      console.error("AppleScript stderr:", stderr);
+    }
+
+    try {
+      const result = JSON.parse(stdout);
+      return {
+        success: result.success,
+        id: result.id,
+        name: result.name,
+        error: result.error
+      };
+    } catch (parseError) {
+      console.error("Error parsing AppleScript result:", parseError);
+      return {
+        success: false,
+        error: `Failed to parse result: ${stdout}`
+      };
+    }
+  } catch (error: any) {
+    if (tempFile) {
+      try { unlinkSync(tempFile); } catch {}
+    }
+
+    console.error("Error in removeTag:", error);
+    return {
+      success: false,
+      error: error?.message || "Unknown error in removeTag"
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add an SSH signature dangerous-grant backend using `ssh-keygen -Y sign` / `ssh-keygen -Y verify`.
- Preserve the existing JWT-style private-key signer as the default compatibility path.
- Add `omnifocus-mcp-grant --signer ssh-signature` with `--ssh-signing-key-*` public identity inputs.
- Add `--ssh-auth-sock` so callers can explicitly target the 1Password SSH agent.
- Extend `doctor` to verify the no-export SSH signature path.
- Document the 1Password public-key/agent-socket flow.

## Verification

- `npm test`
- `npm run build`
- Built CLI generated and verified an `SSHSIG` token with a temporary Ed25519 keypair.
- Built CLI doctor succeeded with the user's 1Password public key refs and explicit 1Password SSH agent socket.

## Safety

- No live OmniFocus destructive actions were run.
- The no-export path reads public key material only and delegates signing to `ssh-keygen` / the configured SSH agent.
