### PR TITLE
#80: bound + fast-fail + retry osascript to tame AppleEvent contention

### DIFF
--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -1,11 +1,9 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { runOsascriptFile } from '../../utils/scriptExecution.js';
 import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { createDateOutsideTellBlock } from '../../utils/dateFormatting.js';
 import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
-const execAsync = promisify(exec);
 
 // Interface for task creation parameters
 export interface AddOmniFocusTaskParams {
@@ -273,7 +271,7 @@ async function verifyTaskResolvable(taskId: string): Promise<boolean> {
     const tempFile = join(tmpdir(), `omnifocus_verify_${crypto.randomUUID()}.applescript`);
     try {
       writeFileSync(tempFile, script, { encoding: 'utf8' });
-      const { stdout } = await execAsync(`osascript "${tempFile}"`);
+      const { stdout } = await runOsascriptFile(tempFile);
       return stdout.trim() === 'found';
     } catch {
       // Treat a transient osascript error as not-yet-resolvable and keep retrying.
@@ -300,7 +298,7 @@ export async function addOmniFocusTask(params: AddOmniFocusTaskParams): Promise<
     writeFileSync(tempFile, script, { encoding: 'utf8' });
 
     // Execute AppleScript from file
-    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
+    const { stdout, stderr } = await runOsascriptFile(tempFile);
 
     if (stderr) {
       console.error("AppleScript stderr:", stderr);

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -1,11 +1,9 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { createDateOutsideTellBlock } from '../../utils/dateFormatting.js';
 import { generateFolderLookupScript, escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
-const execAsync = promisify(exec);
+import { runOsascriptFile } from '../../utils/scriptExecution.js';
 
 // Interface for project creation parameters
 export interface AddProjectParams {
@@ -134,7 +132,7 @@ export async function addProject(params: AddProjectParams): Promise<{success: bo
     writeFileSync(tempFile, script, { encoding: 'utf8' });
 
     // Execute AppleScript from file
-    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
+    const { stdout, stderr } = await runOsascriptFile(tempFile);
 
     // Clean up temp file
     try { unlinkSync(tempFile); } catch {}

--- a/src/tools/primitives/createTag.ts
+++ b/src/tools/primitives/createTag.ts
@@ -1,10 +1,8 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
-const execAsync = promisify(exec);
+import { runOsascriptFile } from '../../utils/scriptExecution.js';
 
 export interface CreateTagParams {
   name: string;
@@ -78,7 +76,7 @@ export async function createTag(params: CreateTagParams): Promise<{success: bool
     tempFile = join(tmpdir(), `create_tag_${crypto.randomUUID()}.applescript`);
     writeFileSync(tempFile, script, { encoding: 'utf8' });
 
-    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
+    const { stdout, stderr } = await runOsascriptFile(tempFile);
 
     try { unlinkSync(tempFile); } catch {}
 

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -1,11 +1,9 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { runOsascriptFile } from '../../utils/scriptExecution.js';
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { generateDateAssignmentV2 } from '../../utils/dateFormatting.js';
 import { generateFolderLookupScript, generateProjectLookupScript, escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
-const execAsync = promisify(exec);
 
 // Status options for tasks and projects
 type TaskStatus = 'incomplete' | 'completed' | 'dropped' | 'skipped';
@@ -482,7 +480,7 @@ export async function editItem(params: EditItemParams): Promise<{
     writeFileSync(tempFile, script);
     
     // Execute AppleScript from file
-    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
+    const { stdout, stderr } = await runOsascriptFile(tempFile);
     
     // Clean up temp file
     try {

--- a/src/tools/primitives/removeItem.ts
+++ b/src/tools/primitives/removeItem.ts
@@ -1,10 +1,8 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
-const execAsync = promisify(exec);
+import { runOsascriptFile } from '../../utils/scriptExecution.js';
 
 // Interface for item removal parameters
 export interface RemoveItemParams {
@@ -142,7 +140,7 @@ export async function removeItem(params: RemoveItemParams): Promise<{success: bo
     writeFileSync(tempFile, script);
 
     // Execute AppleScript from file
-    const { stdout, stderr } = await execAsync(`osascript "${tempFile}"`);
+    const { stdout, stderr } = await runOsascriptFile(tempFile);
 
     // Clean up temp file
     try {

--- a/src/utils/scriptExecution.test.ts
+++ b/src/utils/scriptExecution.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  Semaphore,
+  isRetryableOsascriptError,
+  withOsascriptRetry,
+} from './scriptExecution.js';
+
+describe('Semaphore', () => {
+  it('never runs more than max tasks concurrently', async () => {
+    const sem = new Semaphore(2);
+    let active = 0;
+    let peak = 0;
+    const release: Array<() => void> = [];
+    const make = () =>
+      sem.run(
+        () =>
+          new Promise<void>((resolve) => {
+            active++;
+            peak = Math.max(peak, active);
+            release.push(() => {
+              active--;
+              resolve();
+            });
+          })
+      );
+
+    const tasks = [make(), make(), make(), make()];
+    // Give the semaphore a tick to admit the first batch.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(active).toBe(2); // only 2 admitted
+    // Drain them one at a time.
+    while (release.length) {
+      release.shift()!();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    await Promise.all(tasks);
+    expect(peak).toBe(2);
+  });
+
+  it('releases a slot even when the task throws', async () => {
+    const sem = new Semaphore(1);
+    await expect(sem.run(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+    // If the slot leaked, this second task would hang; a resolved value proves release.
+    await expect(sem.run(() => Promise.resolve('ok'))).resolves.toBe('ok');
+  });
+});
+
+describe('isRetryableOsascriptError', () => {
+  it('flags -1712 / AppleEvent timeouts and killed processes', () => {
+    expect(isRetryableOsascriptError({ message: 'AppleEvent timed out (-1712)' })).toBe(true);
+    expect(isRetryableOsascriptError({ stderr: 'execution error: -1712' })).toBe(true);
+    expect(isRetryableOsascriptError({ killed: true })).toBe(true);
+    expect(isRetryableOsascriptError({ signal: 'SIGTERM' })).toBe(true);
+  });
+
+  it('does not flag genuine script errors', () => {
+    expect(isRetryableOsascriptError({ message: 'syntax error: Expected end of line' })).toBe(false);
+    expect(isRetryableOsascriptError({ stderr: 'Project not found: Foo' })).toBe(false);
+    expect(isRetryableOsascriptError(undefined)).toBe(false);
+  });
+});
+
+describe('withOsascriptRetry', () => {
+  const noSleep = () => Promise.resolve();
+
+  it('returns immediately on success', async () => {
+    const attempt = vi.fn().mockResolvedValue('ok');
+    const out = await withOsascriptRetry(attempt, { shouldRetry: () => true, sleepFn: noSleep });
+    expect(out).toBe('ok');
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries retryable failures then succeeds', async () => {
+    const err = { message: '-1712' };
+    const attempt = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValue('ok');
+    const out = await withOsascriptRetry(attempt, {
+      shouldRetry: isRetryableOsascriptError,
+      backoffsMs: [1, 1],
+      sleepFn: noSleep,
+    });
+    expect(out).toBe('ok');
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry non-retryable failures', async () => {
+    const attempt = vi.fn().mockRejectedValue({ message: 'syntax error' });
+    await expect(
+      withOsascriptRetry(attempt, {
+        shouldRetry: isRetryableOsascriptError,
+        backoffsMs: [1, 1],
+        sleepFn: noSleep,
+      })
+    ).rejects.toMatchObject({ message: 'syntax error' });
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after exhausting backoffs and rethrows the last error', async () => {
+    const attempt = vi.fn().mockRejectedValue({ message: '-1712' });
+    await expect(
+      withOsascriptRetry(attempt, {
+        shouldRetry: isRetryableOsascriptError,
+        backoffsMs: [1, 1],
+        sleepFn: noSleep,
+      })
+    ).rejects.toMatchObject({ message: '-1712' });
+    // initial try + 2 backoff retries = 3 attempts
+    expect(attempt).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/utils/scriptExecution.ts
+++ b/src/utils/scriptExecution.ts
@@ -17,6 +17,128 @@ export function setScriptLogger(logger: Logger): void {
   _logger = logger;
 }
 
+// --- osascript contention control (issue #80, problem B) -----------------------
+// OmniFocus.app is a single-threaded shared resource. Under concurrency it
+// returns `AppleEvent timed out (-1712)` and, at the default timeout, hangs each
+// caller for ~120s. We can't fix cross-process contention from inside one server,
+// but we can stop a single server from making it worse and fail fast instead of
+// hanging: (1) bound how many osascript children we run at once, (2) impose a
+// Node-level timeout that kills a stuck osascript, (3) retry timeouts with
+// backoff — but ONLY for idempotent reads. A -1712 on a write may have partially
+// applied, so retrying a create could duplicate; writes fail fast and honestly.
+
+function resolvePositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+const MAX_CONCURRENT_OSASCRIPT = resolvePositiveIntEnv('OMNIFOCUS_MCP_MAX_CONCURRENT_OSASCRIPT', 4);
+const OSASCRIPT_TIMEOUT_MS = resolvePositiveIntEnv('OMNIFOCUS_MCP_OSASCRIPT_TIMEOUT_MS', 60_000);
+
+/** Minimal FIFO semaphore bounding concurrent work. */
+export class Semaphore {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+  constructor(private readonly max: number) {}
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.active >= this.max) {
+      await new Promise<void>((resolve) => this.queue.push(resolve));
+    }
+    this.active++;
+    try {
+      return await fn();
+    } finally {
+      this.active--;
+      this.queue.shift()?.();
+    }
+  }
+}
+
+const osascriptSemaphore = new Semaphore(MAX_CONCURRENT_OSASCRIPT);
+
+/**
+ * A -1712 AppleEvent timeout, or a Node-level kill of a stuck osascript, is
+ * transient contention and safe to retry for reads. Genuine script errors are
+ * not (and must not be retried).
+ */
+export function isRetryableOsascriptError(err: unknown): boolean {
+  const e = err as { message?: string; stderr?: string; killed?: boolean; signal?: string };
+  const text = `${e?.message ?? ''} ${e?.stderr ?? ''}`;
+  return (
+    e?.killed === true ||
+    e?.signal === 'SIGTERM' ||
+    text.includes('-1712') ||
+    text.includes('AppleEvent timed out') ||
+    text.includes('timed out')
+  );
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `attempt`, retrying with backoff while `shouldRetry(err)` holds. Extracted
+ * (with injectable sleep) so the retry policy is unit-testable without osascript.
+ */
+export async function withOsascriptRetry<T>(
+  attempt: () => Promise<T>,
+  opts: {
+    shouldRetry: (err: unknown) => boolean;
+    backoffsMs?: number[];
+    sleepFn?: (ms: number) => Promise<void>;
+  }
+): Promise<T> {
+  const backoffs = opts.backoffsMs ?? [500, 1500];
+  const doSleep = opts.sleepFn ?? sleep;
+  let i = 0;
+  for (;;) {
+    try {
+      return await attempt();
+    } catch (err) {
+      if (i >= backoffs.length || !opts.shouldRetry(err)) throw err;
+      _logger?.error('scriptExecution', `osascript retryable failure (attempt ${i + 1}); retrying`);
+      await doSleep(backoffs[i]);
+      i++;
+    }
+  }
+}
+
+export interface RunOsascriptOptions {
+  language?: 'AppleScript' | 'JavaScript';
+  maxBuffer?: number;
+  timeoutMs?: number;
+  /** Only enable for idempotent reads — see the note above. */
+  retryOnTimeout?: boolean;
+}
+
+/**
+ * Execute an osascript file behind the shared concurrency gate with a hard
+ * timeout, optionally retrying transient timeouts. All osascript invocations in
+ * the server route through here so the bounds actually apply globally per-process.
+ */
+export async function runOsascriptFile(
+  tempFile: string,
+  options: RunOsascriptOptions = {}
+): Promise<{ stdout: string; stderr: string }> {
+  const {
+    language,
+    maxBuffer = MAX_BUFFER,
+    timeoutMs = OSASCRIPT_TIMEOUT_MS,
+    retryOnTimeout = false,
+  } = options;
+  const langFlag = language === 'JavaScript' ? '-l JavaScript ' : '';
+  const cmd = `osascript ${langFlag}"${tempFile}"`;
+
+  const attempt = () =>
+    osascriptSemaphore.run(() =>
+      execAsync(cmd, { maxBuffer, timeout: timeoutMs, killSignal: 'SIGTERM' })
+    );
+
+  if (!retryOnTimeout) return attempt();
+  return withOsascriptRetry(attempt, { shouldRetry: isRetryableOsascriptError });
+}
+
 // Helper function to execute OmniFocus scripts
 export async function executeJXA(script: string): Promise<any[]> {
   const start = Date.now();
@@ -29,11 +151,11 @@ export async function executeJXA(script: string): Promise<any[]> {
 
     _logger?.debug("scriptExecution", "Executing JXA script");
 
-    // Execute the script using osascript
-    const { stdout, stderr } = await execAsync(
-      `osascript -l JavaScript ${tempFile}`,
-      { maxBuffer: MAX_BUFFER }
-    );
+    // Execute the script using osascript (read path — safe to retry on -1712)
+    const { stdout, stderr } = await runOsascriptFile(tempFile, {
+      language: 'JavaScript',
+      retryOnTimeout: true,
+    });
 
     if (stderr) {
       console.error("Script stderr output:", stderr);
@@ -162,11 +284,11 @@ ${scriptContent}`;
     // Write the JXA script to the temporary file
     writeFileSync(tempFile, jxaScript);
 
-    // Execute the JXA script using osascript
-    const { stdout, stderr } = await execAsync(
-      `osascript -l JavaScript ${tempFile}`,
-      { maxBuffer: MAX_BUFFER }
-    );
+    // Execute the JXA script using osascript (read path — safe to retry on -1712)
+    const { stdout, stderr } = await runOsascriptFile(tempFile, {
+      language: 'JavaScript',
+      retryOnTimeout: true,
+    });
 
     // Clean up the temporary file
     unlinkSync(tempFile);


### PR DESCRIPTION
Second part of #80 (the 80/20; attacks problem **B: AppleEvent contention**). With #86 (idle-timeout, problem A) this is the 80/20 shipped. Does not close #80 — the wrapper-collapse follow-up and the singleton-daemon RFC remain open.

## Problem

`OmniFocus.app` is a single-threaded shared resource. Under concurrency it returns `AppleEvent timed out (-1712)` and, at the default timeout, hangs each caller for ~120s. A single server can't fix cross-process contention, but it can stop making it worse and fail fast instead of hanging.

## Fix

A shared `runOsascriptFile` runner that **all 8 osascript invocations now route through**, so the bounds actually apply per-process:

- **FIFO `Semaphore`** bounding concurrent osascript children (`OMNIFOCUS_MCP_MAX_CONCURRENT_OSASCRIPT`, default 4)
- **Node-level timeout** that kills a stuck osascript instead of hanging (`OMNIFOCUS_MCP_OSASCRIPT_TIMEOUT_MS`, default 60s)
- **retry-with-backoff on transient timeouts — reads only.** A `-1712` on a *write* may have partially applied, so retrying a create could duplicate; writes fail fast and honestly (and `add` already has the #57 verify guard).

Routed: `executeJXA` + `executeOmniFocusScript` (reads, retry **on**), and the `add`/`edit`/`remove`/`createTag`/`addProject` primitives (writes, retry **off**). Dead `exec`/`promisify` imports those primitives no longer need are removed.

## Honest scope

The semaphore is **per-process** — N servers each politely serializing still collectively hammer the app. Global serialization only comes with the singleton daemon (deferred). But per-process bounded concurrency + fast-fail timeout + read-retry still meaningfully cuts one server's contribution to `-1712` storms, and composes with any future transport.

## Testing

- `npx tsc --noEmit` clean; `npm test` — 240 pass (8 new: concurrency cap, release-on-throw, `-1712` vs genuine-error classification, retry/no-retry/give-up)
- `npm run build` OK
- Live smoke test through the routed path: create → edit → query (read path) → remove all succeed and self-clean; 0 leftovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)