### PR TITLE
#80: idle-timeout backstop to reap orphaned stdio servers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { SetLevelRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { Logger } from './utils/logger.js';
 import { setScriptLogger } from './utils/scriptExecution.js';
+import { resolveIdleTimeoutMinutes, installIdleTimeout } from './utils/idleTimeout.js';
 import { registerResources } from './resources/index.js';
 
 // Import tool definitions
@@ -186,3 +187,21 @@ process.stdin.on('close', shutdown);
 process.on('SIGTERM', shutdown);
 process.on('SIGHUP', shutdown);
 process.on('SIGINT', shutdown);
+
+// Idle-timeout backstop (issue #80). The stdin-EOF and signal handlers above
+// catch the clean-disconnect case; when the wrapper chain holds stdin open after
+// a SIGKILL'd client, they don't fire and the server lingers as an orphan. If no
+// client traffic arrives within the idle window, exit. Every JSON-RPC request
+// reaches us as stdin data (the SDK's stdio transport also listens on 'data', so
+// our listener is additive), so an actively-used server keeps resetting the timer
+// and never times out. Configure with OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES
+// (default 30; set 0 to disable). See src/utils/idleTimeout.ts.
+const idleTimeoutMinutes = resolveIdleTimeoutMinutes(
+  process.env.OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES
+);
+installIdleTimeout(process.stdin, idleTimeoutMinutes, () => {
+  console.error(
+    `[omnifocus-mcp] no client traffic for ${idleTimeoutMinutes}m; exiting to avoid orphaned-process accumulation (issue #80).`
+  );
+  process.exit(0);
+});

