### PR TITLE
Stop retries from deepening OmniFocus AppleEvent wedges (#121)

### DIFF
--- a/src/utils/scriptExecution.test.ts
+++ b/src/utils/scriptExecution.test.ts
@@ -1,8 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   Semaphore,
   isRetryableOsascriptError,
+  classifyOsascriptError,
   withOsascriptRetry,
+  markAppUnresponsive,
+  markAppResponsive,
+  isAppKnownUnresponsive,
+  shouldProbeAppHealth,
+  probeOmniFocusAlive,
+  _resetAppHealth,
 } from './scriptExecution.js';
 
 describe('Semaphore', () => {
@@ -110,5 +117,143 @@ describe('withOsascriptRetry', () => {
     ).rejects.toMatchObject({ message: '-1712' });
     // initial try + 2 backoff retries = 3 attempts
     expect(attempt).toHaveBeenCalledTimes(3);
+  });
+});
+
+/**
+ * Issue #121: retrying a client-kill replays a full query into an app that
+ * never answered, and every killed osascript leaves a permanently blocked
+ * AppleEvent queue inside OmniFocus (eight were counted in one process sample).
+ * The retry policy must distinguish "app answered, busy" from "app is gone".
+ */
+describe('classifyOsascriptError (#121)', () => {
+  it('classifies an app-reported timeout as app-timeout — the app answered', () => {
+    expect(classifyOsascriptError({ message: 'AppleEvent timed out (-1712)' })).toBe('app-timeout');
+    expect(classifyOsascriptError({ stderr: 'execution error: -1712' })).toBe('app-timeout');
+  });
+
+  it('classifies our own kill as client-kill — the app never answered', () => {
+    expect(classifyOsascriptError({ killed: true })).toBe('client-kill');
+    expect(classifyOsascriptError({ signal: 'SIGTERM' })).toBe('client-kill');
+  });
+
+  it('prefers client-kill when a killed process also carries timeout text', () => {
+    // execAsync sets killed AND a "timed out" message on a Node-level timeout.
+    // Reading that as app-timeout would put us straight back on the retry path
+    // this issue exists to close.
+    expect(classifyOsascriptError({ killed: true, message: 'Command failed: timed out' })).toBe(
+      'client-kill'
+    );
+  });
+
+  it('leaves genuine script errors unclassified', () => {
+    expect(classifyOsascriptError({ message: 'syntax error: Expected end of line' })).toBe('other');
+    expect(classifyOsascriptError(undefined)).toBe('other');
+  });
+
+  it('isRetryableOsascriptError remains the union of both transient classes', () => {
+    expect(isRetryableOsascriptError({ killed: true })).toBe(true);
+    expect(isRetryableOsascriptError({ message: '-1712' })).toBe(true);
+    expect(isRetryableOsascriptError({ message: 'syntax error' })).toBe(false);
+  });
+});
+
+describe('retry gating on failure class (#121)', () => {
+  const noSleep = () => Promise.resolve();
+  const gate = (err: unknown) => classifyOsascriptError(err) === 'app-timeout';
+
+  it('retries an app-reported timeout', async () => {
+    const attempt = vi.fn().mockRejectedValueOnce({ message: '-1712' }).mockResolvedValue('ok');
+    const out = await withOsascriptRetry(attempt, {
+      shouldRetry: gate,
+      backoffsMs: [1, 1],
+      sleepFn: noSleep,
+    });
+    expect(out).toBe('ok');
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it('never retries a client-kill — one attempt only', async () => {
+    // The property this whole issue turns on: each extra attempt would leave
+    // another orphaned AppleEvent queue in the app.
+    const attempt = vi.fn().mockRejectedValue({ killed: true, signal: 'SIGTERM' });
+    await expect(
+      withOsascriptRetry(attempt, { shouldRetry: gate, backoffsMs: [1, 1], sleepFn: noSleep })
+    ).rejects.toBeDefined();
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses backoffs long enough to let a contended app drain', async () => {
+    // [500, 1500] gave an app no room; anything under a second is not a backoff.
+    const slept: number[] = [];
+    const attempt = vi.fn().mockRejectedValue({ message: '-1712' });
+    await expect(
+      withOsascriptRetry(attempt, {
+        shouldRetry: gate,
+        sleepFn: async (ms) => { slept.push(ms); },
+      })
+    ).rejects.toBeDefined();
+    expect(slept.length).toBeGreaterThan(0);
+    expect(Math.min(...slept)).toBeGreaterThanOrEqual(1000);
+  });
+});
+
+describe('app health circuit breaker (#121)', () => {
+  beforeEach(() => _resetAppHealth());
+
+  it('starts closed', () => {
+    expect(isAppKnownUnresponsive()).toBe(false);
+    expect(shouldProbeAppHealth()).toBe(false);
+  });
+
+  it('opens on an unresponsive mark and blocks dispatch during cooldown', () => {
+    const t = 1_000_000;
+    markAppUnresponsive(t);
+    expect(isAppKnownUnresponsive(t + 1_000)).toBe(true);
+    expect(shouldProbeAppHealth(t + 1_000)).toBe(false);
+  });
+
+  it('switches from blocking to probing once the cooldown elapses', () => {
+    const t = 1_000_000;
+    markAppUnresponsive(t);
+    expect(isAppKnownUnresponsive(t + 31_000)).toBe(false);
+    expect(shouldProbeAppHealth(t + 31_000)).toBe(true);
+  });
+
+  it('closes again when the app is marked responsive', () => {
+    markAppUnresponsive(1_000_000);
+    markAppResponsive();
+    expect(isAppKnownUnresponsive(1_000_001)).toBe(false);
+    expect(shouldProbeAppHealth(1_000_001)).toBe(false);
+  });
+
+  it('is process-wide, so queued callers see one breaker rather than each probing', () => {
+    markAppUnresponsive(1_000_000);
+    const observed = [1, 2, 3].map(() => isAppKnownUnresponsive(1_000_500));
+    expect(observed).toEqual([true, true, true]);
+  });
+});
+
+describe('probeOmniFocusAlive (#121)', () => {
+  it('reports alive when the cheap AppleEvent answers', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: 'OmniFocus', stderr: '' });
+    expect(await probeOmniFocusAlive(exec as any)).toBe(true);
+  });
+
+  it('reports dead — not throwing — when it times out', async () => {
+    const exec = vi.fn().mockRejectedValue({ killed: true });
+    expect(await probeOmniFocusAlive(exec as any)).toBe(false);
+  });
+
+  it('uses a short timeout, not the 60s query timeout', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+    await probeOmniFocusAlive(exec as any);
+    expect(exec.mock.calls[0][1].timeout).toBeLessThanOrEqual(10_000);
+  });
+
+  it('asks for something cheap rather than running a real query', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+    await probeOmniFocusAlive(exec as any);
+    expect(exec.mock.calls[0][0]).toContain('name of default document');
   });
 });

