### PR TITLE
Echo created/edited/removed ids in write-tool results (#104)

### DIFF
--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -61,10 +61,14 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
         placementWarning = `\n⚠️ Parent not found; task created ${placement === 'project' ? 'in project' : 'in inbox'}.`;
       }
 
+      // Echo the id (#104): without it, agents re-query immediately after every
+      // write just to harvest the id for the follow-up edit.
+      const idText = result.taskId ? ` (id: ${result.taskId})` : '';
+
       return {
         content: [{
           type: "text" as const,
-          text: `✅ Task "${args.name}" created successfully ${locationText}${dueDateText}${tagText}.${placementWarning}`
+          text: `✅ Task "${args.name}" created successfully ${locationText}${dueDateText}${tagText}${idText}.${placementWarning}`
         }]
       };
     } else {

--- a/src/tools/definitions/addProject.ts
+++ b/src/tools/definitions/addProject.ts
@@ -36,11 +36,15 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       let sequentialText = args.sequential
         ? " (sequential)"
         : " (parallel)";
-        
+
+      // Echo the id (#104): without it, agents re-query immediately after every
+      // write just to harvest the id for the follow-up edit.
+      const idText = result.projectId ? ` (id: ${result.projectId})` : '';
+
       return {
         content: [{
           type: "text" as const,
-          text: `✅ Project "${args.name}" created successfully ${locationText}${dueDateText}${tagText}${sequentialText}.`
+          text: `✅ Project "${args.name}" created successfully ${locationText}${dueDateText}${tagText}${sequentialText}${idText}.`
         }]
       };
     } else {

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -141,7 +141,10 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
           const itemType = args.items[index].type;
           const itemName = args.items[index].name;
           const where = describePlacement(args.items[index], item.placement, args.items);
-          return `- ✅ ${itemType}: "${itemName}"${where}`;
+          // Echo each created id (#104): batch callers otherwise re-query for
+          // every id they need for follow-up edits.
+          const idText = item.id ? ` (id: ${item.id})` : '';
+          return `- ✅ ${itemType}: "${itemName}"${idText}${where}`;
         } else {
           const itemType = args.items[index].type;
           const itemName = args.items[index].name;
@@ -163,7 +166,7 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
             const itemType = args.items[index].type;
             const itemName = args.items[index].name;
             return r.success
-              ? `- ✅ ${itemType}: \"${itemName}\"${describePlacement(args.items[index], r.placement, args.items)}`
+              ? `- ✅ ${itemType}: \"${itemName}\"${r.id ? ` (id: ${r.id})` : ''}${describePlacement(args.items[index], r.placement, args.items)}`
               : `- ❌ ${itemType}: \"${itemName}\" - Error: ${r?.error || 'Unknown error'}`;
           }).join('\\n')
         : `No items processed. ${result.error || ''}`;

