### PR TITLE
Support repetition rules on create and edit (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Create a new task.
 - `projectName` *(optional)*: project to add the task to (defaults to inbox)
 - `parentTaskId` / `parentTaskName` *(optional)*: nest under an existing task
 - `note`, `dueDate`, `deferDate`, `plannedDate`, `flagged`, `estimatedMinutes`, `tags` *(all optional)*
+- `repeat` *(optional)*: make it recurring — see [Repeating items](#repeating-items)
 
 ### `add_project`
 
@@ -129,7 +130,7 @@ Create a new project.
 - `name`
 - `folderName` *(optional)*: folder to place the project in
 - `sequential` *(optional)*: whether tasks must be completed in order
-- `note`, `dueDate`, `deferDate`, `flagged`, `estimatedMinutes`, `tags` *(all optional)*
+- `note`, `dueDate`, `deferDate`, `flagged`, `estimatedMinutes`, `tags`, `repeat` *(all optional)*
 
 ### `edit_item`
 
@@ -140,6 +141,7 @@ Edit an existing task or project. Also the way to **move** items — set `newPro
 - Common: `newName`, `newNote`, `newDueDate`, `newDeferDate`, `newFlagged`, `newEstimatedMinutes` (dates in ISO format; empty string clears)
 - Tasks: `newStatus` (`incomplete`, `completed`, `dropped`, `skipped` — skipped only for repeating tasks), `addTags`, `removeTags`, `replaceTags`, `newProjectName`, `newPlannedDate`
 - Projects: `newProjectStatus` (`active`, `completed`, `dropped`, `onHold`), `newFolderName`, `newSequential`, `markReviewed` (sets the next review date based on the project's review interval)
+- Repetition: `newRepeat` sets a new rule (same shape as `repeat` on create); `newRepeat: null` clears it
 
 ### `remove_item`
 
@@ -195,6 +197,28 @@ Create a tag, optionally nested under an existing parent.
 
 - `name`
 - `parentTagName` / `parentTagID` *(optional; ID takes precedence)*
+
+### Repeating items
+
+`add_omnifocus_task`, `add_project`, and each item in `batch_add_items` accept a `repeat` object; `edit_item` accepts `newRepeat`. You describe the schedule and the server compiles the ICS recurrence rule, so you never hand-write an RRULE.
+
+| Field | Description |
+|---|---|
+| `method` | `start-after-completion` (counts from when it's actually done), `fixed` (counts from the calendar regardless), or `due-after-completion` |
+| `unit` | `day`, `week`, `month`, or `year` |
+| `steps` *(optional)* | Repeat every N units (default 1) |
+| `weekdays` *(optional)* | Specific days, e.g. `["MO","WE","FR"]`. Requires `unit: "week"` |
+
+```json
+{ "name": "Weekly review", "repeat": { "method": "start-after-completion", "unit": "week" } }
+{ "name": "Strength work", "repeat": { "method": "fixed", "unit": "week", "weekdays": ["TU","TH"] } }
+```
+
+**Pick `method` deliberately** — it's the field most often set wrong by hand. With `fixed`, occurrences appear on schedule whether or not the last one was done, so a missed week leaves a backlog to clear. With `start-after-completion`, the next occurrence is scheduled from when you actually complete it, so the habit simply resumes.
+
+Read a rule back with `query_omnifocus` using the `repetitionRule` (ICS string) and `repetitionMethod` fields, or filter with `isRepeating`.
+
+Not currently supported: positional monthly rules ("third Tuesday"), specific month days, and end conditions (`COUNT`/`UNTIL`). Set those in OmniFocus directly.
 
 ## Resources
 

--- a/src/tools/definitions/addOmniFocusTask.ts
+++ b/src/tools/definitions/addOmniFocusTask.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { addOmniFocusTask, AddOmniFocusTaskParams } from '../primitives/addOmniFocusTask.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import { repeatShape } from './repeatSchema.js';
 
 export const schema = z.object({
   name: z.string().describe("Task name"),
@@ -16,7 +17,8 @@ export const schema = z.object({
   // Hierarchy support
   parentTaskId: z.string().optional().describe("Parent task id (preferred over name)"),
   parentTaskName: z.string().optional().describe("Parent task name; matched within the project if one is given"),
-  hierarchyLevel: z.number().int().min(0).optional().describe("Ordering hint for batch workflows (0 = root); ignored in single add")
+  hierarchyLevel: z.number().int().min(0).optional().describe("Ordering hint for batch workflows (0 = root); ignored in single add"),
+  repeat: repeatShape.optional()
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/addProject.ts
+++ b/src/tools/definitions/addProject.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { addProject, AddProjectParams } from '../primitives/addProject.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import { repeatShape } from './repeatSchema.js';
 
 export const schema = z.object({
   name: z.string().describe("Project name"),
@@ -11,7 +12,8 @@ export const schema = z.object({
   estimatedMinutes: z.number().optional().describe("Time estimate in minutes"),
   tags: z.array(z.string()).optional().describe("Tag names to assign"),
   folderName: z.string().optional().describe("Folder to place the project in (root if omitted)"),
-  sequential: z.boolean().optional().describe("Make tasks sequential (default: false)")
+  sequential: z.boolean().optional().describe("Make tasks sequential (default: false)"),
+  repeat: repeatShape.optional()
 });
 
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {

--- a/src/tools/definitions/batchAddItems.ts
+++ b/src/tools/definitions/batchAddItems.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { batchAddItems, BatchAddItemsParams } from '../primitives/batchAddItems.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import { repeatShape } from './repeatSchema.js';
 
 export const schema = z.object({
   items: z.array(z.object({
@@ -28,7 +29,8 @@ export const schema = z.object({
 
     // Project-specific properties
     folderName: z.string().optional().describe("Projects: folder to place the project in"),
-    sequential: z.boolean().optional().describe("Projects: make tasks sequential")
+    sequential: z.boolean().optional().describe("Projects: make tasks sequential"),
+    repeat: repeatShape.optional()
   })).describe("Items to add"),
   createSequentially: z.boolean().optional().describe("Process parents before children; even when false, parents are resolved first best-effort")
 });

--- a/src/tools/definitions/editItem.ts
+++ b/src/tools/definitions/editItem.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { editItem, EditItemParams } from '../primitives/editItem.js';
 import { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import { repeatShape } from './repeatSchema.js';
 
 export const schema = z.object({
   id: z.string().optional().describe("Item id (takes precedence over name)"),
@@ -15,6 +16,7 @@ export const schema = z.object({
   newPlannedDate: z.string().optional().describe("New planned date (ISO; \"\" clears; tasks only)"),
   newFlagged: z.boolean().optional().describe("Set flagged status"),
   newEstimatedMinutes: z.number().optional().describe("New time estimate in minutes"),
+  newRepeat: repeatShape.nullable().optional().describe("New repetition rule; null clears it"),
 
   // Task-specific fields
   newStatus: z.enum(['incomplete', 'completed', 'dropped', 'skipped']).optional().describe("New task status. 'skipped' (repeating tasks only) completes the occurrence to trigger the next repeat, then drops the instance"),

--- a/src/tools/definitions/repeatSchema.ts
+++ b/src/tools/definitions/repeatSchema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * The shared `repeat` shape for every write tool (issue #116).
+ *
+ * Defined once and imported, so the four tools that accept a repeat cannot drift
+ * apart — the failure mode of #97, where `projectId` existed on
+ * add_omnifocus_task but was missing from batch_add_items, so Zod stripped it
+ * and every batched task silently landed in the inbox reporting success.
+ *
+ * Descriptions are kept deliberately terse (#105): sharing the object in source
+ * does NOT share it on the wire — each tool's serialized JSON schema carries its
+ * own copy, so every character here is paid four times per session.
+ *
+ * The one piece of guidance worth its tokens is that `start-after-completion` is
+ * the usual intent. A census of a real database found it in ~70% of rules, and
+ * getting it wrong is expensive in a specific way: a `fixed` rule keeps
+ * generating occurrences whether or not the last was done, so a missed week
+ * leaves debris to sweep rather than simply resuming.
+ */
+export const repeatShape = z
+  .object({
+    method: z
+      .enum(['fixed', 'start-after-completion', 'due-after-completion'])
+      .describe(
+        "Schedule basis. 'start-after-completion' counts from when it's actually done (usual choice, no backlog); 'fixed' counts from the calendar regardless"
+      ),
+    unit: z.enum(['day', 'week', 'month', 'year']).describe('Interval unit'),
+    steps: z.number().int().min(1).optional().describe('Every N units (default 1)'),
+    weekdays: z
+      .array(z.enum(['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']))
+      .optional()
+      .describe("Specific days, e.g. ['MO','WE','FR']; requires unit 'week'"),
+  })
+  .describe('Repetition rule');

--- a/src/tools/definitions/schemaBudget.test.ts
+++ b/src/tools/definitions/schemaBudget.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { join, dirname } from 'path';
+import { join, dirname, basename } from 'path';
 
 /**
  * Issue #105: tool schema descriptions load into EVERY session that touches the
@@ -10,23 +10,56 @@ import { join, dirname } from 'path';
  * brought them to ~7k; these ceilings keep incremental edits from silently
  * growing them back. If a new tool or a load-bearing clarification genuinely
  * needs room, raise the ceiling in the same PR — visibly.
+ *
+ * The measurement weights shared shape modules by how many tools import them.
+ * Sharing a Zod object in *source* does not share it on the *wire*: each tool's
+ * serialized JSON schema carries its own copy of every description. An unweighted
+ * count made the `repeat` shape (#116) look ~1.3k chars cheaper than it is.
  */
 
 const definitionsDir = dirname(fileURLToPath(import.meta.url));
 
+/** Matches `.describe("…")` and `.describe('…')` — both styles are in use. */
+const DESCRIBE_RE = /\.describe\(\s*(["'])((?:(?!\1)[^\\]|\\.)*)\1\s*\)/g;
+
 function describeChars(source: string): number {
-  const matches = [...source.matchAll(/\.describe\(\s*"((?:[^"\\]|\\.)*)"\s*\)/g)];
-  return matches.reduce((sum, m) => sum + m[1].length, 0);
+  return [...source.matchAll(DESCRIBE_RE)].reduce((sum, m) => sum + m[2].length, 0);
+}
+
+function definitionFiles(): string[] {
+  return readdirSync(definitionsDir).filter(f => f.endsWith('.ts') && !f.includes('test'));
+}
+
+/**
+ * Per-file description cost, with shared modules multiplied by their importer
+ * count — i.e. what the client actually receives across all tool schemas.
+ */
+function weightedCosts(): Record<string, number> {
+  const files = definitionFiles();
+  const sources = new Map(files.map(f => [f, readFileSync(join(definitionsDir, f), 'utf8')]));
+  const costs: Record<string, number> = {};
+
+  for (const file of files) {
+    const own = describeChars(sources.get(file)!);
+    if (own === 0) continue;
+    const stem = basename(file, '.ts');
+    // How many OTHER definition files import this one? A module nobody imports
+    // is a tool schema in its own right and counts once.
+    const importers = files.filter(
+      other => other !== file && new RegExp(`from\\s+['"]\\./${stem}\\.js['"]`).test(sources.get(other)!)
+    ).length;
+    costs[file] = own * Math.max(1, importers);
+  }
+  return costs;
 }
 
 describe('schema description budget (#105)', () => {
-  it('keeps the total .describe() text across all tools under budget', () => {
-    let total = 0;
-    for (const file of readdirSync(definitionsDir)) {
-      if (!file.endsWith('.ts') || file.includes('test')) continue;
-      total += describeChars(readFileSync(join(definitionsDir, file), 'utf8'));
-    }
-    expect(total).toBeLessThanOrEqual(6500);
+  it('keeps the wire-weighted total across all tools under budget', () => {
+    const costs = weightedCosts();
+    const total = Object.values(costs).reduce((a, b) => a + b, 0);
+    // Raised from 6500 to 8200 in #116 to fund the `repeat` shape on four write
+    // tools (~1.7k weighted). Deliberate, not drift.
+    expect(total).toBeLessThanOrEqual(8200);
   });
 
   it('keeps query_omnifocus — the historical worst offender — under its own budget', () => {
@@ -35,11 +68,23 @@ describe('schema description budget (#105)', () => {
     expect(describeChars(source)).toBeLessThanOrEqual(2800);
   });
 
+  it('keeps the shared repeat shape lean, since every character is paid 4x', () => {
+    const source = readFileSync(join(definitionsDir, 'repeatSchema.ts'), 'utf8');
+    expect(describeChars(source)).toBeLessThanOrEqual(500);
+  });
+
   it('keeps the server.tool() registration descriptions under budget', () => {
     const source = readFileSync(join(definitionsDir, '..', '..', 'buildServer.ts'), 'utf8');
     const matches = [...source.matchAll(/server\.tool\(\s*"[^"]+",\s*"((?:[^"\\]|\\.)*)"/g)];
     expect(matches.length).toBeGreaterThan(0);
     const total = matches.reduce((sum, m) => sum + m[1].length, 0);
     expect(total).toBeLessThanOrEqual(1300);
+  });
+
+  it('actually detects sharing — repeatSchema is weighted above its raw size', () => {
+    // Guards the weighting itself: if the import detection breaks, the budget
+    // silently reverts to undercounting shared shapes.
+    const raw = describeChars(readFileSync(join(definitionsDir, 'repeatSchema.ts'), 'utf8'));
+    expect(weightedCosts()['repeatSchema.ts']).toBeGreaterThan(raw);
   });
 });

--- a/src/tools/primitives/addOmniFocusTask.ts
+++ b/src/tools/primitives/addOmniFocusTask.ts
@@ -9,6 +9,7 @@ import {
   generateProjectLookupScript,
   JSON_ESCAPE_HANDLER,
 } from '../../utils/appleScriptHelpers.js';
+import { repetitionRuleRecord, type RepetitionSpec } from '../../utils/repetitionRule.js';
 
 // Interface for task creation parameters
 export interface AddOmniFocusTaskParams {
@@ -22,6 +23,7 @@ export interface AddOmniFocusTaskParams {
   tags?: string[]; // Tag names
   projectId?: string; // Project id to add task to (preferred when disambiguation is needed)
   projectName?: string; // Project name to add task to (used when projectId is not supplied)
+  repeat?: RepetitionSpec; // Repetition rule (#116)
   // Hierarchy support
   parentTaskId?: string;
   parentTaskName?: string;
@@ -171,6 +173,11 @@ export function generateAppleScript(params: AddOmniFocusTaskParams): string {
           set planned date of newTask to ` + plannedDateVar : ''}
         ${flagged ? `set flagged of newTask to true` : ''}
         ${estimatedMinutes ? `set estimated minutes of newTask to ${estimatedMinutes}` : ''}
+        ${params.repeat ? `
+          -- Set the repetition rule (#116). Assigned as a whole record: setting
+          -- \`recurrence\` or \`repetition method\` as sub-properties fails with
+          -- "Can't make … into type specifier".
+          set repetition rule of newTask to ${repetitionRuleRecord(params.repeat)}` : ''}
         
         -- Derive placement from container; distinguish real parent vs project root task
         try

--- a/src/tools/primitives/addProject.ts
+++ b/src/tools/primitives/addProject.ts
@@ -8,6 +8,7 @@ import {
   generateFolderLookupScript,
   JSON_ESCAPE_HANDLER,
 } from '../../utils/appleScriptHelpers.js';
+import { repetitionRuleRecord, type RepetitionSpec } from '../../utils/repetitionRule.js';
 import { runOsascriptFile } from '../../utils/scriptExecution.js';
 
 // Interface for project creation parameters
@@ -21,6 +22,7 @@ export interface AddProjectParams {
   tags?: string[]; // Tag names
   folderName?: string; // Folder name or path (e.g. "Work/Engineering") to add project to
   sequential?: boolean; // Whether tasks should be sequential or parallel
+  repeat?: RepetitionSpec; // Repetition rule (#116)
 }
 
 /**
@@ -88,6 +90,10 @@ export function generateAppleScript(params: AddProjectParams): string {
         ${flagged ? `set flagged of newProject to true` : ''}
         ${estimatedMinutes ? `set estimated minutes of newProject to ${estimatedMinutes}` : ''}
         ${`set sequential of newProject to ${sequential}`}
+        ${params.repeat ? `
+          -- Set the repetition rule (#116). Whole-record assignment only; see
+          -- the note in addOmniFocusTask.
+          set repetition rule of newProject to ${repetitionRuleRecord(params.repeat)}` : ''}
 
         -- Get the project ID
         set projectId to id of newProject as string

--- a/src/tools/primitives/batchAddItems.ts
+++ b/src/tools/primitives/batchAddItems.ts
@@ -1,5 +1,6 @@
 import { addOmniFocusTask, AddOmniFocusTaskParams } from './addOmniFocusTask.js';
 import { addProject, AddProjectParams } from './addProject.js';
+import type { RepetitionSpec } from '../../utils/repetitionRule.js';
 
 // Define the parameters for the batch operation
 export type BatchAddItemsParams = {
@@ -22,6 +23,7 @@ export type BatchAddItemsParams = {
   hierarchyLevel?: number;
   folderName?: string; // For projects
   sequential?: boolean; // For projects
+  repeat?: RepetitionSpec; // Repetition rule, tasks and projects alike (#116)
 };
 
 // Define the result type for individual operations
@@ -135,7 +137,8 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
               estimatedMinutes: item.estimatedMinutes,
               tags: item.tags,
               folderName: item.folderName,
-              sequential: item.sequential
+              sequential: item.sequential,
+              repeat: item.repeat
             };
 
             const projectResult = await addProject(projectParams);
@@ -188,7 +191,8 @@ export async function batchAddItems(items: BatchAddItemsParams[]): Promise<Batch
             projectName,
             parentTaskId,
             parentTaskName: item.parentTaskName,
-            hierarchyLevel: item.hierarchyLevel
+            hierarchyLevel: item.hierarchyLevel,
+            repeat: item.repeat
           };
 
           const taskResult = await addOmniFocusTask(taskParams);

--- a/src/tools/primitives/editItem.ts
+++ b/src/tools/primitives/editItem.ts
@@ -10,6 +10,7 @@ import {
   generateProjectLookupScript,
   JSON_ESCAPE_HANDLER,
 } from '../../utils/appleScriptHelpers.js';
+import { repetitionRuleRecord, type RepetitionSpec } from '../../utils/repetitionRule.js';
 
 // Status options for tasks and projects
 type TaskStatus = 'incomplete' | 'completed' | 'dropped' | 'skipped';
@@ -29,6 +30,7 @@ export interface EditItemParams {
   newPlannedDate?: string;      // New planned date in ISO format (empty string to clear, tasks only)
   newFlagged?: boolean;         // New flagged status (false to remove flag, true to add flag)
   newEstimatedMinutes?: number; // New estimated minutes
+  newRepeat?: RepetitionSpec | null; // New repetition rule; null clears it (#116)
   
   // Task-specific fields
   newStatus?: TaskStatus;       // New status for tasks (incomplete, completed, dropped, skipped - skipped requires repeating task)
@@ -229,7 +231,29 @@ export function generateAppleScript(params: EditItemParams): string {
         set end of changedProperties to "estimated minutes"
 `;
   }
-  
+
+  // Repetition rule (#116). `null` clears — chosen over the dates' empty-string
+  // convention because the value is an object, so there is no empty form of it.
+  // Applies to tasks and projects alike; both can repeat.
+  if (params.newRepeat !== undefined) {
+    if (params.newRepeat === null) {
+      script += `
+        -- Clear the repetition rule
+        set repetition rule of foundItem to missing value
+        set end of changedProperties to "repetition (cleared)"
+`;
+    } else {
+      script += `
+        -- Update the repetition rule. Whole-record assignment only: setting
+        -- \`recurrence\` or \`repetition method\` as sub-properties fails with
+        -- "Can't make … into type specifier".
+        set repetition rule of foundItem to ${repetitionRuleRecord(params.newRepeat)}
+        set end of changedProperties to "repetition"
+`;
+    }
+  }
+
+
   // Tag operations apply to both tasks and projects (OmniFocus supports tags on
   // projects too). Kept in the common section so project edits aren't a no-op.
   if (params.replaceTags && params.replaceTags.length > 0) {

--- a/src/tools/primitives/repetitionWrites.test.ts
+++ b/src/tools/primitives/repetitionWrites.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { generateAppleScript as addTask } from './addOmniFocusTask.js';
+import { generateAppleScript as addProject } from './addProject.js';
+import { generateAppleScript as editItem } from './editItem.js';
+import { schema as addTaskSchema } from '../definitions/addOmniFocusTask.js';
+import { schema as addProjectSchema } from '../definitions/addProject.js';
+import { schema as editItemSchema } from '../definitions/editItem.js';
+import { schema as batchSchema } from '../definitions/batchAddItems.js';
+
+/**
+ * Repetition writes (#116). The AppleScript layer accepts a repetition rule only
+ * as a WHOLE record — sub-property assignment fails with "Can't make … into type
+ * specifier" — so these tests pin the record form at each write site.
+ */
+describe('repetition rule on create (#116)', () => {
+  it('add_omnifocus_task emits the record with method and recurrence', () => {
+    const script = addTask({
+      name: 'Weekly review',
+      repeat: { method: 'start-after-completion', unit: 'week' },
+    });
+    expect(script).toContain(
+      'set repetition rule of newTask to {repetition method:start after completion, recurrence:"FREQ=WEEKLY"}'
+    );
+  });
+
+  it('add_project emits the record too (projects can repeat)', () => {
+    const script = addProject({
+      name: 'Monthly close',
+      repeat: { method: 'fixed', unit: 'month', steps: 3 },
+    });
+    expect(script).toContain(
+      'set repetition rule of newProject to {repetition method:fixed repetition, recurrence:"FREQ=MONTHLY;INTERVAL=3"}'
+    );
+  });
+
+  it('emits no repetition statement when no repeat is requested', () => {
+    expect(addTask({ name: 'One-shot' })).not.toContain('repetition rule');
+    expect(addProject({ name: 'One-shot' })).not.toContain('repetition rule');
+  });
+
+  it('compiles weekday sets through to the record', () => {
+    const script = addTask({
+      name: 'Strength',
+      repeat: { method: 'fixed', unit: 'week', weekdays: ['TU', 'TH'] },
+    });
+    expect(script).toContain('recurrence:"FREQ=WEEKLY;BYDAY=TU,TH"');
+  });
+
+  it('throws rather than creating a task with a silently-dropped repeat', () => {
+    // The whole point of the feature is that repeats stop arriving inert; an
+    // invalid spec must not degrade into "created, reported success, no repeat".
+    expect(() =>
+      addTask({ name: 'Bad', repeat: { method: 'fixed', unit: 'week', steps: 0 } as any })
+    ).toThrow();
+  });
+});
+
+describe('repetition rule on edit (#116)', () => {
+  it('sets a new rule as a whole record', () => {
+    const script = editItem({
+      id: 'abc',
+      itemType: 'task',
+      newRepeat: { method: 'due-after-completion', unit: 'day', steps: 5 },
+    });
+    expect(script).toContain(
+      'set repetition rule of foundItem to {repetition method:due after completion, recurrence:"FREQ=DAILY;INTERVAL=5"}'
+    );
+    expect(script).toContain('set end of changedProperties to "repetition"');
+  });
+
+  it('clears the rule when newRepeat is null', () => {
+    const script = editItem({ id: 'abc', itemType: 'task', newRepeat: null });
+    expect(script).toContain('set repetition rule of foundItem to missing value');
+    expect(script).toContain('repetition (cleared)');
+  });
+
+  it('distinguishes clearing from not-specified', () => {
+    // `undefined` must be a no-op — otherwise every unrelated edit would wipe
+    // the item's repeat.
+    const untouched = editItem({ id: 'abc', itemType: 'task', newName: 'Renamed' });
+    expect(untouched).not.toContain('repetition rule of foundItem');
+  });
+
+  it('works on projects as well as tasks', () => {
+    const script = editItem({
+      id: 'p1',
+      itemType: 'project',
+      newRepeat: { method: 'fixed', unit: 'year' },
+    });
+    expect(script).toContain('set repetition rule of foundItem to');
+    expect(script).toContain('FREQ=YEARLY');
+  });
+});
+
+/**
+ * Schema parity. #97 shipped because add_omnifocus_task accepted `projectId`
+ * while batch_add_items did not, so Zod stripped it and every batched task
+ * landed in the inbox reporting success. A write field missing from one schema
+ * is not a smaller bug than a broken one.
+ */
+describe('repeat is accepted by every write schema (#116)', () => {
+  const repeat = { method: 'start-after-completion' as const, unit: 'week' as const, steps: 2 };
+
+  it('add_omnifocus_task keeps repeat through validation', () => {
+    const parsed = addTaskSchema.parse({ name: 'x', repeat });
+    expect(parsed.repeat).toEqual(repeat);
+  });
+
+  it('add_project keeps repeat through validation', () => {
+    expect(addProjectSchema.parse({ name: 'x', repeat }).repeat).toEqual(repeat);
+  });
+
+  it('batch_add_items keeps repeat on each item', () => {
+    const parsed = batchSchema.parse({ items: [{ type: 'task', name: 'x', repeat }] });
+    expect(parsed.items[0].repeat).toEqual(repeat);
+  });
+
+  it('edit_item keeps newRepeat, including an explicit null', () => {
+    expect(editItemSchema.parse({ id: 'a', itemType: 'task', newRepeat: repeat }).newRepeat).toEqual(repeat);
+    expect(editItemSchema.parse({ id: 'a', itemType: 'task', newRepeat: null }).newRepeat).toBeNull();
+  });
+
+  it('rejects an invalid method at the schema boundary', () => {
+    expect(() => addTaskSchema.parse({ name: 'x', repeat: { method: 'whenever', unit: 'week' } })).toThrow();
+  });
+
+  it('rejects an invalid weekday code at the schema boundary', () => {
+    expect(() =>
+      addTaskSchema.parse({ name: 'x', repeat: { method: 'fixed', unit: 'week', weekdays: ['MON'] } })
+    ).toThrow();
+  });
+});

--- a/src/utils/__tests__/repetitionRule.test.ts
+++ b/src/utils/__tests__/repetitionRule.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compileRecurrence,
+  repetitionRuleRecord,
+  describeRepetition,
+  RepetitionSpecError,
+  OMNIJS_METHOD,
+  type RepetitionSpec,
+} from '../repetitionRule.js';
+
+describe('compileRecurrence (#116)', () => {
+  it('maps each unit to its ICS frequency', () => {
+    const freq = (unit: RepetitionSpec['unit']) =>
+      compileRecurrence({ method: 'fixed', unit });
+    expect(freq('day')).toBe('FREQ=DAILY');
+    expect(freq('week')).toBe('FREQ=WEEKLY');
+    expect(freq('month')).toBe('FREQ=MONTHLY');
+    expect(freq('year')).toBe('FREQ=YEARLY');
+  });
+
+  it('omits INTERVAL when steps is 1 or absent', () => {
+    // INTERVAL=1 is the ICS default; omitting it keeps our rules byte-identical
+    // to what OmniFocus writes for a plain weekly repeat, so a written rule can
+    // be compared against a hand-set one.
+    expect(compileRecurrence({ method: 'fixed', unit: 'week' })).toBe('FREQ=WEEKLY');
+    expect(compileRecurrence({ method: 'fixed', unit: 'week', steps: 1 })).toBe('FREQ=WEEKLY');
+  });
+
+  it('emits INTERVAL for steps above 1', () => {
+    expect(compileRecurrence({ method: 'fixed', unit: 'day', steps: 15 })).toBe(
+      'FREQ=DAILY;INTERVAL=15'
+    );
+  });
+
+  it('compiles weekday sets to BYDAY', () => {
+    expect(
+      compileRecurrence({ method: 'fixed', unit: 'week', weekdays: ['MO', 'WE', 'FR'] })
+    ).toBe('FREQ=WEEKLY;BYDAY=MO,WE,FR');
+  });
+
+  it('normalizes weekday order so the same set always yields the same rule', () => {
+    // Callers pass days in whatever order they think of them; an unstable rule
+    // string would break comparison against an existing rule.
+    expect(
+      compileRecurrence({ method: 'fixed', unit: 'week', weekdays: ['FR', 'MO', 'WE'] })
+    ).toBe('FREQ=WEEKLY;BYDAY=MO,WE,FR');
+  });
+
+  it('combines INTERVAL and BYDAY in ICS field order', () => {
+    // This is the exact shape of the live rule that motivated the feature.
+    expect(
+      compileRecurrence({ method: 'fixed', unit: 'week', steps: 2, weekdays: ['TU', 'TH'] })
+    ).toBe('FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH');
+  });
+
+  it('ignores an empty weekdays array rather than emitting BYDAY=', () => {
+    expect(compileRecurrence({ method: 'fixed', unit: 'week', weekdays: [] })).toBe('FREQ=WEEKLY');
+  });
+
+  describe('rejects malformed specs loudly', () => {
+    // A silently-dropped or silently-wrong repeat is the exact failure this
+    // feature removes, so an invalid spec must never degrade into
+    // "created without a repeat, reported success".
+    const bad: [string, any][] = [
+      ['unknown unit', { method: 'fixed', unit: 'fortnight' }],
+      ['unknown method', { method: 'whenever', unit: 'week' }],
+      ['zero steps', { method: 'fixed', unit: 'week', steps: 0 }],
+      ['negative steps', { method: 'fixed', unit: 'week', steps: -2 }],
+      ['fractional steps', { method: 'fixed', unit: 'week', steps: 1.5 }],
+      ['bad weekday code', { method: 'fixed', unit: 'week', weekdays: ['MON'] }],
+      ['duplicate weekday', { method: 'fixed', unit: 'week', weekdays: ['MO', 'MO'] }],
+      ['weekdays on a non-week unit', { method: 'fixed', unit: 'month', weekdays: ['MO'] }],
+    ];
+    for (const [label, spec] of bad) {
+      it(label, () => {
+        expect(() => compileRecurrence(spec)).toThrow(RepetitionSpecError);
+      });
+    }
+  });
+
+  it('names the unsupported positional case in the weekday error', () => {
+    // "third Tuesday" is the shape a caller will try next; the error should say
+    // where to go rather than just refusing.
+    expect(() =>
+      compileRecurrence({ method: 'fixed', unit: 'month', weekdays: ['TU'] })
+    ).toThrow(/third Tuesday/);
+  });
+});
+
+describe('repetitionRuleRecord (#116)', () => {
+  it('builds the AppleScript record with the right method constant', () => {
+    expect(repetitionRuleRecord({ method: 'fixed', unit: 'week' })).toBe(
+      '{repetition method:fixed repetition, recurrence:"FREQ=WEEKLY"}'
+    );
+    expect(repetitionRuleRecord({ method: 'start-after-completion', unit: 'day', steps: 3 })).toBe(
+      '{repetition method:start after completion, recurrence:"FREQ=DAILY;INTERVAL=3"}'
+    );
+    expect(repetitionRuleRecord({ method: 'due-after-completion', unit: 'month' })).toBe(
+      '{repetition method:due after completion, recurrence:"FREQ=MONTHLY"}'
+    );
+  });
+
+  it('propagates spec errors instead of emitting a broken record', () => {
+    expect(() => repetitionRuleRecord({ method: 'fixed', unit: 'week', steps: 0 })).toThrow(
+      RepetitionSpecError
+    );
+  });
+
+  it('covers every method name with a distinct AppleScript constant', () => {
+    const records = (['fixed', 'start-after-completion', 'due-after-completion'] as const).map(m =>
+      repetitionRuleRecord({ method: m, unit: 'week' })
+    );
+    expect(new Set(records).size).toBe(3);
+  });
+});
+
+describe('OMNIJS_METHOD (#116)', () => {
+  it('maps each API method to the name query_omnifocus reports back (#115)', () => {
+    // This is the round-trip contract: write via AppleScript constant, read back
+    // via repetitionMethod. Verified live against OmniFocus.
+    expect(OMNIJS_METHOD.fixed).toBe('Fixed');
+    expect(OMNIJS_METHOD['start-after-completion']).toBe('DeferUntilDate');
+    expect(OMNIJS_METHOD['due-after-completion']).toBe('DueDate');
+  });
+});
+
+describe('describeRepetition (#116)', () => {
+  it('renders a plain-language summary so callers need not decode RRULEs', () => {
+    expect(describeRepetition({ method: 'start-after-completion', unit: 'week' })).toBe(
+      'every week, starting after completion'
+    );
+    expect(
+      describeRepetition({ method: 'fixed', unit: 'week', steps: 2, weekdays: ['TU', 'TH'] })
+    ).toBe('every 2 weeks on TU, TH, on a fixed schedule');
+    expect(describeRepetition({ method: 'due-after-completion', unit: 'day', steps: 3 })).toBe(
+      'every 3 days, due after completion'
+    );
+  });
+});

--- a/src/utils/repetitionRule.ts
+++ b/src/utils/repetitionRule.ts
@@ -1,0 +1,150 @@
+/**
+ * Repetition rule support (issue #116).
+ *
+ * OmniFocus stores a repeat as an ICS recurrence string plus a method. Callers
+ * shouldn't have to hand-write RRULEs — a mistyped `INTERVAL` is silent and
+ * costly (a live task was found scheduled `FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH`
+ * against a note reading "2x/week", i.e. half the intended rate, undetected for
+ * months). So the tool surface takes a typed shape and this module compiles it.
+ *
+ * Scope is set by a census of a real, heavily-used database (78 rules): every
+ * rule in the wild was a simple interval or a weekday set. Zero used BYSETPOS
+ * ("third Tuesday"), BYMONTHDAY, COUNT, or UNTIL — so those are deliberately
+ * unsupported rather than half-implemented.
+ */
+
+export type RepetitionMethodName = 'fixed' | 'start-after-completion' | 'due-after-completion';
+export type RepetitionUnit = 'day' | 'week' | 'month' | 'year';
+export type Weekday = 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA' | 'SU';
+
+export interface RepetitionSpec {
+  method: RepetitionMethodName;
+  unit: RepetitionUnit;
+  steps?: number;
+  /** Week-unit only; compiles to BYDAY. */
+  weekdays?: Weekday[];
+}
+
+const FREQ_BY_UNIT: Record<RepetitionUnit, string> = {
+  day: 'DAILY',
+  week: 'WEEKLY',
+  month: 'MONTHLY',
+  year: 'YEARLY',
+};
+
+/**
+ * AppleScript enum constants. These are the literal tokens the OmniFocus
+ * dictionary expects — verified by round-trip against OmniJS, which reports them
+ * back as Fixed / DeferUntilDate / DueDate respectively.
+ */
+const APPLESCRIPT_METHOD: Record<RepetitionMethodName, string> = {
+  fixed: 'fixed repetition',
+  'start-after-completion': 'start after completion',
+  'due-after-completion': 'due after completion',
+};
+
+/** How the method reads back from query_omnifocus (#115), for verification. */
+export const OMNIJS_METHOD: Record<RepetitionMethodName, string> = {
+  fixed: 'Fixed',
+  'start-after-completion': 'DeferUntilDate',
+  'due-after-completion': 'DueDate',
+};
+
+const VALID_WEEKDAYS: readonly Weekday[] = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+
+export class RepetitionSpecError extends Error {}
+
+/**
+ * Compile a spec into an ICS recurrence string.
+ *
+ * Throws RepetitionSpecError on anything malformed. Failing loudly matters here:
+ * a silently-dropped or silently-wrong repeat is exactly the failure this
+ * feature exists to remove, so an invalid spec must never degrade into "created
+ * without a repeat, reported success".
+ */
+export function compileRecurrence(spec: RepetitionSpec): string {
+  const freq = FREQ_BY_UNIT[spec.unit];
+  if (!freq) {
+    throw new RepetitionSpecError(
+      `Invalid repeat unit "${spec.unit}". Expected one of: day, week, month, year.`
+    );
+  }
+  if (!(spec.method in APPLESCRIPT_METHOD)) {
+    throw new RepetitionSpecError(
+      `Invalid repeat method "${spec.method}". Expected one of: fixed, start-after-completion, due-after-completion.`
+    );
+  }
+
+  const steps = spec.steps ?? 1;
+  if (!Number.isInteger(steps) || steps < 1) {
+    throw new RepetitionSpecError(
+      `Invalid repeat steps "${spec.steps}". Expected a positive whole number.`
+    );
+  }
+
+  const parts = [`FREQ=${freq}`];
+  // INTERVAL=1 is the ICS default; omitting it keeps rules byte-identical to
+  // what OmniFocus itself writes for a plain weekly repeat, which matters when
+  // comparing a written rule against one set by hand in the inspector.
+  if (steps > 1) parts.push(`INTERVAL=${steps}`);
+
+  if (spec.weekdays && spec.weekdays.length > 0) {
+    if (spec.unit !== 'week') {
+      throw new RepetitionSpecError(
+        `weekdays is only valid with unit "week" (got "${spec.unit}"). For monthly or yearly ` +
+          `positional rules ("third Tuesday"), set the repeat in OmniFocus directly — not yet supported here.`
+      );
+    }
+    const seen = new Set<string>();
+    for (const day of spec.weekdays) {
+      if (!VALID_WEEKDAYS.includes(day)) {
+        throw new RepetitionSpecError(
+          `Invalid weekday "${day}". Expected two-letter codes: ${VALID_WEEKDAYS.join(', ')}.`
+        );
+      }
+      if (seen.has(day)) {
+        throw new RepetitionSpecError(`Duplicate weekday "${day}" in repeat.`);
+      }
+      seen.add(day);
+    }
+    // Emit in calendar order rather than the caller's order, so the same set
+    // always produces the same rule string and comparisons are stable.
+    const ordered = VALID_WEEKDAYS.filter(d => seen.has(d));
+    parts.push(`BYDAY=${ordered.join(',')}`);
+  }
+
+  return parts.join(';');
+}
+
+/**
+ * The AppleScript record literal for a repetition rule, ready to interpolate
+ * into `set repetition rule of X to …` or a `make new …with properties` list.
+ *
+ * NOTE for anyone extending this: only assigning the WHOLE record works.
+ * Setting `recurrence` or `repetition method` as sub-properties fails with
+ * "Can't make … into type specifier". Verified empirically.
+ */
+export function repetitionRuleRecord(spec: RepetitionSpec): string {
+  const recurrence = compileRecurrence(spec);
+  return `{repetition method:${APPLESCRIPT_METHOD[spec.method]}, recurrence:"${recurrence}"}`;
+}
+
+/**
+ * Human-readable rendering for tool results, so a caller can confirm what was
+ * set without decoding an RRULE.
+ */
+export function describeRepetition(spec: RepetitionSpec): string {
+  const steps = spec.steps ?? 1;
+  const every = steps === 1 ? `every ${spec.unit}` : `every ${steps} ${spec.unit}s`;
+  const days =
+    spec.weekdays && spec.weekdays.length > 0
+      ? ` on ${VALID_WEEKDAYS.filter(d => spec.weekdays!.includes(d)).join(', ')}`
+      : '';
+  const from =
+    spec.method === 'fixed'
+      ? 'on a fixed schedule'
+      : spec.method === 'start-after-completion'
+        ? 'starting after completion'
+        : 'due after completion';
+  return `${every}${days}, ${from}`;
+}


### PR DESCRIPTION
> Stacked on #117 (issue #115), which supplies the readback this feature verifies against. Merge #117 first; the base will retarget to `main` automatically.

## Problem

No write tool could set a repetition rule, so every recurring groove an agent created arrived **inert** — in one real batch of 43 writes, 5 were repeat-shaped and all 5 needed a hand-written note telling the user to open the inspector. `edit_item` already *depended* on repetition (`newStatus: "skipped"` errors without a rule) while nothing could create one.

## Change

A typed `repeat` on `add_omnifocus_task`, `add_project`, and each `batch_add_items` item; `newRepeat` on `edit_item` (with `null` to clear). The server compiles the ICS string so no caller hand-writes an RRULE:

```ts
{ method, unit, steps?, weekdays? }   →   FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH
```

| API value | AppleScript constant | reads back as (#115) |
|---|---|---|
| `fixed` | `fixed repetition` | `Fixed` |
| `start-after-completion` | `start after completion` | `DeferUntilDate` |
| `due-after-completion` | `due after completion` | `DueDate` |

Design decisions worth reviewing:

- **Whole-record assignment only.** `set repetition rule of X to {repetition method:…, recurrence:"…"}`. Sub-property assignment (`set recurrence of repetition rule of X to …`) fails with *"Can't make … into type specifier"* — verified, and noted in the code so nobody tries the "obvious" incremental version.
- **Malformed specs throw** rather than degrading to "created successfully, no repeat" — the silent-drop failure this feature exists to remove.
- **`INTERVAL=1` is omitted**, keeping rules byte-identical to what OmniFocus writes for a plain weekly repeat, so a written rule can be compared against a hand-set one.
- **Weekday order is normalized** to calendar order, so the same set always compiles to the same string and comparisons are stable.
- **One shared shape module** for all four schemas, so they cannot drift — the #97 failure mode, where `projectId` existed on one tool and not the other and Zod silently stripped it.

## Scope, set by a census rather than a guess

A census of a real 78-rule database (run independently by two sessions, agreeing on structure): ~70% `start-after-completion`, weekday sets ~13% and in production, and **zero** uses of `BYSETPOS` ("third Tuesday"), `BYMONTHDAY`, `COUNT`, or `UNTIL`. So weekday sets are in; the rest are explicitly unsupported with an error that says where to go, rather than half-implemented. `start-after-completion` is documented as the usual choice because a `fixed` rule keeps generating occurrences whether or not the last was done — a real task was found half-rate with a backlog for exactly that reason.

## Schema cost

The shared shape is ~419 chars of descriptions, but sharing in *source* does not share on the *wire* — each tool's JSON schema carries its own copy, so it costs ~1.7k weighted. **The budget test from #105 was understating this**, counting source occurrences rather than wire copies; it now weights shared modules by importer count, with a guard test that fails if the weighting itself breaks. Ceiling raised 6500 → 8200 deliberately, in this PR, to fund the feature.

## Verification

40 new tests: RRULE compilation (units, intervals, BYDAY, normalization, 8 malformed-spec rejections), the AppleScript record at each write site, set-vs-clear-vs-untouched on edit, and schema-parity checks that every write schema actually retains `repeat` through Zod validation.

The method mapping and whole-record write were **verified live against OmniFocus earlier today** by round-trip probe. **End-to-end verification through the tool layer is still pending**: this machine's OmniFocus stopped answering `evaluateJavascript` mid-session (System Events responds fine and OmniFocus sits idle at 0% CPU, so it's app-local — likely the aftermath of a script I had to SIGTERM at the 60s timeout). It needs an app restart, which is the owner's call. CI gate is green: tsc, 491 tests, build.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1