--- a/src/utils/scriptExecution.ts
+++ b/src/utils/scriptExecution.ts
@@ -60,20 +60,124 @@ export class Semaphore {
 const osascriptSemaphore = new Semaphore(MAX_CONCURRENT_OSASCRIPT);
 
 /**
- * A -1712 AppleEvent timeout, or a Node-level kill of a stuck osascript, is
- * transient contention and safe to retry for reads. Genuine script errors are
- * not (and must not be retried).
+ * Classify an osascript failure (issue #121).
+ *
+ * These two cases look similar and are opposite signals:
+ *
+ * - `app-timeout` — the app ANSWERED, with `-1712`. It is alive and contended.
+ *   Retrying is reasonable.
+ * - `client-kill` — our own Node timeout SIGTERMed the child because the app
+ *   never answered at all. The app is wedged, and a process sample of a wedged
+ *   OmniFocus shows why retrying is actively harmful: every osascript we kill
+ *   leaves a `receiveFrom-<pid>` AppleEvent dispatch queue inside the app,
+ *   blocked forever on ownership it will never get. Eight such orphaned queues
+ *   were counted in one snapshot — four from a concurrency burst, four from
+ *   retries. Nothing on our side can release them; only killing the app can.
+ *
+ * Our timeout (60s) is shorter than the AppleEvent default (~120s), so the kill
+ * fires first in practice — which made `client-kill` the dominant case on the
+ * retry path it is least safe for.
+ */
+export type OsascriptFailureClass = 'app-timeout' | 'client-kill' | 'other';
+
+export function classifyOsascriptError(err: unknown): OsascriptFailureClass {
+  const e = err as { message?: string; stderr?: string; killed?: boolean; signal?: string };
+  if (e?.killed === true || e?.signal === 'SIGTERM') return 'client-kill';
+  const text = `${e?.message ?? ''} ${e?.stderr ?? ''}`;
+  if (text.includes('-1712') || text.includes('AppleEvent timed out') || text.includes('timed out')) {
+    return 'app-timeout';
+  }
+  return 'other';
+}
+
+/**
+ * The union of both transient classes.
+ *
+ * Retained for callers that just want "was this transient?", but do NOT use it
+ * as a retry gate: retrying a `client-kill` is what amplifies a wedge (#121).
+ * Gate on `classifyOsascriptError(err) === 'app-timeout'` instead.
  */
 export function isRetryableOsascriptError(err: unknown): boolean {
-  const e = err as { message?: string; stderr?: string; killed?: boolean; signal?: string };
-  const text = `${e?.message ?? ''} ${e?.stderr ?? ''}`;
-  return (
-    e?.killed === true ||
-    e?.signal === 'SIGTERM' ||
-    text.includes('-1712') ||
-    text.includes('AppleEvent timed out') ||
-    text.includes('timed out')
-  );
+  return classifyOsascriptError(err) !== 'other';
+}
+
+// --- app health circuit breaker (issue #121) ----------------------------------
+// Once the app has failed to answer at all, further dispatches make things
+// strictly worse. Hold that state process-wide so queued queries fail fast
+// instead of each burning a full timeout (and each leaving another orphaned
+// queue) against a target already known to be dead.
+
+const UNRESPONSIVE_COOLDOWN_MS = resolvePositiveIntEnv(
+  'OMNIFOCUS_MCP_UNRESPONSIVE_COOLDOWN_MS',
+  30_000
+);
+const PROBE_TIMEOUT_MS = resolvePositiveIntEnv('OMNIFOCUS_MCP_PROBE_TIMEOUT_MS', 5_000);
+
+export class AppUnresponsiveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AppUnresponsiveError';
+  }
+}
+
+const UNRESPONSIVE_MESSAGE =
+  'OmniFocus is not responding to AppleEvents. Requests are paused to avoid making it worse. ' +
+  'If this persists, quit every omnifocus-mcp process and then restart OmniFocus (in that order).';
+
+let unresponsiveSince: number | null = null;
+
+/** Test hook: clear the breaker. */
+export function _resetAppHealth(): void {
+  unresponsiveSince = null;
+}
+
+export function markAppUnresponsive(now: number = Date.now()): void {
+  if (unresponsiveSince === null) {
+    _logger?.error(
+      'scriptExecution',
+      'OmniFocus did not answer before the timeout; pausing dispatch (issue #121).'
+    );
+  }
+  unresponsiveSince = now;
+}
+
+export function markAppResponsive(): void {
+  if (unresponsiveSince !== null) {
+    _logger?.info('scriptExecution', 'OmniFocus is answering again; resuming dispatch.');
+  }
+  unresponsiveSince = null;
+}
+
+/** True while the breaker is open and still inside its cooldown. */
+export function isAppKnownUnresponsive(now: number = Date.now()): boolean {
+  return unresponsiveSince !== null && now - unresponsiveSince < UNRESPONSIVE_COOLDOWN_MS;
+}
+
+/** True when the breaker is open but the cooldown has elapsed — probe once. */
+export function shouldProbeAppHealth(now: number = Date.now()): boolean {
+  return unresponsiveSince !== null && now - unresponsiveSince >= UNRESPONSIVE_COOLDOWN_MS;
+}
+
+/**
+ * One cheap AppleEvent with a short timeout, used to decide whether the app has
+ * recovered. Deliberately does NOT go through the semaphore: if wedged queries
+ * are holding every slot, the probe must still be able to run. It is also the
+ * only thing we send while the breaker is open, so at most one transaction per
+ * cooldown is risked against a possibly-wedged app.
+ */
+export async function probeOmniFocusAlive(
+  execFn: (cmd: string, opts: any) => Promise<unknown> = execAsync as any,
+  timeoutMs: number = PROBE_TIMEOUT_MS
+): Promise<boolean> {
+  try {
+    await execFn(
+      `osascript -e 'tell application "OmniFocus" to get name of default document'`,
+      { timeout: timeoutMs, killSignal: 'SIGTERM', maxBuffer: 64 * 1024 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -90,7 +194,9 @@ export async function withOsascriptRetry<T>(
     sleepFn?: (ms: number) => Promise<void>;
   }
 ): Promise<T> {
-  const backoffs = opts.backoffsMs ?? [500, 1500];
+  // Backoffs lengthened from [500, 1500] (#121): sub-2s gaps gave a contended
+  // app no room to drain before the next full query landed on it.
+  const backoffs = opts.backoffsMs ?? [2000, 6000];
   const doSleep = opts.sleepFn ?? sleep;
   let i = 0;
   for (;;) {
@@ -131,13 +237,49 @@ export async function runOsascriptFile(
   const langFlag = language === 'JavaScript' ? '-l JavaScript ' : '';
   const cmd = `osascript ${langFlag}"${tempFile}"`;
 
+  // Circuit breaker (#121). While the app is known unresponsive, dispatch
+  // nothing at all — every osascript we send and then kill leaves a permanently
+  // blocked AppleEvent queue inside the app. Failing fast here is not just
+  // faster, it avoids inflicting further damage.
+  if (isAppKnownUnresponsive()) {
+    throw new AppUnresponsiveError(UNRESPONSIVE_MESSAGE);
+  }
+  if (shouldProbeAppHealth()) {
+    if (await probeOmniFocusAlive()) {
+      markAppResponsive();
+    } else {
+      markAppUnresponsive();
+      throw new AppUnresponsiveError(UNRESPONSIVE_MESSAGE);
+    }
+  }
+
   const attempt = () =>
     osascriptSemaphore.run(() =>
       execAsync(cmd, { maxBuffer, timeout: timeoutMs, killSignal: 'SIGTERM' })
     );
 
-  if (!retryOnTimeout) return attempt();
-  return withOsascriptRetry(attempt, { shouldRetry: isRetryableOsascriptError });
+  // A client-kill means the app never answered. Do not retry it — trip the
+  // breaker and surface an honest error instead. Only an app-reported timeout
+  // (-1712), which proves the app is alive and merely contended, is retried.
+  const run = async (): Promise<{ stdout: string; stderr: string }> => {
+    try {
+      const out = retryOnTimeout
+        ? await withOsascriptRetry(attempt, {
+            shouldRetry: (err) => classifyOsascriptError(err) === 'app-timeout',
+          })
+        : await attempt();
+      markAppResponsive();
+      return out;
+    } catch (err) {
+      if (classifyOsascriptError(err) === 'client-kill') {
+        markAppUnresponsive();
+        throw new AppUnresponsiveError(UNRESPONSIVE_MESSAGE);
+      }
+      throw err;
+    }
+  };
+
+  return run();
 }
 
 // Helper function to execute OmniFocus scripts


### PR DESCRIPTION
## Problem

`isRetryableOsascriptError` treated **our own SIGTERM kill** as transient contention, and reads had retries enabled. So against an unresponsive app:

```
query → hangs 60s → SIGTERM → wait 0.5s → replay → hangs 60s → SIGTERM → wait 1.5s → replay → hangs 60s
```

A process sample from a wedged OmniFocus shows what each of those attempts costs: **eight blocked `receiveFrom-<pid>` AppleEvent dispatch queues**, one per osascript we killed — the tight PID cluster matching `MAX_CONCURRENT_OSASCRIPT=4`, the spread matching successive retries. All eight stuck inside the AE framework on `_dispatch_event_loop_wait_for_ownership`, while the app's main thread sat idle in a normal runloop. Nothing on our side can release them; only killing the app can. **Every retry inflicted a permanent wound.**

Five occurrences in two days on one machine, all with MCP query traffic at or shortly before onset.

## The core conflation

`-1712` and a SIGTERM kill are opposite signals that the old predicate treated identically:

| | meaning | safe to retry? |
|---|---|---|
| `-1712` | the app **answered** — alive, contended | yes |
| SIGTERM kill | the app **never answered** in 60s | no — this is the amplifier |

And the defaults made the dangerous case the common one: our Node timeout is 60s, the AppleEvent default ~120s, so **our kill almost always fires first**.

## Changes

- **`classifyOsascriptError`** returns `app-timeout` / `client-kill` / `other`. Retries now gate on `app-timeout` only. `client-kill` is never retried — it trips the breaker and surfaces an honest error. Note it deliberately checks `killed`/`signal` *before* the message text, because Node sets both on a timeout; reading that as `app-timeout` would land straight back on the old path.
- **Process-wide circuit breaker.** While the app is known unresponsive, dispatch nothing — `AppUnresponsiveError` is thrown immediately (measured: **0 ms**, versus 60s of hanging plus a fresh orphaned queue). Shared across queued callers, so four wedged queries can't each burn a slot for minutes.
- **Liveness probe** after a 30s cooldown: one cheap `get name of default document` with a 5s timeout, bypassing the semaphore so wedged queries can't starve it. At most one transaction risked per cooldown instead of a full query.
- **Backoffs 500/1500ms → 2s/6s.** Anything under a second is not a backoff.
- The error message names the actual remedy — quit every omnifocus-mcp process, *then* restart OmniFocus, in that order — which is the sequence that works and the one users kept having to rediscover.

`isRetryableOsascriptError` is retained (still the union) for compatibility, documented as unsafe to use alone as a retry gate.

Tunable via `OMNIFOCUS_MCP_UNRESPONSIVE_COOLDOWN_MS` and `OMNIFOCUS_MCP_PROBE_TIMEOUT_MS`.

## Verification

17 new tests: classification of both signals (including the killed-plus-timeout-text trap), retry gating (an `app-timeout` retries; a `client-kill` gets exactly one attempt), backoff floor, breaker open/cooldown/probe/close transitions and its process-wide sharing, and probe behavior.

Live against a real database: the probe answers `true`; a normal query runs unaffected through the new gate; with the breaker tripped, dispatch is refused in 0 ms with the clear error, then resumes in 118 ms once cleared.

Gate green: tsc, **508 tests**, build.

Worth recording: this retry logic came from #80, added to stop the server making AppleEvent contention worse. The concurrency bound and fail-fast halves did their job. The retry half amplified the exact failure it was meant to contain, because it could not tell "busy" from "gone".

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1