--- a/src/tools/definitions/batchRemoveItems.ts
+++ b/src/tools/definitions/batchRemoveItems.ts
@@ -42,7 +42,9 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       const details = result.results.map((item, index) => {
         if (item.success) {
           const itemType = args.items[index].itemType;
-          return `- ✅ ${itemType}: "${item.name}"`;
+          // Echo each removed id (#104): confirms exactly which item went away.
+          const idText = item.id ? ` (id: ${item.id})` : '';
+          return `- ✅ ${itemType}: "${item.name}"${idText}`;
         } else {
           const itemType = args.items[index].itemType;
           const identifier = args.items[index].id || args.items[index].name;

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -55,10 +55,14 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
         changedText = ` (${result.changedProperties})`;
       }
       
+      // Echo the id (#104) — especially valuable here on the name-fallback
+      // lookup path, where the caller may not have known the id at all.
+      const idText = result.id ? ` (id: ${result.id})` : '';
+
       return {
         content: [{
           type: "text" as const,
-          text: `✅ ${itemTypeLabel} "${result.name}" updated successfully${changedText}.`
+          text: `✅ ${itemTypeLabel} "${result.name}" updated successfully${changedText}${idText}.`
         }]
       };
     } else {

--- a/src/tools/definitions/removeItem.ts
+++ b/src/tools/definitions/removeItem.ts
@@ -42,10 +42,14 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       // Item was removed successfully
       const itemTypeLabel = args.itemType === 'task' ? 'Task' : 'Project';
       
+      // Echo the id (#104): confirms exactly which item was deleted, which
+      // matters most on the name-fallback path.
+      const idText = result.id ? ` (id: ${result.id})` : '';
+
       return {
         content: [{
           type: "text" as const,
-          text: `✅ ${itemTypeLabel} "${result.name}" removed successfully.`
+          text: `✅ ${itemTypeLabel} "${result.name}" removed successfully${idText}.`
         }]
       };
     } else {

--- a/src/tools/definitions/writeResultIds.test.ts
+++ b/src/tools/definitions/writeResultIds.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Issue #104: every write tool's success text must echo the created/edited/
+ * removed item's id. Without it, agents re-query immediately after each write
+ * just to harvest the id for the follow-up call — pure waste, and it forced a
+ * verify-after-write convention on callers.
+ */
+
+vi.mock('../primitives/addOmniFocusTask.js', () => ({
+  addOmniFocusTask: vi.fn(),
+}));
+vi.mock('../primitives/addProject.js', () => ({
+  addProject: vi.fn(),
+}));
+vi.mock('../primitives/editItem.js', () => ({
+  editItem: vi.fn(),
+}));
+vi.mock('../primitives/removeItem.js', () => ({
+  removeItem: vi.fn(),
+}));
+vi.mock('../primitives/batchAddItems.js', () => ({
+  batchAddItems: vi.fn(),
+}));
+vi.mock('../primitives/batchRemoveItems.js', () => ({
+  batchRemoveItems: vi.fn(),
+}));
+
+import { addOmniFocusTask } from '../primitives/addOmniFocusTask.js';
+import { addProject } from '../primitives/addProject.js';
+import { editItem } from '../primitives/editItem.js';
+import { removeItem } from '../primitives/removeItem.js';
+import { batchAddItems } from '../primitives/batchAddItems.js';
+import { batchRemoveItems } from '../primitives/batchRemoveItems.js';
+
+import { handler as addTaskHandler } from './addOmniFocusTask.js';
+import { handler as addProjectHandler } from './addProject.js';
+import { handler as editItemHandler } from './editItem.js';
+import { handler as removeItemHandler } from './removeItem.js';
+import { handler as batchAddHandler } from './batchAddItems.js';
+import { handler as batchRemoveHandler } from './batchRemoveItems.js';
+
+const extra = {} as any;
+
+function textOf(result: any): string {
+  return result.content[0].text;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('write results echo ids (#104)', () => {
+  it('add_omnifocus_task includes the task id', async () => {
+    vi.mocked(addOmniFocusTask).mockResolvedValue({
+      success: true,
+      taskId: 'tASK123',
+      placement: 'inbox',
+    });
+    const result = await addTaskHandler({ name: 'Buy milk' } as any, extra);
+    expect(textOf(result)).toContain('(id: tASK123)');
+  });
+
+  it('add_project includes the project id', async () => {
+    vi.mocked(addProject).mockResolvedValue({ success: true, projectId: 'pROJ456' });
+    const result = await addProjectHandler({ name: 'New Project' } as any, extra);
+    expect(textOf(result)).toContain('(id: pROJ456)');
+  });
+
+  it('edit_item includes the item id', async () => {
+    vi.mocked(editItem).mockResolvedValue({
+      success: true,
+      id: 'iTEM789',
+      name: 'Renamed',
+      changedProperties: 'name',
+    });
+    const result = await editItemHandler(
+      { name: 'Old name', itemType: 'task', newName: 'Renamed' } as any,
+      extra
+    );
+    expect(textOf(result)).toContain('(id: iTEM789)');
+  });
+
+  it('remove_item includes the removed id', async () => {
+    vi.mocked(removeItem).mockResolvedValue({ success: true, id: 'gONE1', name: 'Old task' });
+    const result = await removeItemHandler({ id: 'gONE1', itemType: 'task' } as any, extra);
+    expect(textOf(result)).toContain('(id: gONE1)');
+  });
+
+  it('batch_add_items includes each created id in the per-item details', async () => {
+    vi.mocked(batchAddItems).mockResolvedValue({
+      success: true,
+      results: [
+        { success: true, id: 'nEW1', placement: 'project' },
+        { success: true, id: 'nEW2', placement: 'inbox' },
+      ],
+    } as any);
+    const result = await batchAddHandler(
+      {
+        items: [
+          { type: 'task', name: 'First', projectName: 'Reading' },
+          { type: 'task', name: 'Second' },
+        ],
+      } as any,
+      extra
+    );
+    expect(textOf(result)).toContain('(id: nEW1)');
+    expect(textOf(result)).toContain('(id: nEW2)');
+  });
+
+  it('batch_remove_items includes each removed id in the per-item details', async () => {
+    vi.mocked(batchRemoveItems).mockResolvedValue({
+      success: true,
+      results: [{ success: true, id: 'rM1', name: 'Old task' }],
+    } as any);
+    const result = await batchRemoveHandler(
+      { items: [{ id: 'rM1', itemType: 'task' }] } as any,
+      extra
+    );
+    expect(textOf(result)).toContain('(id: rM1)');
+  });
+
+  it('omits the id clause rather than rendering "(id: undefined)"', async () => {
+    vi.mocked(addOmniFocusTask).mockResolvedValue({ success: true } as any);
+    const result = await addTaskHandler({ name: 'Buy milk' } as any, extra);
+    expect(textOf(result)).not.toContain('undefined');
+    expect(textOf(result)).not.toContain('(id:');
+  });
+});


### PR DESCRIPTION
## Problem

Every write tool except `create_tag` reported success without the item's id — `✅ Task "name" created successfully in project …`. The primitives return the ids (and `add_omnifocus_task` even *verifies persistence by id* before reporting success); the definitions just dropped them. A week of live agent traces showed ~4 queries that existed solely to harvest an id right after a write, and it's what forces the verify-after-write convention on agent callers.

## Change

Append `(id: …)` to the success text of `add_omnifocus_task`, `add_project`, `edit_item`, `remove_item`, and per-item in `batch_add_items` / `batch_remove_items` — the same style `create_tag` already uses. When a result carries no id, the clause is omitted entirely (never `(id: undefined)`).

## Verification

7 new handler tests with mocked primitives cover all six tools plus the missing-id case. Gate: tsc clean, 408 tests, build OK.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1