### PR TITLE
Return the actual repetition rule instead of [object Task.RepetitionRule] (#115)

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.parity.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.parity.test.ts
@@ -324,3 +324,48 @@ describe('folderName filter seeding (#107)', () => {
     expect(script).not.toContain('_folderIdSet');
   });
 });
+
+/**
+ * Repetition readback (#115): the field used to emit `.toString()`, which for
+ * Task.RepetitionRule is the literal "[object Task.RepetitionRule]" — the
+ * wrapper, never the rule. An agent could see THAT a task repeats and never HOW.
+ */
+describe('repetition rule readback (#115)', () => {
+  it('repetitionRule reads ruleString, not toString()', () => {
+    const mapping = generateFieldMapping('tasks', ['repetitionRule']);
+    expect(mapping).toContain('item.repetitionRule.ruleString');
+    expect(mapping).not.toContain('repetitionRule.toString()');
+  });
+
+  it('repetitionMethod strips the Task.RepetitionMethod wrapper', () => {
+    const mapping = generateFieldMapping('tasks', ['repetitionMethod']);
+    expect(mapping).toContain('item.repetitionRule.method');
+    expect(mapping).toContain('RepetitionMethod');
+    expect(mapping).toContain('replace(');
+  });
+
+  it('both fields yield null for a non-repeating item rather than throwing', () => {
+    for (const field of ['repetitionRule', 'repetitionMethod']) {
+      const mapping = generateFieldMapping('tasks', [field]);
+      expect(mapping, field).toContain('item.repetitionRule ?');
+      expect(mapping, field).toContain(': null');
+    }
+  });
+
+  it('repetitionMethod does not fall through to the generic item.<field> mapping', () => {
+    // The generic branch would emit `repetitionMethod: item.repetitionMethod`,
+    // which is undefined on both Task and Project — silently null forever.
+    const mapping = generateFieldMapping('tasks', ['repetitionMethod']);
+    expect(mapping).not.toContain('item.repetitionMethod');
+  });
+
+  it('isRepeating still reports presence independently of the rule text', () => {
+    const mapping = generateFieldMapping('tasks', ['isRepeating']);
+    expect(mapping).toContain('item.repetitionRule !== null');
+  });
+
+  it('projects expose the same repetition fields (they can repeat too)', () => {
+    expect(generateFieldMapping('projects', ['repetitionRule'])).toContain('ruleString');
+    expect(generateFieldMapping('projects', ['repetitionMethod'])).toContain('RepetitionMethod');
+  });
+});

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -39,7 +39,7 @@ export const schema = z.object({
     reviewDue: z.boolean().optional().describe("true = projects due for review (projects only)")
   }).optional().describe("Filters AND together; array filters (tags, status) OR within the array. Date-valued filters (dueWithin, deferredUntil, plannedWithin, dueOn, deferOn, plannedOn) accept a number of days from today, 'today', 'tomorrow', 'this week', 'next week', or 'YYYY-MM-DD'"),
 
-  fields: z.array(z.string()).optional().describe("Only return the listed fields (smaller responses). Tasks: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, dropDate, effectiveDropDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule, modificationDate, creationDate. Projects: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completionDate, dropDate, effectiveDropDate, completedByChildren, containsSingletonActions, taskCount, tasks, nextReviewDate, reviewInterval, modificationDate, creationDate. Folders: id, name, path, parentFolderID, status, projectCount, projects, subfolders"),
+  fields: z.array(z.string()).optional().describe("Only return the listed fields (smaller responses). Tasks: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, dropDate, effectiveDropDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule (ICS, e.g. FREQ=WEEKLY;INTERVAL=2), repetitionMethod (Fixed | DeferUntilDate | DueDate), modificationDate, creationDate. Projects: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completionDate, dropDate, effectiveDropDate, completedByChildren, containsSingletonActions, taskCount, tasks, nextReviewDate, reviewInterval, modificationDate, creationDate. Folders: id, name, path, parentFolderID, status, projectCount, projects, subfolders"),
 
   limit: z.number().optional().describe("Max items to return"),
 
@@ -200,9 +200,16 @@ function formatTasks(tasks: any[]): string {
       parts.push(task.isRepeating ? '[repeating]' : '[not repeating]');
     }
     
