### PR TITLE
Fix folder path and parentFolderID in query_omnifocus (#95)

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.parity.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.parity.test.ts
@@ -219,3 +219,56 @@ describe('query_omnifocus project property routing', () => {
     expect(generateFilterConditions('projects', { tags: ['Work'] })).toContain('item.tags || []');
   });
 });
+
+/**
+ * The folder half of the same lesson (issue #95). `path` and `parentFolderID`
+ * both read `container`, which exists on no OmniJS class — verified live: 0/17
+ * folders, 0/970 tasks, 0/81 projects had `.container`, while 9/17 folders had a
+ * `.parent`. So `path` returned the bare folder name and `parentFolderID`
+ * returned null, and the tool described a flat database without ever erroring.
+ *
+ * These assert the property that is actually read, not merely that some code was
+ * emitted for the field — a presence-only test passes happily on `null`, which is
+ * exactly how this hid.
+ */
+describe('query_omnifocus folder property routing (#95)', () => {
+  it('folder path walks parent and never touches container', () => {
+    const emitted = generateFieldMapping('folders', ['path']);
+    expect(emitted).toContain('node.parent');
+    expect(emitted).not.toContain('container');
+  });
+
+  it('folder path walks the whole chain, not one level', () => {
+    // `container.name + "/" + item.name` could only ever produce depth 1, so a
+    // real nesting like PhD/Dissertation/Project 3 was unreachable by construction.
+    const emitted = generateFieldMapping('folders', ['path']);
+    expect(emitted).toContain('while');
+    expect(emitted).toContain('unshift');
+  });
+
+  it('parentFolderID reads parent.id.primaryKey rather than falling through', () => {
+    const emitted = generateFieldMapping('folders', ['parentFolderID']);
+    expect(emitted).toContain('item.parent ? item.parent.id.primaryKey : null');
+    // The generic fallback emits `item.parentFolderID`, which is not an OmniJS
+    // property and is therefore always null. That fallthrough was the bug.
+    expect(emitted).not.toContain('item.parentFolderID');
+  });
+
+  it('the default folder projection is fixed too, not just explicit fields', () => {
+    // Most callers never pass `fields`, so a fix that only covered
+    // buildFieldExpression would leave the common path broken.
+    const emitted = generateFieldMapping('folders', undefined as any);
+    expect(emitted).toContain('node.parent');
+    expect(emitted).not.toContain('container');
+  });
+
+  it('does not invent a folder-style path for tasks or projects', () => {
+    // Tasks and projects have a parent chain, but `path` is documented as a
+    // folder field; walking theirs would silently define new semantics.
+    for (const entity of ['tasks', 'projects'] as const) {
+      const emitted = generateFieldMapping(entity, ['path']);
+      expect(emitted).toContain('path: item.name');
+      expect(emitted).not.toContain('node.parent');
+    }
+  });
+});

--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -271,6 +271,41 @@ describe('formatFolders - id display', () => {
 });
 
 // ============================================================
