### PR TITLE
#71: implement the 7 missing project filters, fix 3 silent-empty bugs

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.parity.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.parity.test.ts
@@ -49,15 +49,11 @@ const FILTER_SPEC: Record<string, { tasks: boolean; projects: boolean }> = {
 // on the projects branch yet — real "tasks work, projects forgotten" gaps this
 // suite surfaces. Tracked in #71. When one is fixed, the "gaps stay honest" test
 // below fails on purpose, forcing its removal from this set.
-const KNOWN_PROJECT_GAPS = new Set<string>([
-  'tags',
-  'flagged',
-  'dueWithin',
-  'deferredUntil',
-  'hasNote',
-  'dueOn',
-  'deferOn',
-]);
+//
+// Empty as of the #71 follow-up: the seven gaps this suite originally surfaced
+// (tags, flagged, dueWithin, deferredUntil, hasNote, dueOn, deferOn) are all
+// implemented. Keep the mechanism — it is how the next gap gets recorded.
+const KNOWN_PROJECT_GAPS = new Set<string>([]);
 
 // A representative value for invoking each filter.
 const SAMPLE: Record<string, unknown> = {
@@ -172,5 +168,54 @@ describe('query_omnifocus field parity (#71)', () => {
   it('entity-specific status fields map to their own status maps', () => {
     expect(generateFieldMapping('tasks', ['taskStatus'])).toContain('taskStatusMap[item.taskStatus]');
     expect(generateFieldMapping('projects', ['status'])).toContain('projectStatusMap[item.status]');
+  });
+});
+
+/**
+ * Emitting *some* code for a filter (what the parity contract above checks) is not
+ * the same as reading the right property. OmniJS `Project` forwards most of its
+ * root task's properties but NOT `added`/`modified` — those come back `undefined`
+ * on a Project, so `addedWithin`/`addedOn` matched nothing and the `added`/
+ * `modified` fields returned null, silently. Verified against a live database:
+ * 0/43 projects had `.added`, 43/43 had `.task.added`.
+ */
+describe('query_omnifocus project property routing', () => {
+  it('project added filters read the root task, never Project.added', () => {
+    for (const filters of [{ addedWithin: 7 }, { addedOn: 0 }]) {
+      const emitted = generateFilterConditions('projects', filters);
+      expect(emitted).toContain('item.task ? item.task.added');
+      // `item.added` is always undefined on a Project — catching it here is the
+      // whole point, so assert on a boundary-delimited match.
+      expect(emitted).not.toMatch(/[^.]\bitem\.added\b/);
+    }
+  });
+
+  it('tasks still read their own added property', () => {
+    expect(generateFilterConditions('tasks', { addedWithin: 7 })).toContain('item.added');
+    expect(generateFilterConditions('tasks', { addedWithin: 7 })).not.toContain('item.task.added');
+  });
+
+  it('project added/modified fields route through the root task', () => {
+    expect(generateFieldMapping('projects', ['added'])).toContain('item.task ? item.task.added');
+    expect(generateFieldMapping('projects', ['modified'])).toContain('item.task ? item.task.modified');
+    expect(generateFieldMapping('tasks', ['added'])).toContain('formatDate(item.added)');
+    expect(generateFieldMapping('tasks', ['modified'])).toContain('formatDate(item.modified)');
+  });
+
+  it('hasNote coerces to a Boolean so hasNote:false can match', () => {
+    // `item.note && item.note.trim().length > 0` yields "" — not false — for an
+    // empty note, so a strict `!== false` compare rejected everything. Live check
+    // before the fix: hasNote:false returned 0 of 185 tasks and 0 of 31 projects.
+    for (const entity of ['tasks', 'projects'] as const) {
+      const emitted = generateFilterConditions(entity, { hasNote: false });
+      expect(emitted).toContain('Boolean(item.note');
+      expect(emitted).toContain('!== false');
+    }
+  });
+
+  it('project tag filtering tolerates a project with no tags', () => {
+    // A bare `item.tags.some(...)` would throw inside the filter callback and take
+    // the whole query down rather than returning no matches.
+    expect(generateFilterConditions('projects', { tags: ['Work'] })).toContain('item.tags || []');
   });
 });

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -10,6 +10,20 @@ function escapeJXA(str: string): string {
     .replace(/\r/g, '\\r');
 }
 
+// OmniJS `Project` forwards most of its root task's properties (name, note,
+// flagged, dueDate, deferDate, tags, completionDate, dropDate...) but NOT
+// `added`/`modified` — reading those off a Project yields `undefined`, which
+// silently matched nothing. Route them through the root task instead. Verified
+// against the live OmniFocus 4.x database: 0/43 projects had `.added`, 43/43 had
+// `.task.added`.
+const PROJECT_ADDED_EXPR = 'item.task ? item.task.added : null';
+const PROJECT_MODIFIED_EXPR = 'item.task ? item.task.modified : null';
+
+// An empty note makes `item.note && ...` evaluate to "" rather than false, so the
+// strict `hasNote !== false` comparison below rejected every item and
+// `hasNote: false` returned nothing. Coerce before comparing.
+const HAS_NOTE_EXPR = 'Boolean(item.note && item.note.trim().length > 0)';
+
 export interface QueryOmnifocusParams {
   entity: 'tasks' | 'projects' | 'folders';
   filters?: {
@@ -413,7 +427,7 @@ function generateFilterConditions(entity: string, filters: any): string {
 
     if (filters.hasNote !== undefined) {
       conditions.push(`
-        const hasNote = item.note && item.note.trim().length > 0;
+        const hasNote = ${HAS_NOTE_EXPR};
         if (hasNote !== ${filters.hasNote}) return false;
       `);
     }
@@ -468,16 +482,73 @@ function generateFilterConditions(entity: string, filters: any): string {
       conditions.push(`if (!(${statusCondition})) return false;`);
     }
 
-    if (filters.addedWithin !== undefined) {
+    if (filters.tags && filters.tags.length > 0) {
+      const tagCondition = filters.tags.map((tag: string) =>
+        `_projectTags.some(t => t.name === "${escapeJXA(tag)}")`
+      ).join(' || ');
       conditions.push(`
-        if (!item.added || !checkDateWithinPast(item.added, ${filters.addedWithin})) {
+        {
+          const _projectTags = item.tags || [];
+          if (!(${tagCondition})) return false;
+        }
+      `);
+    }
+
+    if (filters.flagged !== undefined) {
+      conditions.push(`if (item.flagged !== ${filters.flagged}) return false;`);
+    }
+
+    if (filters.dueWithin !== undefined) {
+      conditions.push(`
+        if (!item.dueDate || !checkDateFilter(item.dueDate, ${filters.dueWithin})) {
           return false;
         }
       `);
     }
 
+    if (filters.deferredUntil !== undefined) {
+      conditions.push(`
+        if (!item.deferDate || !checkDateFilter(item.deferDate, ${filters.deferredUntil})) {
+          return false;
+        }
+      `);
+    }
+
+    if (filters.dueOn !== undefined) {
+      conditions.push(`if (!checkSameDay(item.dueDate, ${filters.dueOn})) return false;`);
+    }
+
+    if (filters.deferOn !== undefined) {
+      conditions.push(`if (!checkSameDay(item.deferDate, ${filters.deferOn})) return false;`);
+    }
+
+    if (filters.hasNote !== undefined) {
+      conditions.push(`
+        {
+          const hasNote = ${HAS_NOTE_EXPR};
+          if (hasNote !== ${filters.hasNote}) return false;
+        }
+      `);
+    }
+
+    if (filters.addedWithin !== undefined) {
+      conditions.push(`
+        {
+          const addedDate = ${PROJECT_ADDED_EXPR};
+          if (!addedDate || !checkDateWithinPast(addedDate, ${filters.addedWithin})) {
+            return false;
+          }
+        }
+      `);
+    }
+
     if (filters.addedOn !== undefined) {
-      conditions.push(`if (!checkSameDay(item.added, ${filters.addedOn})) return false;`);
+      conditions.push(`
+        {
+          const addedDate = ${PROJECT_ADDED_EXPR};
+          if (!checkSameDay(addedDate, ${filters.addedOn})) return false;
+        }
+      `);
     }
 
     if (filters.completedWithin !== undefined) {
@@ -624,9 +695,13 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
     } else if (field === 'status') {
       return `status: projectStatusMap[item.status]`;
     } else if (field === 'modificationDate' || field === 'modified') {
-      return `modificationDate: formatDate(item.modified)`;
+      return entity === 'projects'
+        ? `modificationDate: formatDate(${PROJECT_MODIFIED_EXPR})`
+        : `modificationDate: formatDate(item.modified)`;
     } else if (field === 'creationDate' || field === 'added') {
-      return `creationDate: formatDate(item.added)`;
+      return entity === 'projects'
+        ? `creationDate: formatDate(${PROJECT_ADDED_EXPR})`
+        : `creationDate: formatDate(item.added)`;
     } else if (field === 'completionDate') {
       return `completionDate: item.completionDate ? formatDate(item.completionDate) : null`;
     } else if (field === 'dropDate') {


### PR DESCRIPTION
Follow-up to #88. The parity suite recorded seven filters that `query_omnifocus` documents for projects but only implemented for tasks. This implements them and empties `KNOWN_PROJECT_GAPS`:

`tags`, `flagged`, `dueWithin`, `deferredUntil`, `hasNote`, `dueOn`, `deferOn`

## Three pre-existing bugs found while verifying against live data

Emitting *some* code for a filter — what the parity suite checks — is not the same as reading the right property. Verifying the new filters against the real database surfaced three filters that ran but silently matched nothing:

**1. `Project.added` / `Project.modified` are `undefined` in OmniJS.** Unlike `name`, `note`, `flagged`, `dueDate`, `deferDate`, `tags`, `completionDate` and `dropDate`, these two are *not* forwarded from the root task. So `addedWithin`/`addedOn` on projects matched zero rows, and the `added`/`modified` fields returned `null`.

```
0/43 projects had .added,  43/43 had .task.added
addedWithin: 100000  ->  0 of 31 projects   (before)
addedWithin: 100000  ->  31 of 31 projects  (after)
fields: [added, modified] -> null, null     (before)
                          -> real dates     (after)
```

**2. `hasNote: false` returned nothing — for tasks as well as projects.** An empty note makes `item.note && item.note.trim().length > 0` evaluate to `""` rather than `false`, so the strict `hasNote !== false` compare rejected every item.

```
tasks hasNote:false  ->  0 of 185      (before)
tasks hasNote:false  ->  122 of 185    (after; 63 + 122 = 185)
projects             ->  15 + 16 = 31  (after)
```

**3. Tag filtering could throw.** A bare `item.tags.some(...)` on a project with no tags would throw inside the filter callback and take down the whole query rather than returning no matches. The projects branch guards with `item.tags || []`.

## Verification

All seven filters checked against the real database, read-only, no fixtures and no mutations:

- `dueOn` returned exactly the expected project at each computed day offset (155, 6, 64 days out)
- `tags` honors OR semantics across an array; a nonexistent tag returns 0 rather than throwing
- `flagged` and `hasNote` now partition the set cleanly

Gate: `npx tsc --noEmit`, `npm test` (299 passing), `npm run build` — all green.

Adds a property-routing test suite alongside the parity contract, asserting projects read `item.task.added` and never `item.added`. That distinction is what let these three bugs hide from a suite that only checked whether code was emitted.

Contributes to #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)