### PR TITLE
Stop rendering [undefined] status and drop the filter echo in query results (#106)

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -3,7 +3,7 @@ import { _testExports as primitives } from '../primitives/queryOmnifocus.js';
 import { _testExports as definitions } from '../definitions/queryOmnifocus.js';
 
 const { escapeJXA, generateFilterConditions, generateFieldMapping } = primitives;
-const { formatTasks, formatProjects, formatFolders, formatFilters } = definitions;
+const { formatTasks, formatProjects, formatFolders, formatQueryResults } = definitions;
 
 // ============================================================
 // escapeJXA
@@ -556,69 +556,6 @@ describe('formatTasks - sequential display', () => {
   });
 });
 
-// ============================================================
-// formatFilters - taskName display
-// ============================================================
-describe('formatFilters', () => {
-  it('displays taskName filter', () => {
-    const result = formatFilters({ taskName: 'email' });
-    expect(result).toContain('taskName: "email"');
-  });
-
-  it('displays combined filters', () => {
-    const result = formatFilters({ projectName: 'Test', taskName: 'foo' });
-    expect(result).toContain('project: "Test"');
-    expect(result).toContain('taskName: "foo"');
-  });
-
-  it('returns empty string for empty filters', () => {
-    const result = formatFilters({});
-    expect(result).toBe('');
-  });
-
-  it('displays string date filter values naturally', () => {
-    const result = formatFilters({ dueWithin: 'this week' });
-    expect(result).toBe('due within this week');
-    expect(result).not.toContain('days');
-  });
-
-  it('displays numeric date filter values with "days" unit', () => {
-    const result = formatFilters({ dueWithin: 7 });
-    expect(result).toBe('due within 7 days');
-  });
-
-  it('displays string dueOn naturally', () => {
-    const result = formatFilters({ dueOn: 'today' });
-    expect(result).toBe('due on today');
-    expect(result).not.toContain('+');
-  });
-
-  it('displays numeric dueOn with +N format', () => {
-    const result = formatFilters({ dueOn: 2 });
-    expect(result).toBe('due on day +2');
-  });
-
-  it('displays ISO date dueOn naturally', () => {
-    const result = formatFilters({ dueOn: '2026-04-15' });
-    expect(result).toBe('due on 2026-04-15');
-  });
-
-  it('displays reviewDue filter', () => {
-    const result = formatFilters({ reviewDue: true });
-    expect(result).toBe('review due: true');
-  });
-
-  it('displays droppedOn filter', () => {
-    const result = formatFilters({ droppedOn: 0 });
-    expect(result).toBe('dropped on day 0');
-  });
-
-  it('displays droppedWithin filter', () => {
-    const result = formatFilters({ droppedWithin: 7 });
-    expect(result).toBe('dropped within 7 days');
-  });
-});
-
 describe('formatTasks - dropDate display', () => {
   it('shows dropDate when present', () => {
     const result = formatTasks([
@@ -632,5 +569,47 @@ describe('formatTasks - dropDate display', () => {
       { name: 'Plain task', id: 't1' },
     ]);
     expect(result).not.toContain('[dropped');
+  });
+});
+
+// ============================================================
+// Result-format overhead fixes (#106)
+// ============================================================
+describe('formatProjects - status guard (#106)', () => {
+  it('renders nothing for status when the field was not requested', () => {
+    // Without the guard, `undefined !== 'Active'` rendered a literal
+    // "[undefined]" on every row — 49 times in one live 49-project query.
+    const result = formatProjects([{ name: 'Barochory', id: 'p1' }]);
+    expect(result).not.toContain('undefined');
+    expect(result).toBe('P: Barochory [p1]');
+  });
+
+  it('still renders a real non-Active status', () => {
+    const result = formatProjects([{ name: 'Paused', id: 'p2', status: 'OnHold' }]);
+    expect(result).toContain('[OnHold]');
+  });
+
+  it('still suppresses the default Active status', () => {
+    const result = formatProjects([{ name: 'Running', id: 'p3', status: 'Active' }]);
+    expect(result).not.toContain('[Active]');
+  });
+});
+
+describe('formatQueryResults - no argument echo (#106)', () => {
+  it('opens with a bare count line, not a markdown header', () => {
+    const output = formatQueryResults([{ name: 'Task', id: 't1' }], 'tasks');
+    expect(output.startsWith('1 tasks:\n')).toBe(true);
+    expect(output).not.toContain('## Query Results');
+  });
+
+  it('never restates the caller filters', () => {
+    const output = formatQueryResults([{ name: 'Task', id: 't1' }], 'tasks');
+    expect(output).not.toContain('Filters applied');
+  });
+
+  it('keeps the empty-result message', () => {
+    expect(formatQueryResults([], 'projects')).toBe(
+      'No projects found matching the specified criteria.'
+    );
   });
 });

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -76,7 +76,7 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
       } else {
         // Format the results in a compact, readable format
         const items = result.items || [];
-        let output = formatQueryResults(items, args.entity, args.filters);
+        let output = formatQueryResults(items, args.entity);
         
         // Add metadata about the query
         if (items.length === args.limit) {
@@ -112,19 +112,20 @@ export async function handler(args: z.infer<typeof schema>, extra: RequestHandle
   }
 }
 
-// Helper function to format query results in a compact way
-function formatQueryResults(items: any[], entity: string, filters?: any): string {
+// Helper function to format query results in a compact way.
+//
+// Deliberately spare (#106): the caller is an agent that still has its own
+// arguments in context, so restating them ("Filters applied: …", a markdown
+// header) was measured at ~15% overhead on typical results and carried no
+// information. The count line stays — it's the one thing the items themselves
+// don't say.
+function formatQueryResults(items: any[], entity: string): string {
   if (items.length === 0) {
     return `No ${entity} found matching the specified criteria.`;
   }
-  
-  let output = `## Query Results: ${items.length} ${entity}\n\n`;
-  
-  // Add filter summary if filters were applied
-  if (filters && Object.keys(filters).length > 0) {
-    output += `Filters applied: ${formatFilters(filters)}\n\n`;
-  }
-  
+
+  let output = `${items.length} ${entity}:\n`;
+
   // Format each item based on entity type
   switch (entity) {
     case 'tasks':
@@ -139,33 +140,6 @@ function formatQueryResults(items: any[], entity: string, filters?: any): string
   }
   
   return output;
-}
-
-function formatFilters(filters: any): string {
-  const parts = [];
-  if (filters.projectId) parts.push(`projectId: "${filters.projectId}"`);
-  if (filters.projectName) parts.push(`project: "${filters.projectName}"`);
-  if (filters.taskName) parts.push(`taskName: "${filters.taskName}"`);
-  if (filters.folderId) parts.push(`folderId: "${filters.folderId}"`);
-  if (filters.tags) parts.push(`tags: [${filters.tags.join(', ')}]`);
-  if (filters.status) parts.push(`status: [${filters.status.join(', ')}]`);
-  if (filters.flagged !== undefined) parts.push(`flagged: ${filters.flagged}`);
-  if (filters.dueWithin) parts.push(typeof filters.dueWithin === 'string' ? `due within ${filters.dueWithin}` : `due within ${filters.dueWithin} days`);
-  if (filters.deferredUntil) parts.push(typeof filters.deferredUntil === 'string' ? `deferred within ${filters.deferredUntil}` : `deferred becoming available within ${filters.deferredUntil} days`);
-  if (filters.hasNote !== undefined) parts.push(`has note: ${filters.hasNote}`);
-  if (filters.inbox !== undefined) parts.push(`inbox: ${filters.inbox}`);
-  if (filters.dueOn !== undefined) parts.push(typeof filters.dueOn === 'string' ? `due on ${filters.dueOn}` : `due on day +${filters.dueOn}`);
-  if (filters.deferOn !== undefined) parts.push(typeof filters.deferOn === 'string' ? `defer on ${filters.deferOn}` : `defer on day +${filters.deferOn}`);
-  if (filters.plannedOn !== undefined) parts.push(typeof filters.plannedOn === 'string' ? `planned on ${filters.plannedOn}` : `planned on day +${filters.plannedOn}`);
-  if (filters.addedWithin !== undefined) parts.push(`added within ${filters.addedWithin} days`);
-  if (filters.addedOn !== undefined) parts.push(`added on day ${filters.addedOn}`);
-  if (filters.isRepeating !== undefined) parts.push(`repeating: ${filters.isRepeating}`);
-  if (filters.completedWithin !== undefined) parts.push(`completed within ${filters.completedWithin} days`);
-  if (filters.completedOn !== undefined) parts.push(`completed on day ${filters.completedOn}`);
-  if (filters.droppedWithin !== undefined) parts.push(`dropped within ${filters.droppedWithin} days`);
-  if (filters.droppedOn !== undefined) parts.push(`dropped on day ${filters.droppedOn}`);
-  if (filters.reviewDue !== undefined) parts.push(`review due: ${filters.reviewDue}`);
-  return parts.join(', ');
 }
 
 function formatTasks(tasks: any[]): string {
@@ -265,7 +239,10 @@ function formatTasks(tasks: any[]): string {
 
 function formatProjects(projects: any[]): string {
   return projects.map(project => {
-    const status = project.status !== 'Active' ? ` [${project.status}]` : '';
+    // The truthiness guard matters (#106): when the caller's `fields` selection
+    // omits status, `undefined !== 'Active'` used to render a literal
+    // "[undefined]" on every row — 49 times in one live 49-project query.
+    const status = project.status && project.status !== 'Active' ? ` [${project.status}]` : '';
     const folder = project.folderName ? ` 📁 ${project.folderName}` : '';
     const taskCount = project.taskCount !== undefined && project.taskCount !== null ? ` (${project.taskCount} tasks)` : '';
     const flagged = project.flagged ? '🚩 ' : '';
@@ -322,5 +299,4 @@ export const _testExports = {
   formatProjects,
   formatFolders,
   formatQueryResults,
-  formatFilters,
 };


### PR DESCRIPTION
Two result-format defects from a week of live traces (details in #106):

1. **`[undefined]` status echo** — `formatProjects` rendered `[${project.status}]` whenever `status !== 'Active'`, which is also true when `fields` simply didn't include `status`. One live 49-project query rendered `[undefined]` 49 times (~20% of the payload). Now guarded on the value being present; real `OnHold`/`Done`/`Dropped` statuses still render, `Active` is still suppressed.

2. **Argument echo ceremony** — every non-empty result opened with `## Query Results: N entity` + `Filters applied: …`, restating the caller's own arguments (~15% overhead on typical results). Replaced with a bare `N entity:` count line. The empty-result message and the truncation warning are unchanged; `formatFilters` (now dead) is removed along with its tests.

6 new tests pin both behaviors. Gate: tsc clean, 396 tests, build OK.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1