### PR TITLE
Version the daemon socket filename (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ Launching `omnifocus-mcp` starts a small shim that connects to a **shared backgr
 
 This matters when several agents use OmniFocus at once. OmniFocus is a single-threaded application driven over AppleEvents, and the server caps how many `osascript` calls it will run concurrently. When each client ran its own server, that cap was per-process — ten clients meant ten independent budgets aimed at one app, causing AppleEvent timeouts. Sharing one process makes the cap global.
 
-The daemon listens on a Unix domain socket in a `0700` directory (`~/.omnifocus-mcp/daemon.sock` by default), so access is enforced by the filesystem — no network port and no token. It exits on its own once no client has been connected for the idle window, and logs to `daemon.log` beside the socket.
+The daemon listens on a Unix domain socket in a `0700` directory (`~/.omnifocus-mcp/daemon-<version>.sock` by default), so access is enforced by the filesystem — no network port and no token. It exits on its own once no client has been connected for the idle window, and logs to `daemon.log` beside the socket.
+
+The socket name carries the package version so that upgrading can never leave you talking to the previous version's daemon. Right after an upgrade you may briefly see two daemons: the old one keeps serving the clients already attached to it and exits once the last of them disconnects.
 
 Nothing about client configuration changes. If the daemon can't be started — an unusual sandbox, a read-only home directory — the shim falls back to running a standalone server in-process, exactly as earlier versions did.
 
@@ -236,7 +238,7 @@ Nothing about client configuration changes. If the daemon can't be started — a
 | Variable | Default | Purpose |
 |---|---|---|
 | `OMNIFOCUS_MCP_NO_DAEMON` | unset | Set to `1` to skip the daemon entirely and run a dedicated server per client (the pre-daemon behavior). First thing to try if you suspect the daemon. |
-| `OMNIFOCUS_MCP_SOCKET` | `~/.omnifocus-mcp/daemon.sock` | Override the socket path, e.g. to run an isolated instance. |
+| `OMNIFOCUS_MCP_SOCKET` | `~/.omnifocus-mcp/daemon-<version>.sock` | Override the socket path, e.g. to run an isolated instance. |
 | `OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES` | `30` | Exit after this long with no client traffic. `0` disables the timeout. |
 | `OMNIFOCUS_MCP_MAX_CONCURRENT_OSASCRIPT` | `4` | Maximum concurrent `osascript` calls. Lower it if you still see AppleEvent timeouts. |
 

--- a/src/buildServer.ts
+++ b/src/buildServer.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SetLevelRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { Logger } from './utils/logger.js';
@@ -33,14 +32,10 @@ import * as createTagTool from './tools/definitions/createTag.js';
  */
 
 // Single-source the version from package.json — the hardcoded string here
-// drifted out of sync with the published version more than once.
-// Works from both src/ (tsx) and dist/ (build): each is one level below the
-// package root.
-const { version } = JSON.parse(
-  readFileSync(new URL("../package.json", import.meta.url), "utf-8")
-);
-
-export const SERVER_VERSION: string = version;
+// drifted out of sync with the published version more than once. Re-exported
+// from version.ts, which the daemon socket path also depends on (#99).
+export { SERVER_VERSION } from "./version.js";
+import { SERVER_VERSION } from "./version.js";
 
 const INSTRUCTIONS = `OmniFocus MCP server for macOS task management.
 
@@ -78,7 +73,10 @@ export interface BuiltServer {
  * Caller owns the transport. Note the logger side-effect below.
  */
 export function createOmniFocusServer(): BuiltServer {
-  const server = new McpServer({ name: "OmniFocus MCP", version }, { instructions: INSTRUCTIONS });
+  const server = new McpServer(
+    { name: "OmniFocus MCP", version: SERVER_VERSION },
+    { instructions: INSTRUCTIONS }
+  );
 
   const logger = new Logger(server.server);
 

--- a/src/daemon/socketPath.test.ts
+++ b/src/daemon/socketPath.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_SOCKET_PATH_LENGTH,
   SOCKET_FILENAME,
 } from './socketPath.js';
+import { VERSION_SLUG } from '../version.js';
 
 describe('resolveSocketDir', () => {
   it('prefers XDG_RUNTIME_DIR when set', () => {
@@ -74,5 +75,56 @@ describe('resolveLockDir', () => {
   it('derives the lock from the socket so separate sockets never serialise', () => {
     expect(resolveLockDir('/a/daemon.sock')).toBe('/a/daemon.sock.lock');
     expect(resolveLockDir('/b/daemon.sock')).not.toBe(resolveLockDir('/a/daemon.sock'));
+  });
+
+  it('versioned sockets get versioned locks, so an upgrade does not serialise on the old one', () => {
+    // Falls out of deriving the lock from the socket path, but it is the property
+    // that matters during an upgrade: the new daemon must not block waiting for a
+    // lock the old one holds.
+    expect(resolveLockDir('/a/daemon-1.11.0.sock')).not.toBe(
+      resolveLockDir('/a/daemon-1.12.0.sock')
+    );
+  });
+});
+
+/**
+ * Issue #99: with a fixed `daemon.sock`, a new shim would connect to whatever was
+ * listening and be served by the previous version's daemon — silently, and
+ * without self-healing, since the idle reaper only arms at zero connections.
+ */
+describe('socket filename is version-qualified (#99)', () => {
+  it('embeds the running package version', () => {
+    expect(SOCKET_FILENAME).toBe(`daemon-${VERSION_SLUG}.sock`);
+    expect(SOCKET_FILENAME).not.toBe('daemon.sock');
+  });
+
+  it('the version slug is filename-safe', () => {
+    // A `/` would silently redirect the socket into a directory that does not
+    // exist; `+` build metadata is legal in semver and would otherwise ride along.
+    expect(VERSION_SLUG).toMatch(/^[A-Za-z0-9._-]+$/);
+  });
+
+  it('two versions resolve to different socket paths', () => {
+    // The property the fix exists for, expressed directly against the filename
+    // construction rather than the module-level constant.
+    const pathFor = (v: string) => `/Users/x/.omnifocus-mcp/daemon-${v}.sock`;
+    expect(pathFor('1.11.0')).not.toBe(pathFor('1.12.0'));
+  });
+
+  it('still fits sun_path with the longer name on a realistic home directory', () => {
+    // The name grew; the guard has to still be measuring the real thing.
+    const path = resolveSocketPath({}, 501, '/Users/someone', '/tmp');
+    expect(path).toContain(VERSION_SLUG);
+    expect(path.length).toBeLessThanOrEqual(MAX_SOCKET_PATH_LENGTH);
+  });
+
+  it('the sun_path fallback accounts for the versioned name', () => {
+    // resolveSocketDir measures join(dir, SOCKET_FILENAME), so a home directory
+    // that only fits the *old* short name must now fall through to the temp dir.
+    const home = `/Users/${'d'.repeat(MAX_SOCKET_PATH_LENGTH - 'daemon.sock'.length - 20)}`;
+    const dir = resolveSocketDir({}, 501, home, '/tmp');
+    expect(`${dir}/${SOCKET_FILENAME}`.length).toBeLessThanOrEqual(
+      Math.max(MAX_SOCKET_PATH_LENGTH, `/tmp/omnifocus-mcp-501/${SOCKET_FILENAME}`.length)
+    );
   });
 });

--- a/src/daemon/socketPath.ts
+++ b/src/daemon/socketPath.ts
@@ -1,5 +1,6 @@
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
+import { VERSION_SLUG } from '../version.js';
 
 /**
  * Where the daemon listens, and why it's a Unix socket rather than a TCP port
@@ -28,7 +29,26 @@ export const SOCKET_DIR_MODE = 0o700;
  */
 export const MAX_SOCKET_PATH_LENGTH = 100;
 
-export const SOCKET_FILENAME = 'daemon.sock';
+/**
+ * The socket filename carries the package version (issue #99).
+ *
+ * With a fixed name, every version resolved to the same path and the shim
+ * treated "something is listening" as success — so after an upgrade, newly
+ * launched clients kept being served by the *old* daemon, silently. It doesn't
+ * self-heal either: the idle reaper only arms at zero connections, so a stale
+ * daemon's lifetime is the max over all its clients, not the idle timeout. With
+ * long-lived MCP clients (an editor session can hold one for days) the old
+ * daemon can outlive the upgrade indefinitely, and each new arrival extends it.
+ *
+ * Versioning the path makes reaching an old daemon structurally impossible
+ * rather than merely unlikely. The cost is one orphaned daemon per upgrade,
+ * which the existing idle timer reaps once its last client disconnects — a
+ * bounded, self-clearing resource cost in exchange for a silent correctness bug.
+ *
+ * `resolveSocketDir` measures the full path against MAX_SOCKET_PATH_LENGTH using
+ * this constant, so the longer name is accounted for before bind().
+ */
+export const SOCKET_FILENAME = `daemon-${VERSION_SLUG}.sock`;
 
 export interface SocketPathEnv {
   /** Explicit override; used verbatim. */

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "fs";
+
+/**
+ * The package version, single-sourced from package.json.
+ *
+ * This lives in its own module rather than in buildServer.ts because the daemon
+ * socket path needs it too (issue #99), and the shim must not import the server
+ * to learn its own version — the whole point of the shim is that it starts
+ * without building an McpServer or touching the OmniFocus bridge.
+ *
+ * Works from both src/ (tsx) and dist/ (build): each is one level below the
+ * package root.
+ */
+const { version } = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8")
+);
+
+export const SERVER_VERSION: string = version;
+
+/**
+ * The version rendered safe for use inside a filename.
+ *
+ * Semver permits characters that are legal in a path but unpleasant in one
+ * (`+` for build metadata, `-` and `.` for prereleases), and nothing stops a
+ * fork from putting a `/` in there — which would silently redirect the socket
+ * into a subdirectory that does not exist. Collapse anything outside a
+ * conservative set.
+ */
+export const VERSION_SLUG: string = SERVER_VERSION.replace(/[^A-Za-z0-9._-]/g, "-");


### PR DESCRIPTION
Fixes #99.

The socket path carried no version identity, and the shim treats "something is listening" as success (`shim.ts:126`), so after an upgrade newly launched clients kept being served by the **old** daemon — silently, with a new version number installed.

**And it does not self-heal.** The idle reaper only arms at zero connections (`daemon.ts:186-188`), so a stale daemon's lifetime is the `max` over all its clients, not the idle window. MCP clients here are long-lived — an editor session or agent runner can hold one open for days — so on a busy machine the count may never reach zero and the old daemon can outlive the upgrade **indefinitely**, with each new arrival extending it. Because the daemon is shared, one stale process serves every client on the machine.

## Fix

`SOCKET_FILENAME` becomes `daemon-<version>.sock`. Reaching an old daemon goes from unlikely to structurally impossible. The cost is one orphaned daemon per upgrade, reaped by the existing idle timer once its last client disconnects — a bounded, self-clearing resource cost traded for a silent correctness bug.

This was option (1) of the three in the issue. Option (2) — a version handshake with drain — is strictly better behaviour and can follow later if orphan daemons prove annoying, but it needs a control message outside the MCP stream and a draining state, which is a lot of machinery to buy the same correctness property.

## Notes

- **`SERVER_VERSION` moves to `src/version.ts`.** The shim needs the version but must not import `buildServer` to get it — the whole point of the shim is that it starts without building an `McpServer` or touching the OmniFocus bridge.
- **`VERSION_SLUG`** collapses anything outside `[A-Za-z0-9._-]`. Semver permits `+` build metadata, and a `/` from a fork would silently redirect the socket into a directory that doesn't exist.
- **The lock dir is versioned for free**, since it's derived from the socket path — so a new daemon never waits on a lock the old one holds.
- **`sun_path` still guarded**: `resolveSocketDir` already measures `join(dir, SOCKET_FILENAME)` against `MAX_SOCKET_PATH_LENGTH`, so the longer name is accounted for before `bind()`. Covered by a test.
- README updated — it documented the literal `daemon.sock` in two places.

## Verification

Simulated an upgrade end to end in an isolated `XDG_RUNTIME_DIR`: started a daemon from this build (1.11.0), then ran a client from a copy with `version` bumped to 1.12.0 while the first daemon was still running.

```
old client -> 1.11.0
new client -> 1.12.0          <- would have been 1.11.0 before this change

sockets:  daemon-1.11.0.sock   daemon-1.12.0.sock
daemons:  both running, each serving its own version
```

Gate: `npx tsc --noEmit` clean · `npm test` 392 passed (was 386) · `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)