### PR TITLE
Fail loudly when a folder/project path has no usable components

### DIFF
--- a/src/utils/appleScriptHelpers.test.ts
+++ b/src/utils/appleScriptHelpers.test.ts
@@ -53,6 +53,17 @@ describe('generateFolderLookupScript', () => {
     expect(result).toContain('set f to missing value');
   });
 
+  it('errors rather than silently resolving nothing for component-less paths', () => {
+    // A component-less path names no folder. If the emitted script only sets the
+    // variable to `missing value` and returns nothing, the caller falls through
+    // to its default container and reports success for a placement the caller
+    // never asked for — see the header comment in the helper.
+    for (const path of ['', '/', '//']) {
+      const result = generateFolderLookupScript(path, 'f', 'boom');
+      expect(result, `path ${JSON.stringify(path)} must fail loudly`).toContain('return "boom"');
+    }
+  });
+
   it('uses the provided variable name', () => {
     const result = generateFolderLookupScript('Work', 'myVar', 'error');
     expect(result).toContain('set myVar to missing value');
@@ -108,6 +119,16 @@ describe('generateProjectLookupScript', () => {
     const result = generateProjectLookupScript('', 'p', 'error');
     expect(result).toContain('set p to missing value');
     expect(result).not.toContain('flattened projects');
+  });
+
+  it('errors rather than silently resolving nothing for component-less paths', () => {
+    // Verified live before this fix: add_omnifocus_task with projectName "/"
+    // returned success:true and created the task in the INBOX, where main had
+    // previously returned "Project not found: /".
+    for (const path of ['', '/', '//']) {
+      const result = generateProjectLookupScript(path, 'p', 'boom');
+      expect(result, `path ${JSON.stringify(path)} must fail loudly`).toContain('return "boom"');
+    }
   });
 
   it('escapes special characters in project name', () => {

--- a/src/utils/appleScriptHelpers.ts
+++ b/src/utils/appleScriptHelpers.ts
@@ -33,7 +33,12 @@ export function generateFolderLookupScript(
 ): string {
   const components = rawFolderPath.split('/').filter(c => c.length > 0);
   if (components.length === 0) {
-    return `set ${varName} to missing value`;
+    // A path with no usable components (e.g. "/" or "//") names no folder. Fail
+    // loudly: leaving `varName` as `missing value` with no return lets the caller
+    // fall through to a default container and report success for a placement
+    // nobody asked for — the silent-success class of bug fixed in #57.
+    return `set ${varName} to missing value
+        return "${errorReturnJson}"`;
   }
 
   const escaped = components.map(c => escapeAppleScriptString(c));
@@ -99,7 +104,10 @@ export function generateProjectLookupScript(
 ): string {
   const components = rawProjectPath.split('/').filter(c => c.length > 0);
   if (components.length === 0) {
-    return `set ${varName} to missing value`;
+    // See the note in generateFolderLookupScript: a component-less path must not
+    // resolve to "no project" silently, or creation falls through to the inbox.
+    return `set ${varName} to missing value
+        return "${errorReturnJson}"`;
   }
 
   const escaped = components.map(c => escapeAppleScriptString(c));


### PR DESCRIPTION
Prep for #82, and a latent silent-success bug in its own right.

`generateFolderLookupScript` and `generateProjectLookupScript` both emitted a bare `set <var> to missing value` — with **no error return** — when a path splits into zero components (`"/"`, `"//"`). The caller then falls through to its default container and reports success for a placement nobody asked for. That is the silent-success class of bug we just fixed in #57.

It is currently latent, but #82 makes it reachable on the creation path. #82 wires `generateProjectLookupScript` into `add_omnifocus_task`; with it applied, `projectName: "/"` behaves like this:

| `add_omnifocus_task({ projectName: "/" })` | result |
|---|---|
| main today | `success: false` — "Project not found: /" |
| main + #82, before this fix | `success: true`, task created in the **inbox** |

Both measured against real builds, not reasoned about.

## The fix

Emit the caller's error JSON for a component-less path so the failure is explicit. Verified live after the fix:

```
add_project   folderName: "/"       -> Folder not found: /
edit_item     newProjectName: "/"   -> Project not found: /
```

## Scope

All three call sites (`addProject.folderName`, `editItem.newProjectName`, `editItem.newFolderName`) already guard against empty/undefined before calling the helpers, so nothing reaches this branch except genuinely degenerate paths. Their behavior changes from silent fallthrough to an explicit error.

The emitted script still sets the variable to `missing value` before returning, so every existing assertion holds unchanged — the two new tests only add the error-return expectation.

Gate: `npx tsc --noEmit`, `npm test` (301 passing, +2), `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)