--- a/src/utils/idleTimeout.test.ts
+++ b/src/utils/idleTimeout.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { Readable } from 'stream';
+import {
+  resolveIdleTimeoutMinutes,
+  installIdleTimeout,
+  DEFAULT_IDLE_TIMEOUT_MINUTES,
+} from './idleTimeout.js';
+
+describe('resolveIdleTimeoutMinutes', () => {
+  it('uses the default when unset or empty', () => {
+    expect(resolveIdleTimeoutMinutes(undefined)).toBe(DEFAULT_IDLE_TIMEOUT_MINUTES);
+    expect(resolveIdleTimeoutMinutes('')).toBe(DEFAULT_IDLE_TIMEOUT_MINUTES);
+    expect(resolveIdleTimeoutMinutes('   ')).toBe(DEFAULT_IDLE_TIMEOUT_MINUTES);
+  });
+
+  it('parses a valid number', () => {
+    expect(resolveIdleTimeoutMinutes('45')).toBe(45);
+    expect(resolveIdleTimeoutMinutes('0')).toBe(0);
+  });
+
+  it('falls back to the default on invalid or negative input', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(resolveIdleTimeoutMinutes('nope')).toBe(DEFAULT_IDLE_TIMEOUT_MINUTES);
+    expect(resolveIdleTimeoutMinutes('-5')).toBe(DEFAULT_IDLE_TIMEOUT_MINUTES);
+    spy.mockRestore();
+  });
+
+  it('honors an explicit custom default', () => {
+    expect(resolveIdleTimeoutMinutes(undefined, 60)).toBe(60);
+  });
+});
+
+describe('installIdleTimeout', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const fakeStream = () => new EventEmitter() as unknown as Readable;
+
+  it('fires onIdle after the window with no traffic', () => {
+    const stream = fakeStream();
+    const onIdle = vi.fn();
+    installIdleTimeout(stream, 1, onIdle);
+    expect(onIdle).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(60_000);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the timer on each data chunk', () => {
+    const stream = fakeStream();
+    const onIdle = vi.fn();
+    installIdleTimeout(stream, 1, onIdle);
+    vi.advanceTimersByTime(50_000);
+    stream.emit('data', Buffer.from('{}')); // reset
+    vi.advanceTimersByTime(50_000);
+    expect(onIdle).not.toHaveBeenCalled(); // 50s < window since last chunk
+    vi.advanceTimersByTime(10_000);
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when disabled (0 or negative)', () => {
+    const stream = fakeStream();
+    const onIdle = vi.fn();
+    const dispose = installIdleTimeout(stream, 0, onIdle);
+    vi.advanceTimersByTime(10 * 60_000);
+    expect(onIdle).not.toHaveBeenCalled();
+    expect(stream.listenerCount('data')).toBe(0);
+    dispose(); // safe to call
+  });
+
+  it('disposer removes the listener and prevents firing', () => {
+    const stream = fakeStream();
+    const onIdle = vi.fn();
+    const dispose = installIdleTimeout(stream, 1, onIdle);
+    expect(stream.listenerCount('data')).toBe(1);
+    dispose();
+    expect(stream.listenerCount('data')).toBe(0);
+    vi.advanceTimersByTime(60_000);
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/idleTimeout.ts
+++ b/src/utils/idleTimeout.ts
@@ -1,0 +1,67 @@
+import type { Readable } from 'stream';
+
+/**
+ * Idle-timeout backstop for the stdio server (issue #80).
+ *
+ * Signal/EOF propagation through the npx → cli.cjs → node wrapper chain is
+ * unreliable: an orphaned server whose client was SIGKILL'd — and whose stdin an
+ * intermediate wrapper is holding open — can survive for days, accumulating and
+ * contending for AppleEvents on the single shared OmniFocus.app (the cause of the
+ * -1712 timeout storms). The server's stdin-EOF and signal handlers catch the
+ * clean-disconnect case; this is the last-resort catch for the unclean one.
+ */
+
+export const DEFAULT_IDLE_TIMEOUT_MINUTES = 30;
+
+/**
+ * Resolve the idle timeout (in minutes) from an env value. Empty/undefined uses
+ * the default; 0 disables; anything non-numeric or negative falls back to the
+ * default with a warning. Pure and side-effect-free except the warning log.
+ */
+export function resolveIdleTimeoutMinutes(
+  raw: string | undefined,
+  defaultMinutes: number = DEFAULT_IDLE_TIMEOUT_MINUTES
+): number {
+  if (raw === undefined || raw.trim() === '') return defaultMinutes;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(
+      `[omnifocus-mcp] ignoring invalid OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES="${raw}"; using default ${defaultMinutes}.`
+    );
+    return defaultMinutes;
+  }
+  return parsed;
+}
+
+/**
+ * Arm an idle timer that fires `onIdle` after `minutes` with no data on `input`.
+ * Every chunk resets the timer, so an actively-used server never times out
+ * (each JSON-RPC request arrives as stdin data). A non-positive `minutes`
+ * disables the backstop entirely. Returns a disposer that removes the listener
+ * and clears the timer.
+ */
+export function installIdleTimeout(
+  input: Readable,
+  minutes: number,
+  onIdle: () => void
+): () => void {
+  if (!(minutes > 0)) return () => {};
+
+  const idleMs = minutes * 60_000;
+  let timer: ReturnType<typeof setTimeout>;
+
+  const reset = (): void => {
+    clearTimeout(timer);
+    timer = setTimeout(onIdle, idleMs);
+    // Don't let this timer alone keep the process alive — stdin already does.
+    (timer as { unref?: () => void }).unref?.();
+  };
+
+  input.on('data', reset);
+  reset();
+
+  return () => {
+    clearTimeout(timer);
+    input.off('data', reset);
+  };
+}


### PR DESCRIPTION
Part of #80 (the 80/20; attacks problem **A: process accumulation**). Does not close #80 — the contention piece (B) and the daemon discussion remain.

## Problem

When a client is SIGKILL'd, EOF may never reach the server through the `npx → cli.cjs → node` wrapper chain (an intermediate wrapper can hold stdin open), so the existing stdin-EOF + signal handlers don't fire and the server lingers as an orphan for days — accumulating and contending for AppleEvents on the single shared `OmniFocus.app` (the `-1712` storms behind the June-15 incident: 16 survivors, oldest ~2 weeks old).

## Fix

A last-resort idle backstop: if no client traffic arrives within an idle window, exit. Every JSON-RPC request reaches the server as stdin `data` (the SDK's stdio transport also listens on `'data'`, so our listener is additive and doesn't disturb it), so each request resets the timer and an actively-used server never times out.

Configurable via `OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES` (default 30; `0` disables). Logic is extracted to `src/utils/idleTimeout.ts` so it's unit-testable (the entry `server.ts` runs side effects on import).

## Testing

- `npx tsc --noEmit` clean; `npm test` — 232 pass (8 new: env parsing incl. invalid/negative/disable, firing, reset-on-traffic, disposer)
- `npm run build` OK
- **Live smoke test against the built server:** no-traffic server idle-exits at the window (3.1s for a 3s window); a server heartbeated for 5s survives past the window and is reaped only ~3s after traffic stops — confirming an in-use server is never killed.

## Note on the default

30 min is conservative but could in principle reap a live-but-silent session that goes 30 min between OmniFocus calls (rare for agent workloads; each tool call resets it). Env-tunable if that bites. Follow-ups for the rest of the 80/20: a shared osascript runner with bounded concurrency + `with timeout` + `-1712` retry (problem B), and collapsing the `cli.cjs` wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)