### PR TITLE
Fix #91: dates written a month late, and read back a day early

### DIFF
--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { queryOmnifocus, QueryOmnifocusParams } from '../primitives/queryOmnifocus.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { resolveDateFilter } from '../../utils/dateFilter.js';
+import { localDatePart } from '../../utils/dateSerialization.js';
 
 export const schema = z.object({
   entity: z.enum(['tasks', 'projects', 'folders']).describe("Type of entity to query. Choose 'tasks' for individual tasks, 'projects' for projects, or 'folders' for folder organization"),
@@ -300,8 +301,10 @@ function formatFolders(folders: any[]): string {
 }
 
 function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toISOString().slice(0, 10);
+  // Delegates to localDatePart rather than `new Date(x).toISOString().slice(0,10)`:
+  // that round-trip re-introduced the off-by-one day for UTC-ahead users even after
+  // the query layer started emitting correct local dates (#91).
+  return localDatePart(dateStr);
 }
 
 // Exported for testing only - not part of the public API

--- a/src/tools/dumpDatabaseOptimized.ts
+++ b/src/tools/dumpDatabaseOptimized.ts
@@ -105,7 +105,7 @@ export async function getDatabaseStats(): Promise<{
           nextActionCount: nextActionCount,
           flaggedCount: flaggedCount,
           inboxCount: inboxCount,
-          lastModified: lastModified.toISOString()
+          lastModified: formatDate(lastModified)
         });
         
       } catch (error) {
@@ -155,7 +155,7 @@ export async function getChangesSince(since: Date): Promise<{
         ).map(task => ({
           id: task.id.primaryKey,
           name: task.name,
-          creationDate: task.creationDate.toISOString()
+          creationDate: formatDate(task.creationDate)
         }));
         
         const updatedTasks = allTasks.filter(task => 
@@ -166,7 +166,7 @@ export async function getChangesSince(since: Date): Promise<{
         ).map(task => ({
           id: task.id.primaryKey,
           name: task.name,
-          modificationDate: task.modificationDate.toISOString()
+          modificationDate: formatDate(task.modificationDate)
         }));
         
         const completedTasks = allTasks.filter(task =>
@@ -175,7 +175,7 @@ export async function getChangesSince(since: Date): Promise<{
         ).map(task => ({
           id: task.id.primaryKey,
           name: task.name,
-          completionDate: task.completionDate.toISOString()
+          completionDate: formatDate(task.completionDate)
         }));
         
         // Find projects that changed
@@ -186,7 +186,7 @@ export async function getChangesSince(since: Date): Promise<{
         ).map(project => ({
           id: project.task.id.primaryKey,
           name: project.name,
-          creationDate: project.creationDate.toISOString()
+          creationDate: formatDate(project.creationDate)
         }));
         
         const updatedProjects = allProjects.filter(project =>
@@ -197,7 +197,7 @@ export async function getChangesSince(since: Date): Promise<{
         ).map(project => ({
           id: project.task.id.primaryKey,
           name: project.name,
-          modificationDate: project.modificationDate.toISOString()
+          modificationDate: formatDate(project.modificationDate)
         }));
         
         return JSON.stringify({

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -1,4 +1,5 @@
 import { executeOmniFocusScript } from '../../utils/scriptExecution.js';
+import { JXA_FORMAT_DATE_SOURCE } from '../../utils/dateSerialization.js';
 
 // Escape user-provided strings before embedding in JXA script template literals.
 // Prevents syntax errors and code injection from characters like " \ newlines.
@@ -112,11 +113,9 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
     try {
       const startTime = new Date();
       
-      // Helper function to format dates
-      function formatDate(date) {
-        if (!date) return null;
-        return date.toISOString();
-      }
+      // Helper function to format dates — injected from src/utils/dateSerialization.ts
+      // so this and the human-readable formatter cannot disagree (#91).
+      ${JXA_FORMAT_DATE_SOURCE}
       
       // Helper to check date filters
       function checkDateFilter(itemDate, daysFromNow) {

--- a/src/utils/dateFormatting.test.ts
+++ b/src/utils/dateFormatting.test.ts
@@ -26,4 +26,65 @@ describe('createDateOutsideTellBlock', () => {
   it('throws on invalid date string', () => {
     expect(() => createDateOutsideTellBlock('not-a-date', 'v')).toThrow();
   });
+
+  /**
+   * Issue #91: the emitted script scaffolds off `current date`, so the intermediate
+   * carries today's day-of-month. Setting the month while that day is out of range
+   * for the target month makes AppleScript roll forward a month, and the later
+   * `set day` cannot undo it (today=Jul 31, target=Nov 1 produced Dec 1).
+   *
+   * Verified against live AppleScript: with the day normalized to 1 first, the
+   * worst case (today = the 31st) resolves correctly for every target below.
+   */
+  describe('month-rollover safety (#91)', () => {
+    const lines = (iso: string) =>
+      createDateOutsideTellBlock(iso, 'v')
+        .split('\n')
+        .map(l => l.trim());
+
+    it('normalizes the day before touching year or month', () => {
+      const l = lines('2026-11-01');
+      const dayReset = l.indexOf('set day of v to 1');
+      const setYear = l.findIndex(x => x.startsWith('set year of v'));
+      const setMonth = l.findIndex(x => x.startsWith('set month of v'));
+
+      expect(dayReset, 'day must be normalized to 1 first').toBeGreaterThanOrEqual(0);
+      expect(dayReset).toBeLessThan(setYear);
+      expect(dayReset).toBeLessThan(setMonth);
+    });
+
+    it('still sets the real day after the month', () => {
+      const l = lines('2026-11-17');
+      const setMonth = l.findIndex(x => x.startsWith('set month of v'));
+      const setDay = l.lastIndexOf('set day of v to 17');
+      expect(setDay).toBeGreaterThan(setMonth);
+    });
+
+    it('day is assigned exactly twice — the reset and the real value', () => {
+      // If a refactor drops the reset, or drops the real assignment, this catches it.
+      const dayAssignments = lines('2026-11-01').filter(l => /^set day of v to \d+$/.test(l));
+      expect(dayAssignments).toEqual(['set day of v to 1', 'set day of v to 1']);
+
+      const other = lines('2026-02-28').filter(l => /^set day of v to \d+$/.test(l));
+      expect(other).toEqual(['set day of v to 1', 'set day of v to 28']);
+    });
+
+    it('targets a short month without depending on today', () => {
+      // The reported case. Pure string generation, so it holds on any run date —
+      // the original bug only reproduced on the 29th-31st, which is exactly why
+      // it went unnoticed for so long.
+      const script = createDateOutsideTellBlock('2026-11-01', 'v');
+      expect(script).toContain('set month of v to 11');
+      expect(script.trimEnd().split('\n').map(l => l.trim())).toEqual([
+        'copy current date to v',
+        'set day of v to 1',
+        'set year of v to 2026',
+        'set month of v to 11',
+        'set day of v to 1',
+        'set hours of v to 0',
+        'set minutes of v to 0',
+        'set seconds of v to 0',
+      ]);
+    });
+  });
 });

--- a/src/utils/dateFormatting.ts
+++ b/src/utils/dateFormatting.ts
@@ -32,8 +32,22 @@ export function createDateOutsideTellBlock(isoDateString: string, varName: strin
   const minutes = date.getMinutes();
   const seconds = date.getSeconds();
   
-  // Generate AppleScript to construct date outside tell blocks
+  // Generate AppleScript to construct date outside tell blocks.
+  //
+  // `set day to 1` FIRST is load-bearing, not tidiness (issue #91). This scaffolds
+  // off `current date`, so the intermediate date carries *today's* day-of-month.
+  // Setting the month while that day is out of range for the target month makes
+  // AppleScript roll the date forward, and the later `set day` cannot undo it:
+  //
+  //     today = Jul 31, target = Nov 1
+  //       set month to 11  -> Nov 31 is invalid -> rolls to Dec 1
+  //       set day to 1     -> already 1, no-op  -> stays Dec 1   (a month late)
+  //
+  // Normalizing the day to 1 up front makes every intermediate valid in every
+  // month, so year/month/day can then be set without rollover. This silently
+  // corrupted any date written on the 29th-31st toward a shorter month.
   return `copy current date to ${varName}
+set day of ${varName} to 1
 set year of ${varName} to ${year}
 set month of ${varName} to ${month}
 set day of ${varName} to ${day}

--- a/src/utils/dateSerialization.test.ts
+++ b/src/utils/dateSerialization.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { formatDateLocal, localDatePart, JXA_FORMAT_DATE_SOURCE } from './dateSerialization.js';
+
+/**
+ * Regression suite for issue #91 (the read half).
+ *
+ * The bug that shipped: every date was serialized with `toISOString()`, so in any
+ * timezone ahead of UTC a local-midnight defer date rendered as the previous
+ * calendar day. It was structurally invisible to anyone developing behind UTC,
+ * which is why no existing test caught it — so these tests assert the property
+ * that actually matters (local calendar day survives) rather than a fixed string,
+ * and the JXA half is *executed*, not pattern-matched.
+ */
+
+describe('formatDateLocal', () => {
+  it('preserves the local calendar day for local midnight', () => {
+    // The exact shape of the reported failure: midnight on the 1st must not
+    // render as the last day of the previous month.
+    const d = new Date(2026, 9, 1, 0, 0, 0); // Oct 1 local, whatever the host TZ
+    expect(formatDateLocal(d)!.slice(0, 10)).toBe('2026-10-01');
+  });
+
+  it('round-trips back to the identical instant', () => {
+    // The offset suffix means switching away from UTC output loses no information.
+    for (const d of [
+      new Date(2026, 0, 1, 0, 0, 0),
+      new Date(2026, 6, 15, 13, 45, 30),
+      new Date(2026, 11, 31, 23, 59, 59),
+    ]) {
+      expect(new Date(formatDateLocal(d)!).getTime()).toBe(d.getTime());
+    }
+  });
+
+  it('emits a well-formed ISO 8601 offset, zero-padded', () => {
+    const s = formatDateLocal(new Date(2026, 2, 4, 5, 6, 7))!;
+    expect(s).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
+    expect(s.slice(0, 19)).toBe('2026-03-04T05:06:07');
+  });
+
+  it('returns null for absent dates rather than throwing', () => {
+    expect(formatDateLocal(null)).toBeNull();
+    expect(formatDateLocal(undefined)).toBeNull();
+  });
+});
+
+describe('localDatePart', () => {
+  it('never round-trips through UTC', () => {
+    // This is the second half of the bug: the human-readable formatter did
+    // `new Date(s).toISOString().slice(0,10)`, which re-broke a correct input.
+    expect(localDatePart('2026-10-01T00:00:00+01:00')).toBe('2026-10-01');
+    expect(localDatePart('2026-10-01T00:00:00+13:00')).toBe('2026-10-01');
+    expect(localDatePart('2026-10-01T23:30:00-08:00')).toBe('2026-10-01');
+  });
+
+  it('leaves a UTC-suffixed instant on its own stated date', () => {
+    expect(localDatePart('2026-09-30T23:00:00.000Z')).toBe('2026-09-30');
+  });
+
+  it('passes through unparseable input instead of emitting Invalid Date', () => {
+    expect(localDatePart('not a date')).toBe('not a date');
+  });
+});
+
+describe('JXA_FORMAT_DATE_SOURCE', () => {
+  // Asserting the source merely *contains* something is the trap that let three
+  // silent-empty query bugs through in #71 ("a filter that emits code is not a
+  // filter that works"). So evaluate it and check behavior.
+  const evalPrelude = (): ((d: Date | null) => string | null) => {
+    // eslint-disable-next-line no-new-func -- deliberately exercising the shipped text
+    return new Function(`${JXA_FORMAT_DATE_SOURCE}\nreturn formatDate;`)();
+  };
+
+  it('evaluates to a working function under the name the payloads call', () => {
+    const formatDate = evalPrelude();
+    expect(typeof formatDate).toBe('function');
+    expect(formatDate(null)).toBeNull();
+  });
+
+  it('behaves identically to the TypeScript implementation', () => {
+    // If someone edits formatDateLocal to reference an import or module-scope
+    // value, `toString()` still produces text but the injected copy breaks at
+    // runtime inside OmniFocus. This catches that class of change.
+    const formatDate = evalPrelude();
+    for (const d of [
+      new Date(2026, 9, 1, 0, 0, 0),
+      new Date(2026, 0, 31, 23, 59, 59),
+      new Date(2026, 5, 15, 12, 0, 0),
+    ]) {
+      expect(formatDate(d)).toBe(formatDateLocal(d));
+    }
+  });
+
+  it('binds the bare name formatDate exactly once, so payloads can rely on it', () => {
+    // \b excludes the inner `formatDateLocal` occurrence the stringified function
+    // body carries — only the standalone binding should match.
+    expect(JXA_FORMAT_DATE_SOURCE.match(/\bformatDate\b/g)?.length).toBe(1);
+    expect(JXA_FORMAT_DATE_SOURCE).toMatch(/^const formatDate = /);
+  });
+});
+
+describe('JXA payloads do not redeclare formatDate', () => {
+  // The executor prepends the prelude to every payload. A `function formatDate`
+  // in a payload would be a redeclaration SyntaxError against the prelude's
+  // `const`, breaking that tool at runtime with no compile-time warning.
+  const dir = join(__dirname, 'omnifocusScripts');
+
+  for (const file of readdirSync(dir).filter(f => f.endsWith('.js'))) {
+    it(`${file} relies on the prelude`, () => {
+      const src = readFileSync(join(dir, file), 'utf8');
+      expect(src, `${file} must not declare its own formatDate`).not.toMatch(
+        /^\s*(function\s+formatDate|(const|let|var)\s+formatDate)\b/m
+      );
+    });
+  }
+});

--- a/src/utils/dateSerialization.ts
+++ b/src/utils/dateSerialization.ts
@@ -1,0 +1,84 @@
+/**
+ * Canonical date -> string serialization for everything this server returns.
+ *
+ * Why this module exists (issue #91): every date field used to be serialized with
+ * `date.toISOString()`, which renders the instant in UTC. OmniFocus dates are
+ * *local* wall-clock times — a defer date is "midnight on the 1st", not an instant
+ * anybody reasons about in UTC. In any timezone ahead of UTC, local midnight
+ * serializes to the previous UTC day:
+ *
+ *     Europe/London (BST, +01:00), defer date = Oct 1 00:00 local
+ *       toISOString()      -> "2026-09-30T23:00:00.000Z"   <- reads as Sep 30
+ *       formatDateLocal()  -> "2026-10-01T00:00:00+01:00"  <- reads as Oct 1
+ *
+ * The bug was invisible to anyone developing behind UTC (the Americas), which is
+ * why it survived this long. An offset-qualified local ISO string fixes the
+ * calendar day *without* losing the instant — it round-trips through `new Date()`
+ * to the exact same moment `toISOString()` would have produced.
+ *
+ * This is the single implementation. The JXA payloads that run inside OmniFocus
+ * cannot `import`, so they receive this function's source text via
+ * `JXA_FORMAT_DATE_SOURCE` rather than keeping their own copies — there is
+ * nothing to drift.
+ */
+
+/**
+ * Serialize a Date as an ISO 8601 string in the host's local timezone, with an
+ * explicit UTC offset (e.g. `2026-10-01T00:00:00+01:00`).
+ *
+ * MUST stay self-contained: its source is stringified and shipped into JXA, so it
+ * cannot reference imports, module-scope values, or anything outside its own body.
+ */
+export function formatDateLocal(date: Date | null | undefined): string | null {
+  if (!date) return null;
+  const pad = (n: number) => (n < 10 ? '0' + n : '' + n);
+  // getTimezoneOffset() is minutes to ADD to local to reach UTC, so it is
+  // positive west of Greenwich — the opposite sign from the ISO suffix.
+  const offset = -date.getTimezoneOffset();
+  const sign = offset < 0 ? '-' : '+';
+  const abs = offset < 0 ? -offset : offset;
+  return (
+    date.getFullYear() +
+    '-' +
+    pad(date.getMonth() + 1) +
+    '-' +
+    pad(date.getDate()) +
+    'T' +
+    pad(date.getHours()) +
+    ':' +
+    pad(date.getMinutes()) +
+    ':' +
+    pad(date.getSeconds()) +
+    sign +
+    pad(Math.floor(abs / 60)) +
+    ':' +
+    pad(abs % 60)
+  );
+}
+
+/**
+ * `formatDateLocal`'s implementation as JXA-injectable source, bound to the name
+ * `formatDate` that the payloads and generated scripts call.
+ *
+ * Derived from the live function rather than hand-copied, so the code the tests
+ * exercise is byte-for-byte the code that runs inside OmniFocus.
+ */
+export const JXA_FORMAT_DATE_SOURCE = `const formatDate = ${formatDateLocal.toString()};`;
+
+/**
+ * Extract the calendar date (`YYYY-MM-DD`) a serialized timestamp refers to.
+ *
+ * Must not round-trip through UTC: `new Date(s).toISOString().slice(0, 10)` is how
+ * the human-readable output re-introduced the very off-by-one day that
+ * `formatDateLocal` exists to prevent. When the string carries its own date part
+ * (every string this server emits does), trust it verbatim.
+ */
+export function localDatePart(dateStr: string): string {
+  const match = /^(\d{4}-\d{2}-\d{2})/.exec(dateStr);
+  if (match) return match[1];
+  // Fall back to local-time getters for anything else (e.g. a bare epoch or a
+  // locale string) — still never UTC.
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return dateStr;
+  return formatDateLocal(date)!.slice(0, 10);
+}

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -361,11 +361,9 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       }
     }
 
-    // Helper functions
-    function formatDate(date) {
-      if (!date) return null;
-      return date.toISOString();
-    }
+    // Helper functions.
+    // formatDate is supplied by the executor prelude (see
+    // src/utils/dateSerialization.ts). Do not redeclare it here — #91.
 
     function getTaskDetails(task) {
       // Task status mapping to match queryOmnifocus.ts

--- a/src/utils/omnifocusScripts/omnifocusDump.js
+++ b/src/utils/omnifocusScripts/omnifocusDump.js
@@ -3,11 +3,8 @@
       try {
         const startTime = new Date();
 
-        // Helper function to format dates consistently or return null
-        function formatDate(date) {
-          if (!date) return null;
-          return date.toISOString();
-        }
+        // formatDate is supplied by the executor prelude (see
+        // src/utils/dateSerialization.ts). Do not redeclare it here — #91.
 
         // Helper function to safely get enum values - Simplified with direct mapping
         const taskStatusMap = {

--- a/src/utils/scriptExecution.ts
+++ b/src/utils/scriptExecution.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "url";
 import { dirname } from "path";
 import { existsSync } from "fs";
 import { Logger } from './logger.js';
+import { JXA_FORMAT_DATE_SOURCE } from './dateSerialization.js';
 
 const execAsync = promisify(exec);
 const MAX_BUFFER = 10 * 1024 * 1024; // 10MB — default 1MB is too small for large OmniFocus databases
@@ -241,14 +242,22 @@ export async function executeOmniFocusScript(
     // Read the script file
     const scriptContent = readFileSync(actualPath, "utf8");
 
-    // Create a wrapper script that sets up arguments and executes the original script
-    let wrappedScript = scriptContent;
+    // Create a wrapper script that sets up arguments and executes the original script.
+    //
+    // Every payload gets `formatDate` from the canonical implementation (#91) instead
+    // of declaring its own. The payloads each used to carry a `toISOString()` copy,
+    // which meant a timezone fix had to be applied in N places or silently only
+    // half-land. Payloads must NOT declare `formatDate` themselves — a `function`
+    // declaration alongside this `const` is a redeclaration SyntaxError, which the
+    // prelude test asserts against.
+    let wrappedScript = `${JXA_FORMAT_DATE_SOURCE}\n\n${scriptContent}`;
 
     if (args && args.length > 0) {
       const quotedArgs = args
         .map((arg) => `"${escapeContent(arg)}"`)
         .join(", ");
-      wrappedScript = `
+      wrappedScript = `${JXA_FORMAT_DATE_SOURCE}
+
 // Set up arguments
 const argv = [${quotedArgs}];
 


### PR DESCRIPTION
Closes #91.

Two independent silent-corruption bugs. Both reported by @mummynoble, whose diagnosis of the first is exactly right; the second turned out to have a different cause than suspected (details below).

## Bug A — write path: month rollover

`createDateOutsideTellBlock` scaffolds off `copy current date`, so the intermediate date carries **today's** day-of-month. Setting the month while that day is out of range for the target month makes AppleScript roll the date forward, and the later `set day` cannot undo it:

```
today = Jul 31, target = Nov 1
  set month to 11  ->  Nov 31 is invalid  ->  rolls to Dec 1
  set day to 1     ->  already 1, no-op   ->  stays Dec 1   (a month late)
```

Reproduced verbatim in AppleScript:

```
base(today)= Friday, July 31, 2026 at 9:13:00 AM
after month: Tuesday, December 1, 2026
after day  : Tuesday, December 1, 2026
```

**Blast radius:** every date write — `add_omnifocus_task`, `add_project`, `edit_item` — for `due`, `defer` and `planned` alike, whenever the run date's day-of-month exceeded the target month's length. So it fired on the 29th–31st and was dormant the rest of the month, which is why it looked intermittent.

**Fix:** normalize the day to 1 *before* setting year/month, so every intermediate is valid in every month. Verified live with a synthetic Jul-31 base across six targets including leap-Feb — all correct.

## Bug B — read path: UTC serialization of local wall-clock dates

Every date was serialized with `toISOString()`. OmniFocus dates are *local* wall-clock times — a defer date is "midnight on the 1st", not an instant anyone reasons about in UTC. In any timezone **ahead of** UTC, local midnight renders as the previous calendar day:

| | output | reads as |
|---|---|---|
| before, Europe/London (BST) | `2026-09-30T23:00:00.000Z` | **Sep 30** ❌ |
| after, Europe/London (BST) | `2026-10-01T00:00:00+01:00` | Oct 1 ✅ |
| before, America/New_York | `2026-10-01T04:00:00.000Z` | Oct 1 (no shift) |

**This was structurally invisible to anyone developing behind UTC**, which is why it survived this long and why no existing test caught it. Every UTC+X user has been seeing off-by-one dates in query output.

The offset-qualified form loses nothing: it round-trips through `new Date()` to the exact same instant `toISOString()` produced, while keeping the calendar day correct.

### On the reported diagnosis

The issue attributes this half to local-time getters in the write path. It isn't there — lines 13–18 of `dateFormatting.ts` already normalize date-only input to local midnight, and a live round-trip confirms the write stores `October 1, 2026 at 12:00:00 AM` correctly. The suggested fix (UTC getters for date-only input) would have **reintroduced** the bug that normalization exists to prevent, and left the real cause untouched.

It's the read side, and it had **two** halves — the JXA query layer *and* the human-readable formatter, which did `new Date(s).toISOString().slice(0,10)` and so re-broke an already-correct input. Fixing either alone would have half-landed.

## One implementation instead of four

There were four `formatDate` definitions, all UTC. Patching them individually is how the next timezone fix silently half-lands, so `src/utils/dateSerialization.ts` now owns the single implementation and ships **its own source text** into JXA via `formatDate.toString()`, injected as a prelude by `executeOmniFocusScript`. The payloads no longer declare their own.

## Tests assert behavior, not emitted text

The `#71` lesson — code that is *emitted* is not code that *works* — applies directly here, so:

- the injected JXA source is **evaluated** and its output compared against the TypeScript function, catching a change that keeps `toString()` working but breaks the injected copy (e.g. referencing an import);
- a test asserts no payload declares its own `formatDate`, since a redeclaration alongside the prelude's `const` is a runtime `SyntaxError` with no compile-time warning;
- the write-path tests assert the *ordering* of the emitted statements and that `set day` appears exactly twice, so dropping either the reset or the real assignment fails;
- Bug A's regression test is pure string generation, so it holds on any run date rather than only on the 29th–31st.

## Verification

Gate: `tsc --noEmit` clean, **324 tests** passing (was 306), `build` OK.

Live, against a real OmniFocus 4.x database:

- all three date fields round-trip **exactly** through `add_omnifocus_task` → `query_omnifocus`, and through `edit_item` → `query_omnifocus`
- correct per-date DST offsets: `2026-02-01T00:00:00-05:00` (EST) vs `2026-04-30T00:00:00-04:00` (EDT)
- all four payload-backed tools confirmed working under the prelude: `list_tags`, `list_perspectives`, `get_perspective_view`, `dump_database`
- `omnifocus://stats` `lastModified` now `2026-08-05T14:41:36-04:00`
- fixtures `TEST:`-prefixed and cleaned up: `leftover tasks=0 projects=0 folders=0`

## Note: output format change

Date fields now carry a local offset instead of a `Z` suffix. `.slice(0, 10)` and `new Date(...)` are unaffected; exact string equality against a `Z`-suffixed literal is not. Deliberate — it's the only way to make the calendar day correct without discarding time-of-day.

## Found while verifying, not fixed here

`getChangesSince` filters on `task.creationDate` / `task.modificationDate`, which **do not exist in OmniJS** (it's `added` / `modified` — live-confirmed), so it always returns empty. It's unreachable dead code, so it's out of scope here; filing separately.