-    // Repetition rule
+    // Repetition rule. Before #115 this rendered the literal string
+    // "[object Task.RepetitionRule]"; it now carries the ICS rule, and the
+    // method rides alongside it because "every 2 weeks" means something
+    // different depending on whether it counts from the calendar or from
+    // completion.
     if (task.repetitionRule) {
-      parts.push(`[rule: ${task.repetitionRule}]`);
+      const method = task.repetitionMethod ? ` ${task.repetitionMethod}` : '';
+      parts.push(`[rule: ${task.repetitionRule}${method}]`);
+    } else if (task.repetitionMethod) {
+      parts.push(`[rule method: ${task.repetitionMethod}]`);
     }
 
     // Hierarchy info

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -45,6 +45,20 @@ const FOLDER_PATH_EXPR =
 // dump_database reported the hierarchy while query_omnifocus flattened it.
 const FOLDER_PARENT_ID_EXPR = 'item.parent ? item.parent.id.primaryKey : null';
 
+/**
+ * Repetition rule readback (issue #115).
+ *
+ * `Task.RepetitionRule` has no useful `toString()` — it renders as the literal
+ * "[object Task.RepetitionRule]", which is what this field emitted before,
+ * telling the caller nothing about the rule. The real data is on two
+ * properties: the ICS recurrence string, and a method constant that
+ * stringifies as "[object Task.RepetitionMethod: DeferUntilDate]". Strip the
+ * wrapper so callers get a bare name they can compare and round-trip.
+ */
+const REPETITION_RULE_EXPR = 'item.repetitionRule ? item.repetitionRule.ruleString : null';
+const REPETITION_METHOD_EXPR =
+  'item.repetitionRule ? String(item.repetitionRule.method).replace(/^\\[object Task\\.RepetitionMethod: |\\]$/g, "") : null';
+
 export interface QueryOmnifocusParams {
   entity: 'tasks' | 'projects' | 'folders';
   filters?: {
@@ -793,7 +807,9 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
     } else if (field === 'isRepeating') {
       return `isRepeating: item.repetitionRule !== null`;
     } else if (field === 'repetitionRule') {
-      return `repetitionRule: item.repetitionRule ? item.repetitionRule.toString() : null`;
+      return `repetitionRule: ${REPETITION_RULE_EXPR}`;
+    } else if (field === 'repetitionMethod') {
+      return `repetitionMethod: ${REPETITION_METHOD_EXPR}`;
     } else if (field === 'sequential') {
       // Both Task and Project expose a `sequential` Boolean in OmniJS. Coerce so an
       // unexpected null/undefined surfaces as false rather than leaking through.


### PR DESCRIPTION
## Problem

`fields: ["repetitionRule"]` returned the literal string `"[object Task.RepetitionRule]"` — the JS object wrapper, not the rule. `Task.RepetitionRule` has no useful `toString()`. So the fleet could see *that* a task repeats (`isRepeating` is computed separately and was always correct) and never *how*.

## Change

- `repetitionRule` now reads `.ruleString` → `"FREQ=WEEKLY;INTERVAL=2"`.
- New `repetitionMethod` field → `"Fixed"` / `"DeferUntilDate"` / `"DueDate"`, with the `[object Task.RepetitionMethod: …]` wrapper stripped. Name matches the `repetitionMethod` already declared in `src/types.ts`.
- Both `null` for non-repeating items; both available on tasks *and* projects (projects can repeat).
- The task formatter renders the method next to the rule — "every 2 weeks" means different things counting from the calendar versus from completion, so the rule text alone is ambiguous.
- Default projections unchanged (these stay opt-in via `fields`, keeping responses lean).

## Verification

6 new tests pin the accessors, the wrapper strip, null-safety, both entities, and specifically that `repetitionMethod` does **not** fall through to the generic `item.<field>` branch (which would emit `item.repetitionMethod` — undefined on both Task and Project, i.e. silently null forever).

The two expressions were confirmed against the live database earlier today: `.ruleString` → `"FREQ=WEEKLY;INTERVAL=2"`, method strip → `"DeferUntilDate"`. **The assembled end-to-end query path is not yet live-verified** — this machine's AppleEvent layer wedged mid-verification (a trivial `1+1` evaluateJavascript and an unrelated System Events call both time out, OmniFocus itself idle at 0% CPU). I'll confirm end-to-end once that clears; the CI gate (tsc + 453 tests + build) is green.

Motivating case in the issue: a real task scheduled `FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH` against a note reading "2x/week" — a mismatch no agent could detect, because the rule was unreadable.

Prerequisite for verify-after-write in #116.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1