### PR TITLE
Fix JSON corruption from quotes in names in write results (#103)

### DIFF
--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -3,7 +3,12 @@ import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { createDateOutsideTellBlock } from '../../utils/dateFormatting.js';
-import { escapeAppleScriptString, generateProjectLookupScript } from '../../utils/appleScriptHelpers.js';
+import {
+  escapeAppleScriptString,
+  escapeForJsonInAppleScript,
+  generateProjectLookupScript,
+  JSON_ESCAPE_HANDLER,
+} from '../../utils/appleScriptHelpers.js';
 
 // Interface for task creation parameters
 export interface AddOmniFocusTaskParams {
@@ -69,12 +74,15 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
     ? generateProjectLookupScript(
         params.projectName,
         'targetProject',
-        `{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${projectName}\\\"}`
+        // escapeForJsonInAppleScript, not escapeAppleScriptString: this name lands
+        // inside a JSON payload, where an AppleScript-escaped quote re-materializes
+        // raw and corrupts the result (#103).
+        `{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${escapeForJsonInAppleScript(params.projectName)}\\\"}`
       )
     : '';
 
   // Construct AppleScript with error handling
-  let script = datePreScript + `
+  let script = JSON_ESCAPE_HANDLER + datePreScript + `
   try
     tell application "OmniFocus"
       tell front document
@@ -85,7 +93,7 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
             set targetProject to first flattened project where id = "${projectId}"
           end try
           if targetProject is missing value then
-            return "{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: id ${projectId}\\\"}"
+            return "{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: id ${params.projectId ? escapeForJsonInAppleScript(params.projectId) : ''}\\\"}"
           end if
         else if "${projectName}" is not "" then
           ${projectNameLookup}
@@ -218,12 +226,14 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
           end try`;
         }).join('\n') : ''}
         
-        -- Return success with task ID and placement
-        return "{\\\"success\\\":true,\\\"taskId\\\":\\"" & taskId & "\\",\\\"name\\\":\\"${name}\\\",\\\"placement\\\":\\"" & placement & "\\"}"
+        -- Return success with task ID and placement. The name is deliberately NOT
+        -- echoed here: the caller already knows it, and splicing it into
+        -- hand-built JSON is how quotes in a task name corrupted the payload (#103).
+        return "{\\\"success\\\":true,\\\"taskId\\\":\\"" & taskId & "\\",\\\"placement\\\":\\"" & placement & "\\"}"
       end tell
     end tell
   on error errorMessage
-    return "{\\\"success\\\":false,\\\"error\\\":\\"" & errorMessage & "\\"}"
+    return "{\\\"success\\\":false,\\\"error\\\":\\"" & my jsonEscape(errorMessage) & "\\"}"
   end try
   `;
   

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -2,7 +2,12 @@ import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { createDateOutsideTellBlock } from '../../utils/dateFormatting.js';
-import { generateFolderLookupScript, escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
+import {
+  escapeAppleScriptString,
+  escapeForJsonInAppleScript,
+  generateFolderLookupScript,
+  JSON_ESCAPE_HANDLER,
+} from '../../utils/appleScriptHelpers.js';
 import { runOsascriptFile } from '../../utils/scriptExecution.js';
 
 // Interface for project creation parameters
@@ -50,8 +55,10 @@ export function generateAppleScript(params: AddProjectParams): string {
   // Build project creation block — either at root or in a folder
   let projectCreationBlock: string;
   if (params.folderName) {
-    const escapedFolderName = escapeAppleScriptString(params.folderName);
-    const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${escapedFolderName}\\\"}`;
+    // escapeForJsonInAppleScript, not escapeAppleScriptString: this name lands
+    // inside a JSON payload, where an AppleScript-escaped quote re-materializes
+    // raw and corrupts the result (#103).
+    const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${escapeForJsonInAppleScript(params.folderName)}\\\"}`;
     const folderLookup = generateFolderLookupScript(params.folderName, 'theFolder', errorJson);
     projectCreationBlock = `
         -- Find the folder (supports nested paths like "Work/Engineering")
@@ -64,7 +71,7 @@ export function generateAppleScript(params: AddProjectParams): string {
   }
 
   // Construct AppleScript with error handling
-  let script = datePreScript + `
+  let script = JSON_ESCAPE_HANDLER + datePreScript + `
   try
     tell application "OmniFocus"
       tell front document
@@ -103,12 +110,14 @@ export function generateAppleScript(params: AddProjectParams): string {
           end try`;
         }).join('\n') : ''}
 
-        -- Return success with project ID
-        return "{\\\"success\\\":true,\\\"projectId\\\":\\"" & projectId & "\\",\\\"name\\\":\\"${name}\\"}"
+        -- Return success with project ID. The name is deliberately NOT echoed:
+        -- the caller already knows it, and splicing it into hand-built JSON is
+        -- how quotes in a name corrupted the payload (#103).
+        return "{\\\"success\\\":true,\\\"projectId\\\":\\"" & projectId & "\\"}"
       end tell
     end tell
   on error errorMessage
-    return "{\\\"success\\\":false,\\\"error\\\":\\"" & errorMessage & "\\"}"
+    return "{\\\"success\\\":false,\\\"error\\\":\\"" & my jsonEscape(errorMessage) & "\\"}"
   end try
   `;
 

--- a/src/tools/primitives/createTag.ts
+++ b/src/tools/primitives/createTag.ts
@@ -1,7 +1,11 @@
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
+import {
+  escapeAppleScriptString,
+  escapeForJsonInAppleScript,
+  JSON_ESCAPE_HANDLER,
+} from '../../utils/appleScriptHelpers.js';
 import { runOsascriptFile } from '../../utils/scriptExecution.js';
 
 export interface CreateTagParams {
@@ -22,7 +26,9 @@ export function generateAppleScript(params: CreateTagParams): string {
 
   if (params.parentTagID) {
     const parentId = escapeAppleScriptString(params.parentTagID);
-    const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Parent tag not found: ${parentId}\\\"}`;
+    // escapeForJsonInAppleScript for the JSON payload — an AppleScript-escaped
+    // quote would re-materialize raw inside the JSON and corrupt it (#103).
+    const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Parent tag not found: ${escapeForJsonInAppleScript(params.parentTagID)}\\\"}`;
     parentLookup = `
         set parentTag to missing value
         try
@@ -34,7 +40,7 @@ export function generateAppleScript(params: CreateTagParams): string {
     creationTarget = 'make new tag with properties {name:"' + name + '"} at end of tags of parentTag';
   } else if (params.parentTagName) {
     const parentName = escapeAppleScriptString(params.parentTagName);
-    const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Parent tag not found: ${parentName}\\\"}`;
+    const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Parent tag not found: ${escapeForJsonInAppleScript(params.parentTagName)}\\\"}`;
     parentLookup = `
         set parentTag to missing value
         try
@@ -46,18 +52,20 @@ export function generateAppleScript(params: CreateTagParams): string {
     creationTarget = 'make new tag with properties {name:"' + name + '"} at end of tags of parentTag';
   }
 
-  const script = `
+  const script = JSON_ESCAPE_HANDLER + `
   try
     tell application "OmniFocus"
       tell front document
         ${parentLookup}
         set newTag to ${creationTarget}
         set tagId to id of newTag as string
-        return "{\\\"success\\\":true,\\\"tagId\\\":\\"" & tagId & "\\",\\\"name\\\":\\"${name}\\"}"
+        -- The name is deliberately NOT echoed: the caller already knows it, and
+        -- splicing it into hand-built JSON is how quotes corrupted payloads (#103).
+        return "{\\\"success\\\":true,\\\"tagId\\\":\\"" & tagId & "\\"}"
       end tell
     end tell
   on error errorMessage
-    return "{\\\"success\\\":false,\\\"error\\\":\\"" & errorMessage & "\\"}"
+    return "{\\\"success\\\":false,\\\"error\\\":\\"" & my jsonEscape(errorMessage) & "\\"}"
   end try
   `;
 
@@ -89,7 +97,9 @@ export async function createTag(params: CreateTagParams): Promise<{success: bool
       return {
         success: result.success,
         tagId: result.tagId,
-        name: result.name,
+        // The script no longer echoes the name (#103); the caller's input is the
+        // authoritative value anyway.
+        name: result.success ? params.name : undefined,
         error: result.error
       };
     } catch (parseError) {

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -3,7 +3,13 @@ import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { generateDateAssignmentV2 } from '../../utils/dateFormatting.js';
-import { generateFolderLookupScript, generateProjectLookupScript, escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
+import {
+  escapeAppleScriptString,
+  escapeForJsonInAppleScript,
+  generateFolderLookupScript,
+  generateProjectLookupScript,
+  JSON_ESCAPE_HANDLER,
+} from '../../utils/appleScriptHelpers.js';
 
 // Status options for tasks and projects
 type TaskStatus = 'incomplete' | 'completed' | 'dropped' | 'skipped';
@@ -84,8 +90,8 @@ export function generateAppleScript(params: EditItemParams): string {
   }
   
   // Build the complete script
-  let script = '';
-  
+  let script = JSON_ESCAPE_HANDLER;
+
   // Add date constructions outside tell blocks
   if (datePreScripts.length > 0) {
     script += datePreScripts.join('\n') + '\n\n';
@@ -350,8 +356,12 @@ export function generateAppleScript(params: EditItemParams): string {
         set end of changedProperties to "project (moved to inbox)"
 `;
       } else {
+        // escapedProjectPath is for AppleScript string contexts (the
+        // changedProperties note below); the error JSON needs
+        // escapeForJsonInAppleScript instead — an AppleScript-escaped quote
+        // would re-materialize raw inside the JSON and corrupt it (#103).
         const escapedProjectPath = escapeAppleScriptString(params.newProjectName);
-        const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${escapedProjectPath}\\\"}`;
+        const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Project not found: ${escapeForJsonInAppleScript(params.newProjectName)}\\\"}`;
         const projectLookup = generateProjectLookupScript(params.newProjectName, 'destProject', errorJson);
         script += `
         -- Find the destination project (supports folder paths like "Work/My Project")
@@ -412,8 +422,7 @@ export function generateAppleScript(params: EditItemParams): string {
 
     // Move to a new folder (supports nested paths like "Work/Engineering")
     if (params.newFolderName !== undefined && params.newFolderName !== '') {
-      const escapedFolderName = escapeAppleScriptString(params.newFolderName);
-      const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${escapedFolderName}\\\"}`;
+      const errorJson = `{\\\"success\\\":false,\\\"error\\\":\\\"Folder not found: ${escapeForJsonInAppleScript(params.newFolderName)}\\\"}`;
       const folderLookup = generateFolderLookupScript(params.newFolderName, 'destFolder', errorJson);
       script += `
         -- Find the destination folder
@@ -436,8 +445,10 @@ export function generateAppleScript(params: EditItemParams): string {
           end if
         end repeat
         
-        -- Return success with details
-        return "{\\\"success\\\":true,\\\"id\\\":\\"" & itemId & "\\",\\\"name\\\":\\"" & itemName & "\\",\\\"changedProperties\\\":\\"" & changedPropsText & "\\"}"
+        -- Return success with details. itemName and changedPropsText only exist
+        -- at script runtime, so they go through the jsonEscape handler — quotes
+        -- in an item name would otherwise corrupt the payload (#103).
+        return "{\\\"success\\\":true,\\\"id\\\":\\"" & itemId & "\\",\\\"name\\\":\\"" & my jsonEscape(itemName) & "\\",\\\"changedProperties\\\":\\"" & my jsonEscape(changedPropsText) & "\\"}"
       else
         -- Item not found
         return "{\\\"success\\\":false,\\\"error\\\":\\\"Item not found\\"}"
@@ -445,7 +456,7 @@ export function generateAppleScript(params: EditItemParams): string {
     end tell
   end tell
 on error errorMessage
-  return "{\\\"success\\\":false,\\\"error\\\":\\"" & errorMessage & "\\"}"
+  return "{\\\"success\\\":false,\\\"error\\\":\\"" & my jsonEscape(errorMessage) & "\\"}"
 end try
 `;
   

--- a/src/tools/primitives/jsonPayloadSafety.test.ts
+++ b/src/tools/primitives/jsonPayloadSafety.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { generateAppleScript as generateAddTaskScript } from './addOmniFocusTask.js';
+import { generateAppleScript as generateAddProjectScript } from './addProject.js';
+import { generateAppleScript as generateCreateTagScript } from './createTag.js';
+import { generateAppleScript as generateRemoveItemScript } from './removeItem.js';
+import { generateAppleScript as generateEditItemScript } from './editItem.js';
+
+/**
+ * Issue #103: every write primitive returns a hand-built JSON payload from
+ * AppleScript. A quote in a user-supplied name used to corrupt that payload —
+ * the write succeeded, the result failed to parse, and the tool reported an
+ * error (a duplicate-retry hazard). This suite pins the two defenses:
+ *
+ * 1. TS-known values are either dropped from the payload (the caller already
+ *    has them) or double-escaped via escapeForJsonInAppleScript.
+ * 2. Runtime-only values (current item name, AppleScript error text) route
+ *    through the script's own `jsonEscape` handler.
+ */
+
+// A name built from the live repro: straight quotes (inch marks) are the ones
+// that corrupt JSON; backslashes ride along to catch the escape-order bug.
+const HOSTILE = 'retitle to "policy \\ infrastructure" engineer';
+
+/**
+ * Evaluate what a pure (splice-free) AppleScript string-literal line returns at
+ * runtime, then JSON.parse it — the same pipeline the daemon runs.
+ */
+function parseReturnedJson(scriptLine: string): any {
+  const literal = scriptLine.slice(scriptLine.indexOf('"') + 1, scriptLine.lastIndexOf('"'));
+  return JSON.parse(literal.replace(/\\(.)/g, '$1'));
+}
+
+function lineContaining(script: string, marker: string): string {
+  const line = script.split('\n').find(l => l.includes(marker));
+  expect(line, `expected a line containing ${marker}`).toBeDefined();
+  return line!;
+}
+
+describe('write-result JSON payload safety (#103)', () => {
+  describe('add_omnifocus_task', () => {
+    it('does not echo the task name into the success payload', () => {
+      const script = generateAddTaskScript({ name: HOSTILE });
+      const success = lineContaining(script, '\\"taskId\\"');
+      expect(success).not.toContain('policy');
+      expect(success).toContain('placement');
+    });
+
+    it('routes AppleScript error text through jsonEscape', () => {
+      const script = generateAddTaskScript({ name: 'x' });
+      expect(script).toContain('on jsonEscape(theText)');
+      expect(script).toContain('my jsonEscape(errorMessage)');
+    });
+
+    it('project-not-found error JSON survives a quoted project name', () => {
+      const script = generateAddTaskScript({ name: 'x', projectName: HOSTILE });
+      // The script always also contains the projectId branch's "Project not
+      // found: id" line, so anchor on the name itself.
+      const result = parseReturnedJson(lineContaining(script, 'Project not found: retitle'));
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(`Project not found: ${HOSTILE}`);
+    });
+
+    it('project-not-found-by-id error JSON survives a quoted id', () => {
+      const script = generateAddTaskScript({ name: 'x', projectId: 'id "with" quotes' });
+      const result = parseReturnedJson(lineContaining(script, 'Project not found: id'));
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Project not found: id id "with" quotes');
+    });
+  });
+
+  describe('add_project', () => {
+    it('does not echo the project name into the success payload', () => {
+      const script = generateAddProjectScript({ name: HOSTILE });
+      const success = lineContaining(script, '\\"projectId\\"');
+      expect(success).not.toContain('policy');
+    });
+
+    it('folder-not-found error JSON survives a quoted folder name', () => {
+      const script = generateAddProjectScript({ name: 'x', folderName: 'Q3 "Deep Work"' });
+      const result = parseReturnedJson(lineContaining(script, 'Folder not found'));
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Folder not found: Q3 "Deep Work"');
+    });
+
+    it('routes AppleScript error text through jsonEscape', () => {
+      const script = generateAddProjectScript({ name: 'x' });
+      expect(script).toContain('on jsonEscape(theText)');
+      expect(script).toContain('my jsonEscape(errorMessage)');
+    });
+  });
+
+  describe('create_tag', () => {
+    it('does not echo the tag name into the success payload', () => {
+      const script = generateCreateTagScript({ name: HOSTILE });
+      const success = lineContaining(script, '\\"tagId\\"');
+      expect(success).not.toContain('policy');
+    });
+
+    it('parent-not-found error JSON survives a quoted parent name', () => {
+      const script = generateCreateTagScript({ name: 'x', parentTagName: 'the "urgent" bucket' });
+      const result = parseReturnedJson(lineContaining(script, 'Parent tag not found'));
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Parent tag not found: the "urgent" bucket');
+    });
+  });
+
+  describe('remove_item', () => {
+    it('routes the runtime item name and error text through jsonEscape', () => {
+      const script = generateRemoveItemScript({ id: 'abc', itemType: 'task' });
+      expect(script).toContain('on jsonEscape(theText)');
+      expect(script).toContain('my jsonEscape(itemName)');
+      expect(script).toContain('my jsonEscape(errorMessage)');
+    });
+  });
+
+  describe('edit_item', () => {
+    it('routes runtime name and changed-properties text through jsonEscape', () => {
+      const script = generateEditItemScript({ id: 'abc', itemType: 'task', newName: 'renamed' });
+      expect(script).toContain('on jsonEscape(theText)');
+      expect(script).toContain('my jsonEscape(itemName)');
+      expect(script).toContain('my jsonEscape(changedPropsText)');
+      expect(script).toContain('my jsonEscape(errorMessage)');
+    });
+
+    it('project-not-found error JSON survives a quoted destination', () => {
+      const script = generateEditItemScript({
+        id: 'abc',
+        itemType: 'task',
+        newProjectName: 'Say "when"',
+      });
+      const result = parseReturnedJson(lineContaining(script, 'Project not found'));
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Project not found: Say "when"');
+    });
+
+    it('folder-not-found error JSON survives a quoted destination', () => {
+      const script = generateEditItemScript({
+        id: 'abc',
+        itemType: 'project',
+        newFolderName: 'Say "when"',
+      });
+      const result = parseReturnedJson(lineContaining(script, 'Folder not found'));
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Folder not found: Say "when"');
+    });
+  });
+
+  it('every write script defines the jsonEscape handler exactly once', () => {
+    const scripts = [
+      generateAddTaskScript({ name: 'x' }),
+      generateAddProjectScript({ name: 'x' }),
+      generateCreateTagScript({ name: 'x' }),
+      generateRemoveItemScript({ id: 'abc', itemType: 'task' }),
+      generateEditItemScript({ id: 'abc', itemType: 'task', newName: 'y' }),
+    ];
+    for (const script of scripts) {
+      expect(script.match(/on jsonEscape\(theText\)/g)).toHaveLength(1);
+    }
+  });
+});

--- a/src/tools/primitives/removeItem.ts
+++ b/src/tools/primitives/removeItem.ts
@@ -1,7 +1,7 @@
 import { writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { escapeAppleScriptString } from '../../utils/appleScriptHelpers.js';
+import { escapeAppleScriptString, JSON_ESCAPE_HANDLER } from '../../utils/appleScriptHelpers.js';
 import { runOsascriptFile } from '../../utils/scriptExecution.js';
 
 // Interface for item removal parameters
@@ -26,7 +26,7 @@ export function generateAppleScript(params: RemoveItemParams): string {
   }
 
   // Construct AppleScript with error handling
-  let script = `
+  let script = JSON_ESCAPE_HANDLER + `
   try
     tell application "OmniFocus"
       tell front document
@@ -102,8 +102,10 @@ export function generateAppleScript(params: RemoveItemParams): string {
           -- Delete the item
           delete foundItem
 
-          -- Return success
-          return "{\\\"success\\\":true,\\\"id\\\":\\"" & itemId & "\\",\\\"name\\\":\\"" & itemName & "\\"}"
+          -- Return success. itemName only exists at script runtime, so it goes
+          -- through the jsonEscape handler — quotes in an item name would
+          -- otherwise corrupt the payload (#103).
+          return "{\\\"success\\\":true,\\\"id\\\":\\"" & itemId & "\\",\\\"name\\\":\\"" & my jsonEscape(itemName) & "\\"}"
         else
           -- Item not found
           return "{\\\"success\\\":false,\\\"error\\\":\\\"Item not found\\\"}"
@@ -111,7 +113,7 @@ export function generateAppleScript(params: RemoveItemParams): string {
       end tell
     end tell
   on error errorMessage
-    return "{\\\"success\\\":false,\\\"error\\\":\\"" & errorMessage & "\\"}"
+    return "{\\\"success\\\":false,\\\"error\\\":\\"" & my jsonEscape(errorMessage) & "\\"}"
   end try
   `;
 

--- a/src/utils/__tests__/appleScriptHelpers.test.ts
+++ b/src/utils/__tests__/appleScriptHelpers.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { escapeAppleScriptString } from '../appleScriptHelpers.js';
+import {
+  escapeAppleScriptString,
+  escapeForJsonInAppleScript,
+  JSON_ESCAPE_HANDLER,
+} from '../appleScriptHelpers.js';
+
+/**
+ * Render what an AppleScript double-quoted string literal evaluates to at
+ * runtime: `\"` becomes `"`, `\\` becomes `\`. This is the missing half of the
+ * pipeline that made #103 invisible to source-level assertions — the bug only
+ * appears after AppleScript has *unescaped* the source.
+ */
+function renderAppleScriptLiteral(source: string): string {
+  return source.replace(/\\(.)/g, '$1');
+}
 
 describe('escapeAppleScriptString', () => {
   it('passes plain strings through unchanged', () => {
@@ -44,5 +58,68 @@ describe('escapeAppleScriptString', () => {
 
   it('handles empty strings', () => {
     expect(escapeAppleScriptString('')).toBe('');
+  });
+});
+
+/**
+ * Issue #103: values spliced into hand-built JSON payloads need TWO escape
+ * layers (JSON first, then AppleScript). escapeAppleScriptString alone keeps the
+ * *source* well-formed but re-materializes raw quotes in the *output*, so the
+ * server reported an error for a write that succeeded.
+ */
+describe('escapeForJsonInAppleScript (#103)', () => {
+  // Simulate the full pipeline: TS builds AppleScript source, AppleScript
+  // evaluates the literal, JSON.parse reads the runtime output.
+  const roundTrip = (value: string): string =>
+    JSON.parse(`"${renderAppleScriptLiteral(escapeForJsonInAppleScript(value))}"`);
+
+  it('round-trips double quotes — the exact repro from the issue', () => {
+    const name = 'Start the resume refresh: retitle the headline to "policy infrastructure engineer"';
+    expect(roundTrip(name)).toBe(name);
+  });
+
+  it('round-trips backslashes', () => {
+    expect(roundTrip('path\\to\\thing')).toBe('path\\to\\thing');
+  });
+
+  it('round-trips newlines and tabs', () => {
+    expect(roundTrip('line1\nline2\ttabbed')).toBe('line1\nline2\ttabbed');
+  });
+
+  it('passes curly quotes and inch marks through untouched', () => {
+    // Curly quotes are JSON-safe as-is; straight quotes (inch marks) are the
+    // dangerous ones. Both appeared in the week of traces that surfaced #103.
+    const name = '“Smart” quotes and a 27" monitor';
+    expect(roundTrip(name)).toBe(name);
+  });
+
+  it('is a plain passthrough for benign names', () => {
+    expect(escapeForJsonInAppleScript('Buy milk')).toBe('Buy milk');
+  });
+});
+
+describe('JSON_ESCAPE_HANDLER (#103)', () => {
+  it('defines a jsonEscape handler', () => {
+    expect(JSON_ESCAPE_HANDLER).toContain('on jsonEscape(theText)');
+    expect(JSON_ESCAPE_HANDLER).toContain('end jsonEscape');
+  });
+
+  it('escapes backslash before quote — the order that cannot double-escape', () => {
+    const backslashIndex = JSON_ESCAPE_HANDLER.indexOf('"\\\\"');
+    const quoteIndex = JSON_ESCAPE_HANDLER.indexOf('"\\""');
+    expect(backslashIndex).toBeGreaterThan(-1);
+    expect(quoteIndex).toBeGreaterThan(-1);
+    expect(backslashIndex).toBeLessThan(quoteIndex);
+  });
+
+  it('handles the control characters JSON.parse rejects raw', () => {
+    for (const constant of ['linefeed', 'return', 'tab']) {
+      expect(JSON_ESCAPE_HANDLER).toContain(`set AppleScript's text item delimiters to ${constant}`);
+    }
+  });
+
+  it('restores the caller text item delimiters', () => {
+    expect(JSON_ESCAPE_HANDLER).toContain('set oldDelims to');
+    expect(JSON_ESCAPE_HANDLER).toContain('set AppleScript\'s text item delimiters to oldDelims');
   });
 });

--- a/src/utils/appleScriptHelpers.ts
+++ b/src/utils/appleScriptHelpers.ts
@@ -20,6 +20,63 @@ export function escapeAppleScriptString(
 }
 
 /**
+ * Escape a TypeScript-known string for embedding as a JSON string *value* inside
+ * a double-quoted AppleScript string literal (issue #103).
+ *
+ * `escapeAppleScriptString` alone is not enough for these sites: it protects the
+ * AppleScript *source*, but at runtime the escaped quote re-materializes as a raw
+ * `"` inside the JSON the script returns, and `JSON.parse` on our side then fails
+ * — reporting an error for a write that succeeded. Two layers, applied in order:
+ * JSON-escape the value (what the parser will see), then AppleScript-escape the
+ * result (so the source stays well-formed).
+ */
+export function escapeForJsonInAppleScript(value: string): string {
+  // slice(1, -1) drops JSON.stringify's surrounding quotes, leaving just the
+  // escaped body. JSON escaping also removes raw newlines, so the AppleScript
+  // layer never sees one.
+  return escapeAppleScriptString(JSON.stringify(value).slice(1, -1));
+}
+
+/**
+ * AppleScript source for a `jsonEscape` handler, for values that only exist at
+ * script runtime (an item's current name, AppleScript error text). Prepend this
+ * to a script and wrap interpolations with `my jsonEscape(...)` wherever a
+ * runtime string is spliced into a JSON return payload (issue #103).
+ *
+ * Escapes backslash first (order matters), then quote, then the control
+ * characters JSON.parse rejects raw. AppleScript has no replace; text item
+ * delimiters are the idiom.
+ */
+export const JSON_ESCAPE_HANDLER = `
+on jsonEscape(theText)
+  set theText to theText as string
+  set oldDelims to AppleScript's text item delimiters
+  set AppleScript's text item delimiters to "\\\\"
+  set theParts to text items of theText
+  set AppleScript's text item delimiters to "\\\\\\\\"
+  set theText to theParts as string
+  set AppleScript's text item delimiters to "\\""
+  set theParts to text items of theText
+  set AppleScript's text item delimiters to "\\\\\\""
+  set theText to theParts as string
+  set AppleScript's text item delimiters to linefeed
+  set theParts to text items of theText
+  set AppleScript's text item delimiters to "\\\\n"
+  set theText to theParts as string
+  set AppleScript's text item delimiters to return
+  set theParts to text items of theText
+  set AppleScript's text item delimiters to "\\\\r"
+  set theText to theParts as string
+  set AppleScript's text item delimiters to tab
+  set theParts to text items of theText
+  set AppleScript's text item delimiters to "\\\\t"
+  set theText to theParts as string
+  set AppleScript's text item delimiters to oldDelims
+  return theText
+end jsonEscape
+`;
+
+/**
  * Generate AppleScript that resolves a folder by path (e.g. "Work/Engineering")
  * or by simple name (e.g. "Work"). Sets `varName` to the found folder object,
  * or returns `errorReturnJson` if not found.


### PR DESCRIPTION
## Problem

Every write primitive returns hand-built JSON from AppleScript. `escapeAppleScriptString` protects the AppleScript *source*, but at runtime the escaped quote re-materializes as a raw `"` inside the JSON payload — `JSON.parse` then fails on our side and the tool errors **on a successful write**. Live repro in #103: the task was created, the result said error, and a trusting agent would have retried and created a duplicate. The same defect sat in every `on error` handler (AppleScript error text routinely contains quotes) and in the "Project/Folder/Parent tag not found" error payloads.

## Fix

Split by when the value is known:

- **TS-known values** — the created item's name is no longer echoed into the success payload at all: the caller already knows it, and none of the TS wrappers read it (`create_tag`'s wrapper now supplies `params.name` itself). Not-found error messages embed user-supplied names via a new `escapeForJsonInAppleScript` (JSON-escape the value, then AppleScript-escape the result).
- **Runtime-only values** (`itemName`, `changedPropsText`, `errorMessage`) — a `jsonEscape` AppleScript handler is prepended to every write script and wraps each splice site. Escapes backslash before quote, plus the control characters `JSON.parse` rejects raw.

## Verification

- 23 new tests: full-pipeline round-trips (TS → rendered AppleScript literal → `JSON.parse`) including the exact repro string from the issue, plus structural assertions on all five write scripts.
- Handler exercised against a **real osascript run** (quotes, backslash, linefeed, tab): output parsed clean.
- Live end-to-end against OmniFocus with the repro name (`TEST:` prefixed, then removed): `add_omnifocus_task` returns clean JSON with a taskId; `remove_item` round-trips the hostile name through the runtime handler.
- Gate: tsc clean, 424 tests, build OK.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1