### PR TITLE
Nudge stale-attached clients in-band when a newer daemon is serving (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ This matters when several agents use OmniFocus at once. OmniFocus is a single-th
 
 The daemon listens on a Unix domain socket in a `0700` directory (`~/.omnifocus-mcp/daemon-<version>.sock` by default), so access is enforced by the filesystem — no network port and no token. It exits on its own once no client has been connected for the idle window, and logs to `daemon.log` beside the socket.
 
-The socket name carries the package version so that upgrading can never leave you talking to the previous version's daemon. Right after an upgrade you may briefly see two daemons: the old one keeps serving the clients already attached to it and exits once the last of them disconnects.
+The socket name carries the package version so that upgrading can never leave you talking to the previous version's daemon. Right after an upgrade you may briefly see two daemons: the old one keeps serving the clients already attached to it and exits once the last of them disconnects. Clients still attached to the old daemon are told about it in-band — while a newer daemon is serving, every tool result carries a one-line upgrade notice, so nobody has to remember to reconnect.
 
 Nothing about client configuration changes. If the daemon can't be started — an unusual sandbox, a read-only home directory — the shim falls back to running a standalone server in-process, exactly as earlier versions did.
 

--- a/src/buildServer.ts
+++ b/src/buildServer.ts
@@ -3,6 +3,7 @@ import { SetLevelRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { Logger } from './utils/logger.js';
 import { setScriptLogger } from './utils/scriptExecution.js';
 import { registerResources } from './resources/index.js';
+import { withUpgradeNudge } from './daemon/upgradeNudge.js';
 
 // Import tool definitions
 import * as dumpDatabaseTool from './tools/definitions/dumpDatabase.js';
@@ -102,84 +103,84 @@ export function createOmniFocusServer(): BuiltServer {
     "dump_database",
     "Gets the current state of your OmniFocus database",
     dumpDatabaseTool.schema.shape,
-    dumpDatabaseTool.handler
+    withUpgradeNudge(dumpDatabaseTool.handler)
   );
 
   server.tool(
     "add_omnifocus_task",
     "Create a NEW task. If a matching task already exists (e.g. in the Inbox), do NOT create a duplicate — MOVE it with edit_item + newProjectName. When unsure, check with query_omnifocus first.",
     addOmniFocusTaskTool.schema.shape,
-    addOmniFocusTaskTool.handler
+    withUpgradeNudge(addOmniFocusTaskTool.handler)
   );
 
   server.tool(
     "add_project",
     "Add a new project to OmniFocus",
     addProjectTool.schema.shape,
-    addProjectTool.handler
+    withUpgradeNudge(addProjectTool.handler)
   );
 
   server.tool(
     "remove_item",
     "Remove a task or project from OmniFocus",
     removeItemTool.schema.shape,
-    removeItemTool.handler
+    withUpgradeNudge(removeItemTool.handler)
   );
 
   server.tool(
     "edit_item",
     "Edit an existing task or project. Also how you MOVE a task: set newProjectName (or \"\" / \"inbox\"). Prefer moving an existing task over re-creating it — never make duplicates.",
     editItemTool.schema.shape,
-    editItemTool.handler
+    withUpgradeNudge(editItemTool.handler)
   );
 
   server.tool(
     "batch_add_items",
     "Add multiple tasks or projects to OmniFocus in a single operation",
     batchAddItemsTool.schema.shape,
-    batchAddItemsTool.handler
+    withUpgradeNudge(batchAddItemsTool.handler)
   );
 
   server.tool(
     "batch_remove_items",
     "Remove multiple tasks or projects from OmniFocus in a single operation",
     batchRemoveItemsTool.schema.shape,
-    batchRemoveItemsTool.handler
+    withUpgradeNudge(batchRemoveItemsTool.handler)
   );
 
   server.tool(
     "query_omnifocus",
     "Query tasks, projects, or folders with filters (project, folder, tags, status, dates). Much faster and lighter than dump_database for targeted lookups.",
     queryOmniFocusTool.schema.shape,
-    queryOmniFocusTool.handler
+    withUpgradeNudge(queryOmniFocusTool.handler)
   );
 
   server.tool(
     "list_perspectives",
     "List built-in and custom perspectives (custom is a Pro feature)",
     listPerspectivesTool.schema.shape,
-    listPerspectivesTool.handler
+    withUpgradeNudge(listPerspectivesTool.handler)
   );
 
   server.tool(
     "get_perspective_view",
     "Get the items visible in a named OmniFocus perspective",
     getPerspectiveViewTool.schema.shape,
-    getPerspectiveViewTool.handler
+    withUpgradeNudge(getPerspectiveViewTool.handler)
   );
 
   server.tool(
     "list_tags",
     "List all tags with their hierarchy",
     listTagsTool.schema.shape,
-    listTagsTool.handler
+    withUpgradeNudge(listTagsTool.handler)
   );
 
   server.tool(
     "create_tag",
     "Create a new tag in OmniFocus, optionally nested under an existing parent tag",
     createTagTool.schema.shape,
-    createTagTool.handler
+    withUpgradeNudge(createTagTool.handler)
   );
 
   return { server, logger };

--- a/src/daemon/upgradeNudge.test.ts
+++ b/src/daemon/upgradeNudge.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSocketVersion,
+  compareVersions,
+  upgradeNoticeText,
+  findNewerServingVersion,
+  withUpgradeNudge,
+} from './upgradeNudge.js';
+
+describe('parseSocketVersion (#113)', () => {
+  it('extracts a clean release version', () => {
+    expect(parseSocketVersion('daemon-1.13.0.sock')).toBe('1.13.0');
+  });
+
+  it('rejects everything else', () => {
+    // Prereleases, the pre-#99 fixed name, locks, and logs must not participate.
+    for (const name of [
+      'daemon.sock',
+      'daemon-1.13.0-beta.1.sock',
+      'daemon-1.13.0.sock.lock',
+      'daemon.log',
+      'daemon-1.13.sock',
+    ]) {
+      expect(parseSocketVersion(name), name).toBeNull();
+    }
+  });
+});
+
+describe('compareVersions (#113)', () => {
+  it('compares numerically, not lexically', () => {
+    // The lexical trap: "1.9.0" > "1.13.0" as strings.
+    expect(compareVersions('1.13.0', '1.9.0')).toBeGreaterThan(0);
+    expect(compareVersions('2.0.0', '1.99.99')).toBeGreaterThan(0);
+    expect(compareVersions('1.13.0', '1.13.0')).toBe(0);
+    expect(compareVersions('1.13.0', '1.13.1')).toBeLessThan(0);
+  });
+});
+
+describe('findNewerServingVersion (#113)', () => {
+  const base = {
+    currentVersion: '1.13.0',
+    socketDir: '/sockets',
+  };
+
+  it('returns the newest strictly-newer live version', async () => {
+    const result = await findNewerServingVersion({
+      ...base,
+      listDir: () => ['daemon-1.12.0.sock', 'daemon-1.13.0.sock', 'daemon-1.14.0.sock', 'daemon-2.0.0.sock'],
+      probe: async () => true,
+    });
+    expect(result).toBe('2.0.0');
+  });
+
+  it('skips dead sockets — a crash-orphaned file must not nag forever', async () => {
+    const probed: string[] = [];
+    const result = await findNewerServingVersion({
+      ...base,
+      listDir: () => ['daemon-1.14.0.sock', 'daemon-2.0.0.sock'],
+      probe: async path => {
+        probed.push(path);
+        return path.includes('1.14.0');
+      },
+    });
+    expect(result).toBe('1.14.0');
+    // Newest-first: the dead 2.0.0 was tried before falling back.
+    expect(probed).toEqual(['/sockets/daemon-2.0.0.sock', '/sockets/daemon-1.14.0.sock']);
+  });
+
+  it('returns null when only own and older versions are serving', async () => {
+    const result = await findNewerServingVersion({
+      ...base,
+      listDir: () => ['daemon-1.12.0.sock', 'daemon-1.13.0.sock'],
+      probe: async () => true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the socket directory does not exist', async () => {
+    const result = await findNewerServingVersion({
+      ...base,
+      listDir: () => {
+        throw new Error('ENOENT');
+      },
+      probe: async () => true,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('withUpgradeNudge (#113)', () => {
+  const toolResult = () => ({ content: [{ type: 'text' as const, text: '✅ done' }] });
+
+  it('appends the notice as its own content block while a newer daemon serves', async () => {
+    const wrapped = withUpgradeNudge(async () => toolResult(), async () =>
+      upgradeNoticeText('1.13.0', '1.14.0')
+    );
+    const result = await wrapped({}, {});
+    expect(result.content).toHaveLength(2);
+    expect(result.content[1].text).toContain('1.14.0 is serving');
+    expect(result.content[1].text).toContain('Reconnect the MCP server');
+  });
+
+  it('leaves results untouched when no newer daemon is serving', async () => {
+    const wrapped = withUpgradeNudge(async () => toolResult(), async () => null);
+    const result = await wrapped({}, {});
+    expect(result.content).toHaveLength(1);
+  });
+
+  it('nudges error results too — a stale client debugging is exactly who should hear it', async () => {
+    const wrapped = withUpgradeNudge(
+      async () => ({ content: [{ type: 'text' as const, text: 'Failed' }], isError: true }),
+      async () => upgradeNoticeText('1.13.0', '1.14.0')
+    );
+    const result = await wrapped({}, {});
+    expect(result.isError).toBe(true);
+    expect(result.content).toHaveLength(2);
+  });
+
+  it('never lets a nudge failure break the tool result', async () => {
+    const wrapped = withUpgradeNudge(async () => toolResult(), async () => {
+      throw new Error('probe exploded');
+    });
+    const result = await wrapped({}, {});
+    expect(result.content).toHaveLength(1);
+  });
+});

--- a/src/daemon/upgradeNudge.ts
+++ b/src/daemon/upgradeNudge.ts
@@ -1,0 +1,155 @@
+import { readdirSync } from 'fs';
+import { createConnection } from 'net';
+import { join } from 'path';
+import { SERVER_VERSION } from '../version.js';
+import { resolveSocketDir } from './socketPath.js';
+
+/**
+ * In-band upgrade nudge (issue #113).
+ *
+ * #99 versioned the daemon socket so an upgrade can never silently serve old
+ * code to new clients — but it left the inverse gap: clients attached to the
+ * OLD daemon keep running it indefinitely, and nothing tells them a newer
+ * version is available. The design principle here is that nobody should have
+ * to remember anything: any tool call made while stale-attached carries one
+ * appended line saying a newer daemon is serving and a reconnect upgrades.
+ *
+ * The signal is derived from the same mechanism #99 introduced: the socket
+ * directory. A `daemon-<version>.sock` with a strictly newer semver, which is
+ * actually accepting connections, means a newer server is live on this machine
+ * right now. Liveness is probed so a crash-orphaned socket file cannot nag
+ * forever, and the whole check is throttled so its cost amortizes to nothing.
+ */
+
+/** Only clean release versions participate; prereleases and odd slugs don't. */
+const SOCKET_VERSION_RE = /^daemon-(\d+\.\d+\.\d+)\.sock$/;
+
+export function parseSocketVersion(filename: string): string | null {
+  const match = SOCKET_VERSION_RE.exec(filename);
+  return match ? match[1] : null;
+}
+
+/** Standard numeric semver comparison for the major.minor.patch subset. */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+export function upgradeNoticeText(current: string, newer: string): string {
+  return `⬆️ omnifocus-mcp ${newer} is serving on this machine; this connection is on ${current}. Reconnect the MCP server to upgrade.`;
+}
+
+/** True if something is actually accepting connections on the socket. */
+function probeSocketAlive(socketPath: string, timeoutMs = 250): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = createConnection(socketPath);
+    let settled = false;
+    const done = (alive: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(alive);
+    };
+    socket.once('connect', () => done(true));
+    socket.once('error', () => done(false));
+    socket.setTimeout(timeoutMs, () => done(false));
+  });
+}
+
+export interface NudgeDeps {
+  currentVersion?: string;
+  socketDir?: string;
+  listDir?: (dir: string) => string[];
+  probe?: (socketPath: string) => Promise<boolean>;
+}
+
+/**
+ * Find the newest strictly-newer version with a live daemon socket, or null.
+ * Dependency-injected for tests; the real wiring comes from the defaults.
+ */
+export async function findNewerServingVersion(deps: NudgeDeps = {}): Promise<string | null> {
+  const current = deps.currentVersion ?? SERVER_VERSION;
+  const dir = deps.socketDir ?? resolveSocketDir();
+  const listDir = deps.listDir ?? readdirSync;
+  const probe = deps.probe ?? probeSocketAlive;
+
+  let entries: string[];
+  try {
+    entries = listDir(dir);
+  } catch {
+    return null;
+  }
+
+  const newer = entries
+    .map(name => ({ name, version: parseSocketVersion(name) }))
+    .filter((e): e is { name: string; version: string } => e.version !== null)
+    .filter(e => compareVersions(e.version, current) > 0)
+    .sort((a, b) => compareVersions(b.version, a.version));
+
+  for (const candidate of newer) {
+    if (await probe(join(dir, candidate.name))) {
+      return candidate.version;
+    }
+  }
+  return null;
+}
+
+const CHECK_TTL_MS = 5 * 60_000;
+let cache: { at: number; notice: string | null } | null = null;
+
+/** Test hook: reset the throttle cache. */
+export function _resetNudgeCache(): void {
+  cache = null;
+}
+
+/**
+ * The throttled, production entry point: the current notice text, or null.
+ *
+ * Skipped entirely under OMNIFOCUS_MCP_SOCKET — an isolated instance's socket
+ * lives outside the shared directory, so the shared directory says nothing
+ * about it.
+ */
+export async function upgradeNotice(): Promise<string | null> {
+  if (process.env.OMNIFOCUS_MCP_SOCKET) return null;
+  const now = Date.now();
+  if (cache && now - cache.at < CHECK_TTL_MS) return cache.notice;
+  let notice: string | null = null;
+  try {
+    const newer = await findNewerServingVersion();
+    if (newer) notice = upgradeNoticeText(SERVER_VERSION, newer);
+  } catch {
+    // The nudge is best-effort; never let it break a tool result.
+  }
+  cache = { at: now, notice };
+  return notice;
+}
+
+type ToolHandler = (...args: any[]) => Promise<any>;
+
+/**
+ * Wrap a tool handler so its result carries the upgrade notice while (and only
+ * while) a newer daemon is serving. Appended as its own content block; error
+ * results are nudged too — a stale client debugging an error is exactly the
+ * client that should hear "reconnect".
+ */
+export function withUpgradeNudge(
+  handler: ToolHandler,
+  notice: () => Promise<string | null> = upgradeNotice
+): ToolHandler {
+  return async (...args: any[]) => {
+    const result = await handler(...args);
+    try {
+      const text = await notice();
+      if (text && result && Array.isArray(result.content)) {
+        result.content.push({ type: 'text' as const, text });
+      }
+    } catch {
+      // Never let the nudge interfere with the actual result.
+    }
+    return result;
+  };
+}


### PR DESCRIPTION
## Problem

#99 versioned the daemon socket so an upgrade can never silently serve old code to *new* clients — but clients attached to the **old** daemon keep running it indefinitely, and nothing tells them. Long-lived MCP sessions (editors, agents) stay stale until someone remembers to reconnect.

## Change

A deterministic in-band nudge, derived from the same mechanism #99 introduced. Every tool handler is wrapped centrally in `buildServer`; while the shared socket directory contains a `daemon-<version>.sock` with a **strictly newer** semver that is **actually accepting connections**, each tool result carries one appended content block:

> ⬆️ omnifocus-mcp 1.14.0 is serving on this machine; this connection is on 1.13.0. Reconnect the MCP server to upgrade.

Design points:

- **Liveness-probed** (250ms unix-socket connect), so a crash-orphaned socket file can't nag forever; probes newest-first and falls back.
- **Throttled** — one fs scan + probe per 5 minutes, cached; cost amortizes to nothing.
- **Conservative** — skipped under `OMNIFOCUS_MCP_SOCKET` (isolated/test instances); only clean `major.minor.patch` names participate (prereleases, `daemon.sock`, `.lock` dirs excluded); numeric semver compare (no `1.9 > 1.13` lexical trap).
- **Best-effort** — any nudge failure is swallowed; it can never break a tool result. Error results are nudged too: a stale client debugging an error is exactly who should hear "reconnect".

## Verification

11 new tests (parsing, numeric compare, newest-first live selection, dead-socket fallback, wrapper behavior incl. failure isolation), plus a **live end-to-end check**: a dummy listener on `~/.omnifocus-mcp/daemon-9.9.9.sock` made a real `list_perspectives` call carry the notice as its own content block; cleanup restored silence.

Gate: tsc clean, 447 tests, build OK.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1