+// formatFolders - hierarchy rendering (#95)
+// ============================================================
+describe('formatFolders - hierarchy', () => {
+  it('renders a nested path', () => {
+    const result = formatFolders([
+      { name: 'Dissertation', id: 'd1', path: 'PhD/Dissertation' },
+    ]);
+    expect(result).toContain('📍 PhD/Dissertation');
+  });
+
+  it('omits the path when it only echoes the name', () => {
+    // A top-level folder's path IS its name. Printing "📍 Health" beside
+    // "F: Health" looks like a located folder rather than an unlocated one, which
+    // is part of why every folder reading as top-level went unnoticed.
+    const result = formatFolders([{ name: 'Health', id: 'h1', path: 'Health' }]);
+    expect(result).not.toContain('📍');
+  });
+
+  it('renders parentFolderID and subfolder count when present', () => {
+    const result = formatFolders([
+      { name: 'Attentional Health', id: 'a1', parentFolderID: 'h1', subfolders: ['x', 'y'] },
+    ]);
+    expect(result).toContain('⬆️ h1');
+    expect(result).toContain('📁 2 subfolders');
+  });
+
+  it('omits hierarchy markers for a folder with no parent and no children', () => {
+    const result = formatFolders([
+      { name: 'Solo', id: 's1', parentFolderID: null, subfolders: [] },
+    ]);
+    expect(result).toBe('F: Solo [s1]');
+  });
+});
+
+// ============================================================
 // generateFieldMapping - dropDate field
 // ============================================================
 describe('generateFieldMapping - dropDate', () => {

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -294,9 +294,18 @@ function formatFolders(folders: any[]): string {
   return folders.map(folder => {
     const id = folder.id ? ` [${folder.id}]` : '';
     const projectCount = folder.projectCount !== undefined ? ` (${folder.projectCount} projects)` : '';
-    const path = folder.path ? ` 📍 ${folder.path}` : '';
+    // Only render the path once it says something the name doesn't. A top-level
+    // folder's path is just its own name, and "📍 Health" beside "F: Health"
+    // reads like a confirmed location when it is only an echo — which is part of
+    // how the flat-path bug (#95) stayed invisible.
+    const path = folder.path && folder.path !== folder.name ? ` 📍 ${folder.path}` : '';
+    // Fields formatFolders used to drop on the floor: requesting parentFolderID
+    // and seeing nothing rendered is indistinguishable from requesting it and
+    // getting null back (#95).
+    const parentFolderID = folder.parentFolderID ? ` ⬆️ ${folder.parentFolderID}` : '';
+    const subfolders = folder.subfolders?.length ? ` 📁 ${folder.subfolders.length} subfolders` : '';
 
-    return `F: ${folder.name}${id}${projectCount}${path}`;
+    return `F: ${folder.name}${id}${projectCount}${path}${parentFolderID}${subfolders}`;
   }).join('\n');
 }
 

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -25,6 +25,26 @@ const PROJECT_MODIFIED_EXPR = 'item.task ? item.task.modified : null';
 // `hasNote: false` returned nothing. Coerce before comparing.
 const HAS_NOTE_EXPR = 'Boolean(item.note && item.note.trim().length > 0)';
 
+// OmniJS has no `container` property at all — the containing folder is `parent`.
+// Both the `path` field and `parentFolderID` read `container`, so `path` fell
+// through to the bare name for every folder and `parentFolderID` (which had no
+// branch of its own) defaulted to null. Neither errored; both just quietly
+// described a flat database. Verified live against OmniFocus 4.x: 0/17 folders,
+// 0/970 tasks and 0/81 projects had `.container`, while 9/17 folders had a
+// `.parent` (issue #95).
+//
+// Walk the chain rather than reading one level up: nesting deeper than one folder
+// is real (`PhD/Dissertation/Project 3` in the database this was verified
+// against), and `container.name + "/" + item.name` could not have produced a
+// depth-2 path even if `container` had existed. `parent` is null at the top
+// level, which terminates the loop.
+const FOLDER_PATH_EXPR =
+  '(() => { const segments = []; let node = item; while (node) { segments.unshift(node.name); node = node.parent; } return segments.join("/"); })()';
+
+// Matches omnifocusDump.js, which has read folder parentage correctly all along —
+// dump_database reported the hierarchy while query_omnifocus flattened it.
+const FOLDER_PARENT_ID_EXPR = 'item.parent ? item.parent.id.primaryKey : null';
+
 export interface QueryOmnifocusParams {
   entity: 'tasks' | 'projects' | 'folders';
   filters?: {
@@ -673,7 +693,8 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
           id: item.id.primaryKey,
           name: item.name || "",
           projectCount: projectArray.length,
-          path: item.container ? item.container.name + "/" + item.name : item.name
+          path: ${FOLDER_PATH_EXPR},
+          parentFolderID: ${FOLDER_PARENT_ID_EXPR}
         };
       `;
     }
@@ -747,8 +768,16 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
       return `projects: item.projects ? item.projects.map(p => p.task.id.primaryKey) : []`;
     } else if (field === 'subfolders') {
       return `subfolders: item.folders ? item.folders.map(f => f.id.primaryKey) : []`;
+    } else if (field === 'parentFolderID') {
+      return `parentFolderID: ${FOLDER_PARENT_ID_EXPR}`;
     } else if (field === 'path') {
-      return `path: item.container ? item.container.name + "/" + item.name : item.name`;
+      // `path` is documented as a folder field. Tasks and projects have a
+      // `parent`/`parentFolder` chain too, but walking it would invent an
+      // undocumented meaning for them, so they keep returning the bare name —
+      // which is what the broken `container` expression already gave them.
+      return entity === 'folders'
+        ? `path: ${FOLDER_PATH_EXPR}`
+        : `path: item.name`;
     } else if (field === 'isRepeating') {
       return `isRepeating: item.repetitionRule !== null`;
     } else if (field === 'repetitionRule') {


### PR DESCRIPTION
Fixes #95.

`path` and `parentFolderID` both read `container`, which **exists on no OmniJS class**. Verified live against OmniFocus 4.x:

| class | has `.container` | has `.parent` |
|---|---|---|
| Folder | 0 / 17 | 9 / 17 |
| Task | 0 / 970 | — |
| Project | 0 / 81 | — |

So `path` always took the else branch and returned the bare folder name, and `parentFolderID` — which had **no branch of its own** — fell through to the generic default `item.parentFolderID`, not an OmniJS property either, and returned `null`.

Neither errored. `query_omnifocus` simply reported a flat database. This is a silent-wrong-data bug: `path` returned a plausible value that was never a path, so anything reasoning about folder nesting recorded the wrong hierarchy and had no way to know.

Notably `dump_database` has read folder parentage **correctly all along** (`omnifocusScripts/omnifocusDump.js:116` already does `folder.parent ? folder.parent.id.primaryKey : null`) — the two tools disagreed about the same database.

## Changes

- **Walk `parent`** to build the full path instead of reading one level. Depth > 1 is real — `PhD/Dissertation/Project 3` exists in the database this was verified against — and `container.name + "/" + item.name` could not have produced it even if `container` existed. `parent` is `null` at the top level, which terminates the walk.
- **Implement `parentFolderID`** as `item.parent ? item.parent.id.primaryKey : null`, matching `omnifocusDump.js`.
- **Fix the default folder projection too**, not just the explicit-`fields` path. Most callers never pass `fields`, so a `buildFieldExpression`-only fix would have left the common path broken.
- **Render `parentFolderID` and subfolder count** in `formatFolders`, which dropped both — requesting a field and seeing nothing is indistinguishable from requesting it and getting null. Also suppress `path` when it merely echoes the name: `📍 Health` beside `F: Health` reads as a *located* folder rather than an unlocated one, which is part of how this stayed invisible.
- **Leave `path` on tasks/projects as the bare name.** They do have a parent chain, but `path` is documented as a folder field and walking theirs would quietly define new semantics — out of scope here.

## Tests

9 new assertions. The parity ones mirror the property-routing block added in #89: they assert *which property is read*, not merely that code was emitted for the field — a presence-only test passes happily on `null`, which is exactly how this class of bug hides.

## Verification

Live against the real database, after the fix:

```
total folders: 17
with a real (nested) path: 9
with parentFolderID: 9
max depth: 3

  Attentional Health     path=Health/Attentional Health          parent=hv2pjbKcnUw
  Systems Health         path=Garden/Systems Health              parent=e3jJJMdJCWY
  Dissertation           path=PhD/Dissertation                   parent=biMWl9PLV4a
  Project 3              path=PhD/Dissertation/Project 3         parent=m2zM35qfgeD
```

Before: all 17 folders reported as top-level.

Gate: `npx tsc --noEmit` clean · `npm test` 395 passed (was 386) · `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)