### PR TITLE
Fix #57: verify task persisted before add_omnifocus_task returns success

### DIFF
--- a/src/tools/primitives/addOmniFocusTask.test.ts
+++ b/src/tools/primitives/addOmniFocusTask.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { generateAppleScript } from './addOmniFocusTask.js';
+import { describe, it, expect, vi } from 'vitest';
+import { generateAppleScript, verifyPersistedWithRetries } from './addOmniFocusTask.js';
 
 describe('addOmniFocusTask generateAppleScript', () => {
   it('creates inbox task when no project specified', () => {
@@ -25,5 +25,42 @@ describe('addOmniFocusTask generateAppleScript', () => {
     expect(script).toContain(
       'set note of newTask to "Line 1" & linefeed & "Line 2" & linefeed & "Line 3"'
     );
+  });
+});
+
+describe('verifyPersistedWithRetries (issue #57 persistence guard)', () => {
+  const noSleep = () => Promise.resolve();
+
+  it('returns true on the first successful probe without sleeping', async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const sleepFn = vi.fn(noSleep);
+    const ok = await verifyPersistedWithRetries(probe, { sleepFn });
+    expect(ok).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it('retries until a later probe succeeds, then stops', async () => {
+    const probe = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const ok = await verifyPersistedWithRetries(probe, {
+      delaysMs: [0, 10, 20, 40],
+      sleepFn: noSleep,
+    });
+    expect(ok).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns false when the task never becomes resolvable', async () => {
+    const probe = vi.fn().mockResolvedValue(false);
+    const ok = await verifyPersistedWithRetries(probe, {
+      delaysMs: [0, 10, 20],
+      sleepFn: noSleep,
+    });
+    expect(ok).toBe(false);
+    expect(probe).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -211,6 +211,81 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
   return script;
 }
 
+// Backoff schedule (ms) for confirming a freshly-created task is resolvable.
+// First probe is immediate; on a warm database it hits and adds one cheap read.
+// The tail (~1.5s total) only elapses in the rare cold/racy case.
+const VERIFY_DELAYS_MS = [0, 50, 100, 200, 400, 800];
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Retry a "is this task resolvable yet?" probe on a backoff schedule, returning
+ * true as soon as the probe succeeds and false if it never does.
+ *
+ * Extracted (with injectable probe/sleep) so the retry behavior can be unit
+ * tested without driving osascript. See verifyTaskResolvable for why this exists.
+ */
+export async function verifyPersistedWithRetries(
+  probe: () => Promise<boolean>,
+  opts: { delaysMs?: number[]; sleepFn?: (ms: number) => Promise<void> } = {}
+): Promise<boolean> {
+  const delays = opts.delaysMs ?? VERIFY_DELAYS_MS;
+  const doSleep = opts.sleepFn ?? sleep;
+  for (const delay of delays) {
+    if (delay > 0) await doSleep(delay);
+    if (await probe()) return true;
+  }
+  return false;
+}
+
+/**
+ * Confirm a newly-created task is resolvable by its id in a SEPARATE osascript
+ * invocation before we report success (issue #57).
+ *
+ * OmniFocus commits new objects on its own run loop. Immediately after
+ * `make new task`, the record can be briefly invisible to a fresh `whose id`
+ * lookup from another process, so an immediate follow-up edit_item (by the id we
+ * returned) finds nothing — yet add reported success. That silent false-success
+ * is the worst failure class: it makes the audit trail lie.
+ *
+ * The re-fetch MUST be a separate process. An in-script re-fetch (inside the
+ * create tell block) resolves the in-memory object even when it isn't yet visible
+ * to other processes, so it cannot distinguish committed from uncommitted —
+ * verified empirically. A bounded, separate-process retry waits the commit out —
+ * the same effect as the reporter's manual query-between-calls workaround — and
+ * lets us return an honest failure if the task truly never lands.
+ */
+async function verifyTaskResolvable(taskId: string): Promise<boolean> {
+  const escapedId = escapeAppleScriptString(taskId);
+  const script = `
+    tell application "OmniFocus"
+      tell front document
+        try
+          set t to first flattened task whose id is "${escapedId}"
+          return "found"
+        on error
+          return "missing"
+        end try
+      end tell
+    end tell`;
+
+  const probe = async (): Promise<boolean> => {
+    const tempFile = join(tmpdir(), `omnifocus_verify_${crypto.randomUUID()}.applescript`);
+    try {
+      writeFileSync(tempFile, script, { encoding: 'utf8' });
+      const { stdout } = await execAsync(`osascript "${tempFile}"`);
+      return stdout.trim() === 'found';
+    } catch {
+      // Treat a transient osascript error as not-yet-resolvable and keep retrying.
+      return false;
+    } finally {
+      try { unlinkSync(tempFile); } catch {}
+    }
+  };
+
+  return verifyPersistedWithRetries(probe);
+}
+
 /**
  * Add a task to OmniFocus
  */
@@ -239,7 +314,23 @@ export async function addOmniFocusTask(params: AddOmniFocusTaskParams): Promise<
     // Parse the result
     try {
       const result = JSON.parse(stdout);
-      
+
+      // Before reporting success, confirm the task actually persisted and is
+      // resolvable by the id we're about to hand back (issue #57). Without this,
+      // an immediate follow-up edit_item can operate on a not-yet-committed task
+      // and the "success" we returned would be a lie.
+      if (result.success && result.taskId) {
+        const persisted = await verifyTaskResolvable(result.taskId);
+        if (!persisted) {
+          return {
+            success: false,
+            taskId: result.taskId,
+            placement: result.placement,
+            error: `Task "${params.name}" was created but could not be confirmed in OmniFocus after retries; it may not have persisted. Please retry.`
+          };
+        }
+      }
+
       // Return the result
       return {
         success: result.success,


### PR DESCRIPTION
Closes #57.

## Problem

`add_omnifocus_task` could report success for a task that hadn't yet committed in OmniFocus. OmniFocus commits new objects on its own run loop, so immediately after `make new task` the record can be briefly invisible to a fresh `whose id` lookup **from another process**. An immediate follow-up `edit_item` (by the returned id) then finds nothing — yet `add` already claimed success. That silent false-success is the worst failure class: it makes the audit trail lie and every downstream agent unreliable.

## Investigation

Reproduced the exact production path (project + tags + note + immediate `mark complete` by id) against a live OmniFocus: **25/25 inbox and 30/30 in-project, zero failures, id never drifted.** The race is real (see the issue thread + integration-test cold-run flakiness) but **environment-triggered — it does not reproduce on a warm database.**

Key mechanism finding: an *in-script* re-fetch (inside the create `tell` block) resolves the in-memory object even at zero delay, so it **cannot distinguish committed from uncommitted.** The re-fetch only means something as a **separate process**, which is what actually waits out the run-loop commit — the same reason the reporter's manual query-between-calls workaround worked.

## Fix

After the create script returns, confirm the new task is resolvable by its id in a **separate `osascript` invocation** before reporting success, retrying on a short backoff (immediate first probe → one cheap read when warm; ~1.5s worst case). If it never resolves, return an honest `success: false` instead of a false success.

Living in the primitive, this also hardens `batch_add_items`, which feeds a created task's id back as `parentTaskId` for its children.

Retry logic is extracted as `verifyPersistedWithRetries` (injectable probe/sleep) and unit tested for the first-hit, retry-then-hit, and never-resolves cases.

## Testing

- `npx tsc --noEmit` clean
- `npm test` — 224 pass (3 new)
- `npm run build` OK
- Live happy-path 8/8 through the new guard; 0 `TEST:` leftovers afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)