### PR TITLE
Honor projectId in batch_add_items and report placement (#97)

### DIFF
--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -33,7 +33,16 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       if (placement === 'parent') {
         locationText = 'under the parent task';
       } else if (placement === 'project') {
-        locationText = args.projectName ? `in project "${args.projectName}"` : 'in a project';
+        // Name the project we were asked for. "in a project" was the old
+        // fallback for the projectId path, which is exactly the caller who
+        // cannot check the result by eye.
+        if (args.projectName) {
+          locationText = `in project "${args.projectName}"`;
+        } else if (args.projectId) {
+          locationText = `in project id ${args.projectId}`;
+        } else {
+          locationText = 'in a project';
+        }
       } else {
         locationText = 'in your inbox';
       }

--- a/src/tools/definitions/batchAddItems.test.ts
+++ b/src/tools/definitions/batchAddItems.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { describePlacement } from './batchAddItems.js';
+
+describe('describePlacement', () => {
+  it('flags a task that asked for a project and landed in the inbox (#97)', () => {
+    const text = describePlacement(
+      { type: 'task', projectId: 'bARxLhruZIp' },
+      'inbox'
+    );
+    expect(text).toContain('⚠️');
+    expect(text).toContain('inbox');
+    expect(text).toContain('bARxLhruZIp');
+  });
+
+  it('flags an unhonored parent request the same way', () => {
+    expect(describePlacement({ type: 'task', parentTaskName: 'Parent' }, 'inbox')).toContain('⚠️');
+  });
+
+  it('does not warn when the inbox is where the task was meant to go', () => {
+    expect(describePlacement({ type: 'task' }, 'inbox')).toBe(' → inbox');
+  });
+
+  it('names the project a task landed in', () => {
+    expect(describePlacement({ type: 'task', projectName: 'Reading' }, 'project')).toBe(
+      ' → in project "Reading"'
+    );
+  });
+
+  it('falls back to the project id when only an id was supplied', () => {
+    expect(describePlacement({ type: 'task', projectId: 'abc' }, 'project')).toBe(
+      ' → in project id abc'
+    );
+  });
+
+  it('resolves a within-batch project target back to its name', () => {
+    // "tempId p1" tells the caller nothing about where the task went.
+    const batch = [
+      { type: 'project' as const, name: 'Reading', tempId: 'p1' },
+      { type: 'task' as const, name: 'Child', parentTempId: 'p1' },
+    ];
+    expect(describePlacement(batch[1], 'project', batch)).toBe(' → in project "Reading"');
+  });
+
+  it('falls back to the raw tempId when the sibling is not in the batch', () => {
+    expect(describePlacement({ type: 'task', parentTempId: 'p1' }, 'project')).toBe(
+      ' → in project tempId p1'
+    );
+  });
+
+  it('warns when a named parent was not honored but the project was', () => {
+    const text = describePlacement(
+      { type: 'task', projectName: 'Reading', parentTaskName: 'Missing' },
+      'project'
+    );
+    expect(text).toContain('in project "Reading"');
+    expect(text).toContain('⚠️ parent not found');
+  });
+
+  it('reports a parent placement', () => {
+    expect(describePlacement({ type: 'task', parentTaskId: 'abc' }, 'parent')).toBe(
+      ' → under parent id abc'
+    );
+  });
+
+  it('says nothing for projects, which have no placement', () => {
+    expect(describePlacement({ type: 'project' }, 'project')).toBe('');
+  });
+
+  it('says nothing when the primitive reported no placement', () => {
+    // Older result shapes, and any future caller that drops the field, should
+    // degrade to the previous output rather than inventing a location.
+    expect(describePlacement({ type: 'task', projectName: 'Reading' }, undefined)).toBe('');
+  });
+});

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -14,8 +14,12 @@ export const schema = z.object({
     estimatedMinutes: z.number().optional().describe("Estimated time to complete the item, in minutes"),
     tags: z.array(z.string()).optional().describe("Tags to assign to the item"),
 
-    // Task-specific properties
-    projectName: z.string().optional().describe("For tasks: The name of the project to add the task to"),
+    // Task-specific properties.
+    // Keep these in sync with add_omnifocus_task's schema — the two drifted
+    // apart once already (#97): projectId was missing here, so Zod stripped it
+    // and every task in the batch landed in the inbox reporting success.
+    projectId: z.string().optional().describe("For tasks: The id of the project to add the task to (preferred when the project name is ambiguous — e.g. multiple 'Single Actions' projects across folders). Obtain via query_omnifocus. Takes precedence over projectName when both are supplied."),
+    projectName: z.string().optional().describe("For tasks: The name or folder path of the project to add the task to (e.g. 'My Project' or 'Work/My Project' to disambiguate by folder). Will add to inbox if not specified. Used when projectId is not supplied; for ambiguous names, prefer projectId."),
     parentTaskId: z.string().optional().describe("For tasks: ID of the parent task"),
     parentTaskName: z.string().optional().describe("For tasks: Name of the parent task (scoped to project when provided)"),
     tempId: z.string().optional().describe("For tasks: Temporary ID for within-batch references"),
@@ -29,6 +33,78 @@ export const schema = z.object({
   ,
   createSequentially: z.boolean().optional().describe("Process parents before children; when false, best-effort order will still try to resolve parents first")
 });
+
+type PlacementRequest = {
+  type: 'task' | 'project';
+  name?: string;
+  tempId?: string;
+  projectId?: string;
+  projectName?: string;
+  parentTaskId?: string;
+  parentTaskName?: string;
+  parentTempId?: string;
+};
+
+/**
+ * Render where a task actually landed, next to where it was asked to go.
+ *
+ * The reason this exists (#97): the batch result used to be `✅ task: "name"`
+ * and nothing else, so a task that was supposed to go into a project but ended
+ * up in the inbox looked identical to one that worked. A silent placement
+ * fallthrough is only silent if nobody prints the placement.
+ *
+ * Returns '' for projects, which have no placement, and for results from a
+ * primitive that didn't report one.
+ */
+export function describePlacement(
+  item: PlacementRequest,
+  placement?: 'parent' | 'project' | 'inbox',
+  batch: PlacementRequest[] = []
+): string {
+  if (item.type !== 'task' || !placement) return '';
+
+  // A parentTempId is meaningless to the caller on its own; resolve it back to
+  // the name of the sibling item it points at.
+  const sibling = item.parentTempId
+    ? batch.find((other) => other.tempId === item.parentTempId)
+    : undefined;
+  const tempLabel = sibling?.name
+    ? `"${sibling.name}"`
+    : item.parentTempId
+      ? `tempId ${item.parentTempId}`
+      : undefined;
+
+  // Ids are rendered bare and names quoted, matching add_omnifocus_task — a
+  // quoted id reads as a name the caller can go look for and won't find.
+  const parentRequest = item.parentTaskId
+    ? `id ${item.parentTaskId}`
+    : item.parentTaskName
+      ? `"${item.parentTaskName}"`
+      : tempLabel;
+  const projectRequest = item.projectName
+    ? `"${item.projectName}"`
+    : item.projectId
+      ? `id ${item.projectId}`
+      : undefined;
+
+  if (placement === 'inbox') {
+    const requested = parentRequest ?? projectRequest;
+    return requested ? ` → ⚠️ inbox — requested ${requested}, not honored` : ' → inbox';
+  }
+
+  if (placement === 'parent') {
+    return parentRequest ? ` → under parent ${parentRequest}` : ' → under parent task';
+  }
+
+  // placement === 'project'
+  const label = projectRequest ?? tempLabel;
+  // Mirrors add_omnifocus_task: an explicitly named parent that didn't take is
+  // worth flagging even though the task did land somewhere reasonable.
+  const parentMissed = item.parentTaskId || item.parentTaskName
+    ? ' ⚠️ parent not found'
+    : '';
+  return `${label ? ` → in project ${label}` : ' → in a project'}${parentMissed}`;
+}
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {
   try {
@@ -44,13 +120,28 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       if (failureCount > 0) {
         message += ` ⚠️ Failed to add ${failureCount} items.`;
       }
-      
+
+      // Hoist silent misplacement into the summary line. Callers — agents
+      // especially — routinely read the first line and stop, which is how #97
+      // went unnoticed long enough to be reported as data loss.
+      const misplaced = result.results.filter((r, index) => {
+        if (!r.success || r.placement !== 'inbox') return false;
+        const item = args.items[index];
+        return Boolean(
+          item.projectId || item.projectName || item.parentTaskId || item.parentTaskName || item.parentTempId
+        );
+      }).length;
+      if (misplaced > 0) {
+        message += ` ⚠️ ${misplaced} landed in the inbox despite a requested project or parent.`;
+      }
+
       // Include details about added items
       const details = result.results.map((item, index) => {
         if (item.success) {
           const itemType = args.items[index].type;
           const itemName = args.items[index].name;
-          return `- ✅ ${itemType}: "${itemName}"`;
+          const where = describePlacement(args.items[index], item.placement, args.items);
+          return `- ✅ ${itemType}: "${itemName}"${where}`;
         } else {
           const itemType = args.items[index].type;
           const itemName = args.items[index].name;
@@ -72,7 +163,7 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
             const itemType = args.items[index].type;
             const itemName = args.items[index].name;
             return r.success
-              ? `- ✅ ${itemType}: \"${itemName}\"`
+              ? `- ✅ ${itemType}: \"${itemName}\"${describePlacement(args.items[index], r.placement, args.items)}`
               : `- ❌ ${itemType}: \"${itemName}\" - Error: ${r?.error || 'Unknown error'}`;
           }).join('\\n')
         : `No items processed. ${result.error || ''}`;

--- a/src/tools/primitives/batchAddItems.test.ts
+++ b/src/tools/primitives/batchAddItems.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  addOmniFocusTask: vi.fn(),
+  addProject: vi.fn(),
+}));
+
+vi.mock('./addOmniFocusTask.js', () => ({ addOmniFocusTask: mocks.addOmniFocusTask }));
+vi.mock('./addProject.js', () => ({ addProject: mocks.addProject }));
+
+import { batchAddItems } from './batchAddItems.js';
+
+beforeEach(() => {
+  mocks.addOmniFocusTask.mockReset();
+  mocks.addProject.mockReset();
+  mocks.addOmniFocusTask.mockResolvedValue({ success: true, taskId: 'task-1', placement: 'project' });
+  mocks.addProject.mockResolvedValue({ success: true, projectId: 'proj-1' });
+});
+
+describe('batchAddItems parameter forwarding', () => {
+  it('forwards projectId to addOmniFocusTask (#97)', async () => {
+    // The bug: projectId was absent from the item schema, so Zod stripped it and
+    // every task in the batch silently landed in the inbox reporting success.
+    await batchAddItems([{ type: 'task', name: 'Read a book', projectId: 'bARxLhruZIp' }]);
+
+    expect(mocks.addOmniFocusTask).toHaveBeenCalledTimes(1);
+    expect(mocks.addOmniFocusTask.mock.calls[0][0]).toMatchObject({
+      name: 'Read a book',
+      projectId: 'bARxLhruZIp',
+    });
+  });
+
+  it('forwards both ids and lets the primitive apply precedence', async () => {
+    await batchAddItems([
+      { type: 'task', name: 'Ambiguous', projectId: 'id-1', projectName: 'Single Actions' },
+    ]);
+
+    expect(mocks.addOmniFocusTask.mock.calls[0][0]).toMatchObject({
+      projectId: 'id-1',
+      projectName: 'Single Actions',
+    });
+  });
+
+  it('forwards the other task fields it used to forward', async () => {
+    await batchAddItems([
+      {
+        type: 'task',
+        name: 'Everything',
+        note: 'n',
+        dueDate: '2026-01-01',
+        deferDate: '2026-01-02',
+        plannedDate: '2026-01-03',
+        flagged: true,
+        estimatedMinutes: 15,
+        tags: ['a'],
+        parentTaskName: 'Parent',
+        hierarchyLevel: 1,
+      },
+    ]);
+
+    expect(mocks.addOmniFocusTask.mock.calls[0][0]).toMatchObject({
+      note: 'n',
+      dueDate: '2026-01-01',
+      deferDate: '2026-01-02',
+      plannedDate: '2026-01-03',
+      flagged: true,
+      estimatedMinutes: 15,
+      tags: ['a'],
+      parentTaskName: 'Parent',
+      hierarchyLevel: 1,
+    });
+  });
+});
+
+describe('batchAddItems placement reporting', () => {
+  it('carries placement through to the result', async () => {
+    mocks.addOmniFocusTask.mockResolvedValue({ success: true, taskId: 't', placement: 'inbox' });
+
+    const result = await batchAddItems([{ type: 'task', name: 'Stray', projectName: 'Nowhere' }]);
+
+    expect(result.results[0]).toMatchObject({ success: true, placement: 'inbox' });
+  });
+
+  it('leaves placement undefined for projects, which have none', async () => {
+    const result = await batchAddItems([{ type: 'project', name: 'A project' }]);
+
+    expect(result.results[0].success).toBe(true);
+    expect(result.results[0].placement).toBeUndefined();
+  });
+});
+
+describe('batchAddItems tempId resolution', () => {
+  it('targets a batch-created project by id rather than by name', async () => {
+    // Both ids here are the AppleScript namespace, and a same-named project
+    // elsewhere in the database would otherwise swallow the children.
+    mocks.addProject.mockResolvedValue({ success: true, projectId: 'new-proj' });
+
+    await batchAddItems([
+      { type: 'project', name: 'Single Actions', tempId: 'p1' },
+      { type: 'task', name: 'Child', parentTempId: 'p1' },
+    ]);
+
+    const taskParams = mocks.addOmniFocusTask.mock.calls[0][0];
+    expect(taskParams.projectId).toBe('new-proj');
+    expect(taskParams.projectName).toBeUndefined();
+  });
+
+  it('still resolves a task parent by id', async () => {
+    mocks.addOmniFocusTask
+      .mockResolvedValueOnce({ success: true, taskId: 'parent-task', placement: 'inbox' })
+      .mockResolvedValueOnce({ success: true, taskId: 'child-task', placement: 'parent' });
+
+    await batchAddItems([
+      { type: 'task', name: 'Parent', tempId: 't1' },
+      { type: 'task', name: 'Child', parentTempId: 't1' },
+    ]);
+
+    expect(mocks.addOmniFocusTask.mock.calls[1][0]).toMatchObject({ parentTaskId: 'parent-task' });
+  });
+
+  it('does not let a resolved parent override an explicit projectId', async () => {
+    await batchAddItems([
+      { type: 'task', name: 'Parent', tempId: 't1' },
+      { type: 'task', name: 'Child', parentTempId: 't1', projectId: 'explicit' },
+    ]);
+
+    // parentTempId resolved to a task, so the project request stands untouched.
+    expect(mocks.addOmniFocusTask.mock.calls[1][0]).toMatchObject({ projectId: 'explicit' });
+  });
+});

--- a/src/tools/primitives/batchAddItems.ts
+++ b/src/tools/primitives/batchAddItems.ts
@@ -12,6 +12,7 @@ export type BatchAddItemsParams = {
   flagged?: boolean;
   estimatedMinutes?: number;
   tags?: string[];
+  projectId?: string; // For tasks; takes precedence over projectName
   projectName?: string; // For tasks
   // Hierarchy for tasks
   parentTaskId?: string;
@@ -28,6 +29,13 @@ type ItemResult = {
   success: boolean;
   id?: string;
   error?: string;
+  /**
+   * Where the task actually ended up. Forwarded from addOmniFocusTask rather
+   * than discarded (#97): a dropped placement argument degrades to "inbox +
+   * success", so without this the caller cannot tell a correct placement from
+   * a silent fallthrough. Undefined for projects, which have no placement.
+   */
+  placement?: 'parent' | 'project' | 'inbox';
 };
 
 // Define the result type for the batch operation
@@ -146,6 +154,7 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
 
           // task
           let parentTaskId = item.parentTaskId;
+          let projectId = item.projectId;
           let projectName = item.projectName;
           if (!parentTaskId && item.parentTempId) {
             const resolved = tempResolved.get(item.parentTempId);
@@ -154,7 +163,13 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
               continue;
             }
             if (resolved.type === 'project') {
-              projectName = resolved.name;
+              // Target the project we just created by id, not by name. Both ids
+              // here are the AppleScript namespace (addProject returns `id of
+              // project`, which is what addOmniFocusTask looks up), and a batch
+              // that creates a project whose name already exists elsewhere would
+              // otherwise attach children to the wrong one.
+              projectId = resolved.id;
+              projectName = undefined;
             } else {
               parentTaskId = resolved.id;
             }
@@ -169,6 +184,7 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
             flagged: item.flagged,
             estimatedMinutes: item.estimatedMinutes,
             tags: item.tags,
+            projectId,
             projectName,
             parentTaskId,
             parentTaskName: item.parentTaskName,
@@ -179,7 +195,8 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
           results[i] = {
             success: taskResult.success,
             id: taskResult.taskId,
-            error: taskResult.error
+            error: taskResult.error,
+            placement: taskResult.placement
           };
           if (item.tempId && taskResult.taskId && taskResult.success) {
             tempResolved.set(item.tempId, { id: taskResult.taskId, type: 'task', name: item.name });


### PR DESCRIPTION
Fixes #97.

## The bug

`batch_add_items` accepted `projectId` on task items only in the sense that nothing rejected it. Zod's default is to strip unknown keys, so the argument never reached the primitive, every task landed in the inbox, and the tool reported `✅ Successfully added N items.` Recovery meant noticing by eye and re-homing each task with `edit_item newProjectName`.

Measured back to back against the same real project (`bARxLhruZIp`), v1.10.0:

| call | landed in | message |
|---|---|---|
| `add_omnifocus_task({name, projectId})` | the project ✅ | `✅ Task "…" created successfully in a project.` |
| `batch_add_items({items:[{type:"task", name, projectId}]})` | **Inbox** ❌ | `✅ Successfully added 1 items.` |

## Two defects, not one

**1. The schemas drifted.** `add_omnifocus_task` grew `projectId`; `batch_add_items` didn't. Added to the item schema, to `BatchAddItemsParams`, and to the `taskParams` forwarding, reusing `add_omnifocus_task`'s wording so the guidance stays consistent, with a comment on the schema recording that these two have to be kept in sync.

**2. The batch reported no placement at all.** This is the part that made the bug survive. `addOmniFocusTask` already returns `placement: 'parent' | 'project' | 'inbox'`; `batchAddItems` threw it away, keeping only `success`/`id`/`error`. So even with `projectId` plumbed through, the *next* dropped placement argument would still look identical to success. Now:

```
✅ Successfully added 3 items. ⚠️ 1 landed in the inbox despite a requested project or parent.

- ✅ task: "In the project" → in project "Reading"
- ✅ task: "Deliberately unplaced" → inbox
- ✅ task: "Silently dropped" → ⚠️ inbox — requested "Reading", not honored
```

Ids render bare (`in project id abc`) and names quoted, matching `add_omnifocus_task` — a quoted id reads as a name the caller will go looking for and not find.

## Also in here

- `parentTempId` pointing at a batch-created project now targets it **by id** rather than by name. Both are the AppleScript namespace (`addProject` returns `id of project`, which is exactly what `addOmniFocusTask` looks up), and a batch creating a project whose name already exists elsewhere would otherwise attach its children to the wrong one.
- `add_omnifocus_task` said `in a project` when placement came from `projectId` — i.e. it withheld the location precisely from the caller who can't eyeball it. It now names the id.

## Verification

Gate: `npx tsc --noEmit` clean, 386 tests across 21 files, `npm run build` clean. 19 new unit tests (`describePlacement` behavior + primitive forwarding, including a direct regression test for the stripped `projectId`).

Live against real OmniFocus with `TEST:`-prefixed fixtures, all removed afterward and the removal confirmed by re-query:

- project + child via `parentTempId` → child in the project, reported as `→ in project "TEST: 97 target a1"`
- task with explicit `projectId` → **in the project** (the repro; confirmed independently by the fact that deleting the project took it along, while the inbox control survived)
- task with nothing requested → `→ inbox`, no warning
- task with a bogus `projectId` → fails loudly (`Project not found: id no-such-id-xyz`) rather than falling through to the inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)