### PR TITLE
Halve the token cost of tool schema descriptions (#105)

### DIFF
--- a/src/buildServer.ts
+++ b/src/buildServer.ts
@@ -107,7 +107,7 @@ export function createOmniFocusServer(): BuiltServer {
 
   server.tool(
     "add_omnifocus_task",
-    "Create a NEW task in OmniFocus. Use this ONLY when the task does not already exist. If a matching task already exists (e.g. an item already in the Inbox, or one referenced earlier in the conversation) and the goal is to file/place/move it into a project or the inbox, do NOT create a duplicate here — use edit_item with newProjectName to MOVE the existing task instead. When unsure whether a matching task already exists, search with query_omnifocus first and prefer moving over creating.",
+    "Create a NEW task. If a matching task already exists (e.g. in the Inbox), do NOT create a duplicate — MOVE it with edit_item + newProjectName. When unsure, check with query_omnifocus first.",
     addOmniFocusTaskTool.schema.shape,
     addOmniFocusTaskTool.handler
   );
@@ -128,7 +128,7 @@ export function createOmniFocusServer(): BuiltServer {
 
   server.tool(
     "edit_item",
-    "Edit an existing task or project in OmniFocus. This is also how you MOVE/reassign an existing task: set newProjectName to a project name/path to move it into that project, or to \"\" / \"inbox\" to move it to the inbox. Whenever a task already exists, prefer moving it with this tool over creating a new one via add_omnifocus_task, so you never create duplicates.",
+    "Edit an existing task or project. Also how you MOVE a task: set newProjectName (or \"\" / \"inbox\"). Prefer moving an existing task over re-creating it — never make duplicates.",
     editItemTool.schema.shape,
     editItemTool.handler
   );
@@ -149,28 +149,28 @@ export function createOmniFocusServer(): BuiltServer {
 
   server.tool(
     "query_omnifocus",
-    "Efficiently query OmniFocus database with powerful filters. Get specific tasks, projects, or folders without loading the entire database. Supports filtering by project, tags, status, due dates, and more. Much faster than dump_database for targeted queries.",
+    "Query tasks, projects, or folders with filters (project, folder, tags, status, dates). Much faster and lighter than dump_database for targeted lookups.",
     queryOmniFocusTool.schema.shape,
     queryOmniFocusTool.handler
   );
 
   server.tool(
     "list_perspectives",
-    "List all available perspectives in OmniFocus, including built-in perspectives (Inbox, Projects, Tags, etc.) and custom perspectives (Pro feature)",
+    "List built-in and custom perspectives (custom is a Pro feature)",
     listPerspectivesTool.schema.shape,
     listPerspectivesTool.handler
   );
 
   server.tool(
     "get_perspective_view",
-    "Get the items visible in a specific OmniFocus perspective. Shows what tasks and projects are displayed when viewing that perspective",
+    "Get the items visible in a named OmniFocus perspective",
     getPerspectiveViewTool.schema.shape,
     getPerspectiveViewTool.handler
   );
 
   server.tool(
     "list_tags",
-    "List all tags in OmniFocus with their hierarchy. Useful for discovering available tags before creating or editing tasks.",
+    "List all tags with their hierarchy",
     listTagsTool.schema.shape,
     listTagsTool.handler
   );

--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -3,20 +3,20 @@ import { addOmniFocusTask, AddOmniFocusTaskParams } from '../primitives/addOmniF
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 
 export const schema = z.object({
-  name: z.string().describe("The name of the task"),
-  note: z.string().optional().describe("Additional notes for the task"),
-  dueDate: z.string().optional().describe("The due date of the task in ISO format (YYYY-MM-DD or full ISO date)"),
-  deferDate: z.string().optional().describe("The defer date of the task in ISO format (YYYY-MM-DD or full ISO date)"),
-  plannedDate: z.string().optional().describe("The planned date of the task in ISO format (YYYY-MM-DD or full ISO date) - indicates intention to work on this task on this date"),
-  flagged: z.boolean().optional().describe("Whether the task is flagged or not"),
-  estimatedMinutes: z.number().optional().describe("Estimated time to complete the task, in minutes"),
-  tags: z.array(z.string()).optional().describe("Tags to assign to the task"),
-  projectId: z.string().optional().describe("The id of the project to add the task to (preferred when the project name is ambiguous — e.g. multiple 'Single Actions' projects across folders). Obtain via query_omnifocus. Takes precedence over projectName when both are supplied."),
-  projectName: z.string().optional().describe("The name or folder path of the project to add the task to (e.g. 'My Project' or 'Work/My Project' to disambiguate by folder). Will add to inbox if not specified. Used when projectId is not supplied; for ambiguous names, prefer projectId. This places a NEWLY created task; to move a task that already exists into a project, use edit_item with newProjectName instead of creating a new task here."),
+  name: z.string().describe("Task name"),
+  note: z.string().optional().describe("Task note"),
+  dueDate: z.string().optional().describe("Due date (YYYY-MM-DD or full ISO)"),
+  deferDate: z.string().optional().describe("Defer date (YYYY-MM-DD or full ISO)"),
+  plannedDate: z.string().optional().describe("Planned date — the day you intend to work on it (YYYY-MM-DD or full ISO)"),
+  flagged: z.boolean().optional().describe("Flag the task"),
+  estimatedMinutes: z.number().optional().describe("Time estimate in minutes"),
+  tags: z.array(z.string()).optional().describe("Tag names to assign"),
+  projectId: z.string().optional().describe("Project id to place the task in; takes precedence over projectName. Prefer when names are ambiguous"),
+  projectName: z.string().optional().describe("Project name or folder path ('Work/My Project') to place the task in; defaults to inbox. To move an EXISTING task, use edit_item with newProjectName instead of creating a duplicate here"),
   // Hierarchy support
-  parentTaskId: z.string().optional().describe("ID of the parent task (preferred for accuracy)"),
-  parentTaskName: z.string().optional().describe("Name of the parent task (used if ID not provided; matched within project or globally if no project)"),
-  hierarchyLevel: z.number().int().min(0).optional().describe("Explicit level indicator for ordering in batch workflows (0=root) - ignored in single add")
+  parentTaskId: z.string().optional().describe("Parent task id (preferred over name)"),
+  parentTaskName: z.string().optional().describe("Parent task name; matched within the project if one is given"),
+  hierarchyLevel: z.number().int().min(0).optional().describe("Ordering hint for batch workflows (0 = root); ignored in single add")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/addProject.ts
+++ b/src/tools/definitions/addProject.ts
@@ -3,15 +3,15 @@ import { addProject, AddProjectParams } from '../primitives/addProject.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 
 export const schema = z.object({
-  name: z.string().describe("The name of the project"),
-  note: z.string().optional().describe("Additional notes for the project"),
-  dueDate: z.string().optional().describe("The due date of the project in ISO format (YYYY-MM-DD or full ISO date)"),
-  deferDate: z.string().optional().describe("The defer date of the project in ISO format (YYYY-MM-DD or full ISO date)"),
-  flagged: z.boolean().optional().describe("Whether the project is flagged or not"),
-  estimatedMinutes: z.number().optional().describe("Estimated time to complete the project, in minutes"),
-  tags: z.array(z.string()).optional().describe("Tags to assign to the project"),
-  folderName: z.string().optional().describe("The name of the folder to add the project to (will add to root if not specified)"),
-  sequential: z.boolean().optional().describe("Whether tasks in the project should be sequential (default: false)")
+  name: z.string().describe("Project name"),
+  note: z.string().optional().describe("Project note"),
+  dueDate: z.string().optional().describe("Due date (YYYY-MM-DD or full ISO)"),
+  deferDate: z.string().optional().describe("Defer date (YYYY-MM-DD or full ISO)"),
+  flagged: z.boolean().optional().describe("Flag the project"),
+  estimatedMinutes: z.number().optional().describe("Time estimate in minutes"),
+  tags: z.array(z.string()).optional().describe("Tag names to assign"),
+  folderName: z.string().optional().describe("Folder to place the project in (root if omitted)"),
+  sequential: z.boolean().optional().describe("Make tasks sequential (default: false)")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -4,34 +4,33 @@ import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.j
 
 export const schema = z.object({
   items: z.array(z.object({
-    type: z.enum(['task', 'project']).describe("Type of item to add ('task' or 'project')"),
-    name: z.string().describe("The name of the item"),
-    note: z.string().optional().describe("Additional notes for the item"),
-    dueDate: z.string().optional().describe("The due date in ISO format (YYYY-MM-DD or full ISO date)"),
-    deferDate: z.string().optional().describe("The defer date in ISO format (YYYY-MM-DD or full ISO date)"),
-    plannedDate: z.string().optional().describe("The planned date in ISO format (YYYY-MM-DD or full ISO date) - tasks only"),
-    flagged: z.boolean().optional().describe("Whether the item is flagged or not"),
-    estimatedMinutes: z.number().optional().describe("Estimated time to complete the item, in minutes"),
-    tags: z.array(z.string()).optional().describe("Tags to assign to the item"),
+    type: z.enum(['task', 'project']).describe("What to create"),
+    name: z.string().describe("Item name"),
+    note: z.string().optional().describe("Item note"),
+    dueDate: z.string().optional().describe("Due date (YYYY-MM-DD or full ISO)"),
+    deferDate: z.string().optional().describe("Defer date (YYYY-MM-DD or full ISO)"),
+    plannedDate: z.string().optional().describe("Planned date (ISO; tasks only)"),
+    flagged: z.boolean().optional().describe("Flag the item"),
+    estimatedMinutes: z.number().optional().describe("Time estimate in minutes"),
+    tags: z.array(z.string()).optional().describe("Tag names to assign"),
 
     // Task-specific properties.
     // Keep these in sync with add_omnifocus_task's schema — the two drifted
     // apart once already (#97): projectId was missing here, so Zod stripped it
     // and every task in the batch landed in the inbox reporting success.
-    projectId: z.string().optional().describe("For tasks: The id of the project to add the task to (preferred when the project name is ambiguous — e.g. multiple 'Single Actions' projects across folders). Obtain via query_omnifocus. Takes precedence over projectName when both are supplied."),
-    projectName: z.string().optional().describe("For tasks: The name or folder path of the project to add the task to (e.g. 'My Project' or 'Work/My Project' to disambiguate by folder). Will add to inbox if not specified. Used when projectId is not supplied; for ambiguous names, prefer projectId."),
-    parentTaskId: z.string().optional().describe("For tasks: ID of the parent task"),
-    parentTaskName: z.string().optional().describe("For tasks: Name of the parent task (scoped to project when provided)"),
-    tempId: z.string().optional().describe("For tasks: Temporary ID for within-batch references"),
-    parentTempId: z.string().optional().describe("For tasks: Reference to parent's tempId within the batch"),
-    hierarchyLevel: z.number().int().min(0).optional().describe("Optional ordering hint (0=root, 1=child, ...)"),
-    
+    projectId: z.string().optional().describe("Tasks: project id to place the task in; takes precedence over projectName. Prefer when names are ambiguous"),
+    projectName: z.string().optional().describe("Tasks: project name or folder path ('Work/My Project'); defaults to inbox"),
+    parentTaskId: z.string().optional().describe("Tasks: parent task id"),
+    parentTaskName: z.string().optional().describe("Tasks: parent task name, scoped to the project when one is given"),
+    tempId: z.string().optional().describe("Tasks: temporary id other items in this batch can reference"),
+    parentTempId: z.string().optional().describe("Tasks: nest under the batch item with this tempId"),
+    hierarchyLevel: z.number().int().min(0).optional().describe("Ordering hint (0 = root)"),
+
     // Project-specific properties
-    folderName: z.string().optional().describe("For projects: The name of the folder to add the project to"),
-    sequential: z.boolean().optional().describe("For projects: Whether tasks in the project should be sequential")
-  })).describe("Array of items (tasks or projects) to add")
-  ,
-  createSequentially: z.boolean().optional().describe("Process parents before children; when false, best-effort order will still try to resolve parents first")
+    folderName: z.string().optional().describe("Projects: folder to place the project in"),
+    sequential: z.boolean().optional().describe("Projects: make tasks sequential")
+  })).describe("Items to add"),
+  createSequentially: z.boolean().optional().describe("Process parents before children; even when false, parents are resolved first best-effort")
 });
 
 type PlacementRequest = {

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -3,31 +3,31 @@ import { editItem, EditItemParams } from '../primitives/editItem.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 
 export const schema = z.object({
-  id: z.string().optional().describe("The ID of the task or project to edit"),
-  name: z.string().optional().describe("The name of the task or project to edit (as fallback if ID not provided)"),
-  itemType: z.enum(['task', 'project']).describe("Type of item to edit ('task' or 'project')"),
-  
-  // Common editable fields
-  newName: z.string().optional().describe("New name for the item"),
-  newNote: z.string().optional().describe("New note for the item"),
-  newDueDate: z.string().optional().describe("New due date in ISO format (YYYY-MM-DD or full ISO date); set to empty string to clear"),
-  newDeferDate: z.string().optional().describe("New defer date in ISO format (YYYY-MM-DD or full ISO date); set to empty string to clear"),
-  newPlannedDate: z.string().optional().describe("New planned date in ISO format (YYYY-MM-DD or full ISO date); set to empty string to clear (tasks only)"),
-  newFlagged: z.boolean().optional().describe("Set flagged status (set to false for no flag, true for flag)"),
-  newEstimatedMinutes: z.number().optional().describe("New estimated minutes"),
+  id: z.string().optional().describe("Item id (takes precedence over name)"),
+  name: z.string().optional().describe("Item name, as fallback when no id"),
+  itemType: z.enum(['task', 'project']).describe("What kind of item"),
+
+  // Common editable fields. Dates take YYYY-MM-DD or full ISO; "" clears.
+  newName: z.string().optional().describe("New name"),
+  newNote: z.string().optional().describe("New note"),
+  newDueDate: z.string().optional().describe("New due date (ISO; \"\" clears)"),
+  newDeferDate: z.string().optional().describe("New defer date (ISO; \"\" clears)"),
+  newPlannedDate: z.string().optional().describe("New planned date (ISO; \"\" clears; tasks only)"),
+  newFlagged: z.boolean().optional().describe("Set flagged status"),
+  newEstimatedMinutes: z.number().optional().describe("New time estimate in minutes"),
 
   // Task-specific fields
-  newStatus: z.enum(['incomplete', 'completed', 'dropped', 'skipped']).optional().describe("New status for tasks (incomplete, completed, dropped, skipped). 'skipped' only works on repeating tasks — it completes the current occurrence to trigger the next repeat, then drops the completed instance."),
-  addTags: z.array(z.string()).optional().describe("Tags to add to the task"),
-  removeTags: z.array(z.string()).optional().describe("Tags to remove from the task"),
-  replaceTags: z.array(z.string()).optional().describe("Tags to replace all existing tags with"),
-  newProjectName: z.string().optional().describe("Move this task to a different project by name or folder path (e.g. 'My Project' or 'Work/My Project' to disambiguate). Pass an empty string or 'inbox' to move the task to the inbox. (tasks only)"),
+  newStatus: z.enum(['incomplete', 'completed', 'dropped', 'skipped']).optional().describe("New task status. 'skipped' (repeating tasks only) completes the occurrence to trigger the next repeat, then drops the instance"),
+  addTags: z.array(z.string()).optional().describe("Tags to add"),
+  removeTags: z.array(z.string()).optional().describe("Tags to remove"),
+  replaceTags: z.array(z.string()).optional().describe("Replace all tags with these"),
+  newProjectName: z.string().optional().describe("Move the task to this project (name or folder path like 'Work/My Project'); \"\" or 'inbox' moves it to the inbox (tasks only)"),
 
   // Project-specific fields
-  newSequential: z.boolean().optional().describe("Whether the project should be sequential"),
-  newFolderName: z.string().optional().describe("New folder to move the project to"),
-  newProjectStatus: z.enum(['active', 'completed', 'dropped', 'onHold']).optional().describe("New status for projects"),
-  markReviewed: z.boolean().optional().describe("Mark the project as reviewed (projects only). Sets the next review date to now + the project's review interval. Only works when set to true.")
+  newSequential: z.boolean().optional().describe("Make the project sequential"),
+  newFolderName: z.string().optional().describe("Move the project to this folder"),
+  newProjectStatus: z.enum(['active', 'completed', 'dropped', 'onHold']).optional().describe("New project status"),
+  markReviewed: z.boolean().optional().describe("true marks the project reviewed, scheduling the next review from its review interval (projects only)")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/getPerspectiveView.ts
+++ b/src/tools/definitions/getPerspectiveView.ts
@@ -3,13 +3,13 @@ import { getPerspectiveView } from '../primitives/getPerspectiveView.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 
 export const schema = z.object({
-  perspectiveName: z.string().describe("Name of the perspective to view (e.g., 'Inbox', 'Projects', 'Flagged', or custom perspective name)"),
-  
-  limit: z.number().optional().describe("Maximum number of items to return. Default: 100"),
-  
-  includeMetadata: z.boolean().optional().describe("Include additional metadata like project names, tags, dates. Default: true"),
-  
-  fields: z.array(z.string()).optional().describe("Specific fields to include in the response. Reduces response size. Available fields: id, name, note, flagged, dueDate, deferDate, completionDate, taskStatus, projectName, tagNames, estimatedMinutes")
+  perspectiveName: z.string().describe("Perspective name, built-in ('Inbox', 'Flagged', …) or custom"),
+
+  limit: z.number().optional().describe("Max items to return (default: 100)"),
+
+  includeMetadata: z.boolean().optional().describe("Include project names, tags, dates (default: true)"),
+
+  fields: z.array(z.string()).optional().describe("Only return the listed fields: id, name, note, flagged, dueDate, deferDate, completionDate, taskStatus, projectName, tagNames, estimatedMinutes")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -4,47 +4,52 @@ import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.j
 import { resolveDateFilter } from '../../utils/dateFilter.js';
 import { localDatePart } from '../../utils/dateSerialization.js';
 
+// Description budget (#105): these strings load into EVERY session that touches
+// the server, so shared grammar is stated once on the filters object and each
+// field describe keeps only what an agent can't infer — case-sensitivity,
+// exact-vs-partial matching, and cross-field requirements. A test caps the
+// total; spend the budget deliberately.
 export const schema = z.object({
-  entity: z.enum(['tasks', 'projects', 'folders']).describe("Type of entity to query. Choose 'tasks' for individual tasks, 'projects' for projects, or 'folders' for folder organization"),
-  
+  entity: z.enum(['tasks', 'projects', 'folders']).describe("What to query"),
+
   filters: z.object({
-    projectId: z.string().optional().describe("Filter tasks by exact project ID (use when you know the specific project ID)"),
-    projectName: z.string().optional().describe("Filter tasks by project name. CASE-INSENSITIVE PARTIAL MATCHING - 'review' matches 'Weekly Review', 'Review Documents', etc. Special value: 'inbox' returns inbox tasks"),
-    taskName: z.string().optional().describe("Filter tasks by task name. CASE-INSENSITIVE PARTIAL MATCHING - 'email' matches 'Send email to IT', 'Confirm email' etc. Useful for fuzzy searching specific tasks across all projects"),
-    folderId: z.string().optional().describe("Filter by folder ID. For tasks, returns tasks whose containing project is in this folder (or a subfolder). For projects, returns projects in this folder (or a subfolder)"),
-    folderName: z.string().optional().describe("Filter by folder name. CASE-INSENSITIVE PARTIAL MATCHING; may match several folders, each including its subfolders. Same task/project semantics as folderId, which takes precedence when both are given"),
-    tags: z.array(z.string()).optional().describe("Filter by tag names. EXACT MATCH, CASE-SENSITIVE. OR logic - items must have at least ONE of the specified tags. Example: ['Work'] and ['work'] are different"),
-    status: z.array(z.string()).optional().describe("Filter by status (OR logic - matches any). TASKS: 'Next' (next action), 'Available' (ready to work), 'Blocked' (waiting), 'DueSoon' (due <24h), 'Overdue' (past due), 'Completed', 'Dropped'. PROJECTS: 'Active', 'OnHold', 'Done', 'Dropped'"),
-    flagged: z.boolean().optional().describe("Filter by flagged status. true = only flagged items, false = only unflagged items"),
-    dueWithin: z.union([z.number(), z.string()]).optional().describe("Returns items due from TODAY through N days in future. Accepts: number (days), 'today', 'tomorrow', 'this week', 'next week', or ISO date 'YYYY-MM-DD'"),
-    deferredUntil: z.union([z.number(), z.string()]).optional().describe("Returns items CURRENTLY DEFERRED that will become available within N days. Accepts: number (days), 'today', 'tomorrow', 'this week', 'next week', or ISO date 'YYYY-MM-DD'"),
-    plannedWithin: z.union([z.number(), z.string()]).optional().describe("Returns tasks planned from TODAY through N days in future. Accepts: number (days), 'today', 'tomorrow', 'this week', 'next week', or ISO date 'YYYY-MM-DD'"),
-    hasNote: z.boolean().optional().describe("Filter by note presence. true = items with non-empty notes (whitespace ignored), false = items with no notes or only whitespace"),
-    inbox: z.boolean().optional().describe("Filter tasks by inbox status. true = only inbox tasks (no project), false = only tasks in a project"),
-    dueOn: z.union([z.number(), z.string()]).optional().describe("Returns items due on exactly this day. Accepts: number (0 = today, 1 = tomorrow), 'today', 'tomorrow', 'this week', 'next week', or ISO date 'YYYY-MM-DD'"),
-    deferOn: z.union([z.number(), z.string()]).optional().describe("Returns items with defer date on exactly this day. Accepts: number (0 = today, 1 = tomorrow), 'today', 'tomorrow', 'this week', 'next week', or ISO date 'YYYY-MM-DD'"),
-    plannedOn: z.union([z.number(), z.string()]).optional().describe("Returns tasks with planned date on exactly this day. Accepts: number (0 = today, 1 = tomorrow), 'today', 'tomorrow', 'this week', 'next week', or ISO date 'YYYY-MM-DD'"),
-    addedWithin: z.number().optional().describe("Returns items added (created) within the last N days. Example: 7 = items added in the last week"),
-    addedOn: z.number().optional().describe("Returns items added (created) on exactly this day. 0 = today, 1 = tomorrow, -1 = yesterday. Negative values look backward"),
-    isRepeating: z.boolean().optional().describe("Filter by repeating status. true = only repeating tasks, false = only non-repeating tasks"),
-    completedWithin: z.number().optional().describe("Returns items completed within the last N days (uses completionDate, which OmniFocus only sets for truly completed items, not dropped ones). Example: 7 = items completed in the last week. For dropped items, use droppedWithin. Note: use with includeCompleted: true"),
-    completedOn: z.number().optional().describe("Returns items completed on exactly this day (uses completionDate, which OmniFocus only sets for truly completed items, not dropped ones). 0 = today, -1 = yesterday. Negative values look backward. For dropped items, use droppedOn. Note: use with includeCompleted: true"),
-    droppedWithin: z.number().optional().describe("Returns items dropped within the last N days (uses dropDate). Example: 7 = items dropped in the last week. Typically combined with status: ['Dropped']. Note: use with includeCompleted: true"),
-    droppedOn: z.number().optional().describe("Returns items dropped on exactly this day (uses dropDate). 0 = today, -1 = yesterday. Negative values look backward. Typically combined with status: ['Dropped']. Note: use with includeCompleted: true"),
-    reviewDue: z.boolean().optional().describe("Filter projects by review status. true = only projects whose next review date is today or in the past (due for review). false = only projects not yet due for review. Only applies to 'projects' entity")
-  }).optional().describe("Optional filters to narrow results. ALL filters combine with AND logic (must match all). Within array filters (tags, status) OR logic applies"),
-  
-  fields: z.array(z.string()).optional().describe("Specific fields to return (reduces response size). TASK FIELDS: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, dropDate, effectiveDropDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule, modificationDate (or modified), creationDate (or added). PROJECT FIELDS: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completionDate, dropDate, effectiveDropDate, completedByChildren, containsSingletonActions, taskCount, tasks, nextReviewDate, reviewInterval, modificationDate, creationDate. FOLDER FIELDS: id, name, path, parentFolderID, status, projectCount, projects, subfolders. NOTE: Date fields use 'added' and 'modified' in OmniFocus API"),
-  
-  limit: z.number().optional().describe("Maximum number of items to return. Useful for large result sets. Default: no limit"),
-  
-  sortBy: z.string().optional().describe("Field to sort by. OPTIONS: name (alphabetical), dueDate (earliest first, null last), deferDate (earliest first, null last), modificationDate (most recent first), creationDate (oldest first), estimatedMinutes (shortest first), taskStatus (groups by status)"),
-  
-  sortOrder: z.enum(['asc', 'desc']).optional().describe("Sort order. 'asc' = ascending (A-Z, old-new, small-large), 'desc' = descending (Z-A, new-old, large-small). Default: 'asc'"),
-  
-  includeCompleted: z.boolean().optional().describe("Include completed and dropped items. Default: false (active items only)"),
-  
-  summary: z.boolean().optional().describe("Return only count of matches, not full details. Efficient for statistics. Default: false")
+    projectId: z.string().optional().describe("Exact project id"),
+    projectName: z.string().optional().describe("Project name; case-insensitive partial match. 'inbox' targets the inbox"),
+    taskName: z.string().optional().describe("Task name; case-insensitive partial match"),
+    folderId: z.string().optional().describe("Folder id, including subfolders; tasks match via their containing project"),
+    folderName: z.string().optional().describe("Folder name; case-insensitive partial match, may match several folders, each including subfolders. folderId takes precedence"),
+    tags: z.array(z.string()).optional().describe("Tag names; exact match, case-sensitive"),
+    status: z.array(z.string()).optional().describe("Tasks: Next, Available, Blocked, DueSoon, Overdue, Completed, Dropped. Projects: Active, OnHold, Done, Dropped"),
+    flagged: z.boolean().optional().describe("true = flagged only, false = unflagged only"),
+    dueWithin: z.union([z.number(), z.string()]).optional().describe("Due between today and the given day/range"),
+    deferredUntil: z.union([z.number(), z.string()]).optional().describe("Currently deferred, becoming available by the given day"),
+    plannedWithin: z.union([z.number(), z.string()]).optional().describe("Planned between today and the given day/range"),
+    hasNote: z.boolean().optional().describe("true = has a non-empty note"),
+    inbox: z.boolean().optional().describe("true = inbox tasks only, false = project tasks only"),
+    dueOn: z.union([z.number(), z.string()]).optional().describe("Due on exactly that day"),
+    deferOn: z.union([z.number(), z.string()]).optional().describe("Defer date exactly that day"),
+    plannedOn: z.union([z.number(), z.string()]).optional().describe("Planned date exactly that day"),
+    addedWithin: z.number().optional().describe("Added in the last N days"),
+    addedOn: z.number().optional().describe("Added on day N (0 = today, -1 = yesterday)"),
+    isRepeating: z.boolean().optional().describe("true = repeating tasks only"),
+    completedWithin: z.number().optional().describe("Completed in the last N days (dropped items need droppedWithin). Requires includeCompleted: true"),
+    completedOn: z.number().optional().describe("Completed on day N (0 = today, -1 = yesterday). Requires includeCompleted: true"),
+    droppedWithin: z.number().optional().describe("Dropped in the last N days. Requires includeCompleted: true"),
+    droppedOn: z.number().optional().describe("Dropped on day N (0 = today, -1 = yesterday). Requires includeCompleted: true"),
+    reviewDue: z.boolean().optional().describe("true = projects due for review (projects only)")
+  }).optional().describe("Filters AND together; array filters (tags, status) OR within the array. Date-valued filters (dueWithin, deferredUntil, plannedWithin, dueOn, deferOn, plannedOn) accept a number of days from today, 'today', 'tomorrow', 'this week', 'next week', or 'YYYY-MM-DD'"),
+
+  fields: z.array(z.string()).optional().describe("Only return the listed fields (smaller responses). Tasks: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, dropDate, effectiveDropDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule, modificationDate, creationDate. Projects: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completionDate, dropDate, effectiveDropDate, completedByChildren, containsSingletonActions, taskCount, tasks, nextReviewDate, reviewInterval, modificationDate, creationDate. Folders: id, name, path, parentFolderID, status, projectCount, projects, subfolders"),
+
+  limit: z.number().optional().describe("Max items to return"),
+
+  sortBy: z.string().optional().describe("name, dueDate, deferDate, modificationDate, creationDate, estimatedMinutes, or taskStatus"),
+
+  sortOrder: z.enum(['asc', 'desc']).optional().describe("Default: asc"),
+
+  includeCompleted: z.boolean().optional().describe("Include completed/dropped items (default: false)"),
+
+  summary: z.boolean().optional().describe("Return only the match count")
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/schemaBudget.test.ts
+++ b/src/tools/definitions/schemaBudget.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+
+/**
+ * Issue #105: tool schema descriptions load into EVERY session that touches the
+ * server, before a single call is made. At their peak they cost ~13k chars
+ * (~3.4k tokens) — more than a typical week of actual result traffic. The diet
+ * brought them to ~7k; these ceilings keep incremental edits from silently
+ * growing them back. If a new tool or a load-bearing clarification genuinely
+ * needs room, raise the ceiling in the same PR — visibly.
+ */
+
+const definitionsDir = dirname(fileURLToPath(import.meta.url));
+
+function describeChars(source: string): number {
+  const matches = [...source.matchAll(/\.describe\(\s*"((?:[^"\\]|\\.)*)"\s*\)/g)];
+  return matches.reduce((sum, m) => sum + m[1].length, 0);
+}
+
+describe('schema description budget (#105)', () => {
+  it('keeps the total .describe() text across all tools under budget', () => {
+    let total = 0;
+    for (const file of readdirSync(definitionsDir)) {
+      if (!file.endsWith('.ts') || file.includes('test')) continue;
+      total += describeChars(readFileSync(join(definitionsDir, file), 'utf8'));
+    }
+    expect(total).toBeLessThanOrEqual(6500);
+  });
+
+  it('keeps query_omnifocus — the historical worst offender — under its own budget', () => {
+    // 5,473 chars before the diet; the fields list is most of what remains.
+    const source = readFileSync(join(definitionsDir, 'queryOmnifocus.ts'), 'utf8');
+    expect(describeChars(source)).toBeLessThanOrEqual(2800);
+  });
+
+  it('keeps the server.tool() registration descriptions under budget', () => {
+    const source = readFileSync(join(definitionsDir, '..', '..', 'buildServer.ts'), 'utf8');
+    const matches = [...source.matchAll(/server\.tool\(\s*"[^"]+",\s*"((?:[^"\\]|\\.)*)"/g)];
+    expect(matches.length).toBeGreaterThan(0);
+    const total = matches.reduce((sum, m) => sum + m[1].length, 0);
+    expect(total).toBeLessThanOrEqual(1300);
+  });
+});


### PR DESCRIPTION
## Problem

Measured on v1.12.0: ~11.2k chars of `.describe()` text plus ~1.8k chars of `server.tool()` registration descriptions ≈ **3.4k tokens loaded by every session** before a single call — outweighing a measured week of actual result traffic (~5k tokens). The `query_omnifocus` `fields` describe alone was ~1.4k chars, and the "Accepts: number (days), 'today', 'tomorrow', …" sentence was repeated verbatim on six date filters.

## Change

Descriptions only — **no schema shape changes** (tsc + all behavior tests confirm):

- Shared grammar stated once at the object level: the date-filter value grammar moved to the `filters` describe; the id-vs-name precedence and ISO-date/clear conventions compressed per-field.
- Load-bearing facts kept: tag case-sensitivity, exact-vs-partial matching, `includeCompleted` requirements, `skipped`-only-for-repeating, the move-don't-recreate anti-duplicate directive, and the full field lists (they're facts, not framing).
- Registration descriptions trimmed the same way (`add_omnifocus_task` 488→~190 chars with the directive intact).

**12,995 → 6,959 chars (−46%, ~1.6k tokens saved per session).** A new budget test caps the totals (definitions ≤6.5k, `query_omnifocus` ≤2.8k, registrations ≤1.3k) so the prose can't silently grow back — raising a ceiling has to happen visibly, in the PR that needs it.

Gate: tsc clean, 404 tests, build OK.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1