### PR TITLE
Ping the client on idle instead of exiting (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ The daemon listens on a Unix domain socket in a `0700` directory (`~/.omnifocus-
 
 The socket name carries the package version so that upgrading can never leave you talking to the previous version's daemon. Right after an upgrade you may briefly see two daemons: the old one keeps serving the clients already attached to it and exits once the last of them disconnects. Clients still attached to the old daemon are told about it in-band — while a newer daemon is serving, every tool result carries a one-line upgrade notice, so nobody has to remember to reconnect.
 
+A session that simply goes quiet is no longer disconnected: when the idle window passes with no traffic, the shim pings the client and keeps the session if it answers, so long-lived sessions (Claude Code and similar) keep their tools across long quiet stretches. Only a client that never answers is treated as gone.
+
 If the daemon dies while clients are attached — a crash, or a manual kill during troubleshooting — each shim now reconnects, replays its client's `initialize` handshake to the new daemon, and fails any in-flight requests with a retryable error rather than leaving the client waiting. Previously the shim exited, which cost clients their tools for the rest of the session.
 
 Nothing about client configuration changes. If the daemon can't be started — an unusual sandbox, a read-only home directory — the shim falls back to running a standalone server in-process, exactly as earlier versions did.
@@ -273,7 +275,7 @@ Note that the check is on *repeating item plus terminal status*, not on the shap
 |---|---|---|
 | `OMNIFOCUS_MCP_NO_DAEMON` | unset | Set to `1` to skip the daemon entirely and run a dedicated server per client (the pre-daemon behavior). First thing to try if you suspect the daemon. |
 | `OMNIFOCUS_MCP_SOCKET` | `~/.omnifocus-mcp/daemon-<version>.sock` | Override the socket path, e.g. to run an isolated instance. |
-| `OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES` | `30` | Exit after this long with no client traffic. `0` disables the timeout. |
+| `OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES` | `30` | Idle window after which the server pings the client and exits only if it gets no answer. `0` disables the check. |
 | `OMNIFOCUS_MCP_MAX_CONCURRENT_OSASCRIPT` | `4` | Maximum concurrent `osascript` calls. Lower it if you still see AppleEvent timeouts. |
 
 ## Roadmap

--- a/src/daemon/clientProbe.test.ts
+++ b/src/daemon/clientProbe.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StringDecoder } from 'string_decoder';
+import { ClientProbe, PROBE_TIMEOUT_MS } from './clientProbe.js';
+
+describe('ClientProbe', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const makeProbe = () => {
+    const written: string[] = [];
+    const onAlive = vi.fn();
+    const onDead = vi.fn();
+    const probe = new ClientProbe({
+      write: (line) => written.push(line),
+      onAlive,
+      onDead,
+    });
+    return { probe, written, onAlive, onDead };
+  };
+
+  /** A client's answer to the outstanding ping. */
+  const answer = (probe: ClientProbe, body: Record<string, unknown> = { result: {} }) =>
+    JSON.stringify({ jsonrpc: '2.0', id: probe.lastId, ...body });
+
+  it('passes chunks through untouched when no probe is outstanding', () => {
+    const { probe } = makeProbe();
+    expect(probe.filter('{"jsonrpc":"2.0","id":1,"method":"tools/list"}\n')).toBe(
+      '{"jsonrpc":"2.0","id":1,"method":"tools/list"}\n'
+    );
+    expect(probe.filter('{"partial')).toBe('{"partial');
+    expect(probe.filter('not json at all\n')).toBe('not json at all\n');
+    expect(probe.outstanding).toBe(false);
+  });
+
+  it('writes exactly one well-formed ping request', () => {
+    const { probe, written } = makeProbe();
+    probe.start();
+    expect(written).toHaveLength(1);
+    const msg = JSON.parse(written[0]);
+    expect(msg).toMatchObject({ jsonrpc: '2.0', method: 'ping' });
+    expect(typeof msg.id).toBe('string');
+    expect(msg.id).toMatch(/^omnifocus-mcp-probe-\d+$/);
+    expect(msg.id).toBe(probe.lastId);
+    expect(probe.outstanding).toBe(true);
+  });
+
+  it('treats a result response as alive and removes only that line', () => {
+    const { probe, onAlive, onDead } = makeProbe();
+    probe.start();
+    const before = '{"jsonrpc":"2.0","id":7,"method":"tools/list"}\n';
+    const after = '{"jsonrpc":"2.0","id":8,"method":"ping"}\n';
+    const out = probe.filter(before + answer(probe) + '\n' + after);
+    expect(out).toBe(before + after);
+    expect(onAlive).toHaveBeenCalledTimes(1);
+    expect(onDead).not.toHaveBeenCalled();
+    expect(probe.outstanding).toBe(false);
+  });
+
+  it('treats an error response as alive (a client answering at all is alive)', () => {
+    const { probe, onAlive } = makeProbe();
+    probe.start();
+    const out = probe.filter(
+      answer(probe, { error: { code: -32601, message: 'Method not found' } }) + '\n'
+    );
+    expect(out).toBe('');
+    expect(onAlive).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects a response split across chunks, preserving surrounding bytes', () => {
+    const { probe, onAlive } = makeProbe();
+    probe.start();
+    const response = answer(probe);
+    const head = response.slice(0, 12);
+    const tail = response.slice(12);
+    expect(probe.filter(head)).toBe('');
+    expect(onAlive).not.toHaveBeenCalled();
+    const out = probe.filter(tail + '\n{"jsonrpc":"2.0","id":9,"method":"tools/list"}\n');
+    expect(out).toBe('{"jsonrpc":"2.0","id":9,"method":"tools/list"}\n');
+    expect(onAlive).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the client dead when nothing answers within the timeout', () => {
+    const { probe, onAlive, onDead } = makeProbe();
+    probe.start();
+    vi.advanceTimersByTime(PROBE_TIMEOUT_MS - 1);
+    expect(onDead).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onDead).toHaveBeenCalledTimes(1);
+    expect(onAlive).not.toHaveBeenCalled();
+    expect(probe.outstanding).toBe(false);
+  });
+
+  it('accepts unrelated client traffic as proof of life, forwarding it unchanged', () => {
+    const { probe, onAlive, onDead } = makeProbe();
+    probe.start();
+    const request = '{"jsonrpc":"2.0","id":3,"method":"tools/call"}\n';
+    expect(probe.filter(request)).toBe(request);
+    expect(onAlive).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(PROBE_TIMEOUT_MS * 2);
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it('still swallows a ping response arriving just behind other traffic', () => {
+    const { probe } = makeProbe();
+    probe.start();
+    probe.filter('{"jsonrpc":"2.0","id":3,"method":"tools/call"}\n');
+    expect(probe.filter(answer(probe) + '\n')).toBe('');
+  });
+
+  it('ignores a second start() while outstanding and uses a fresh id after', () => {
+    const { probe, written } = makeProbe();
+    probe.start();
+    const firstId = probe.lastId;
+    probe.start();
+    expect(written).toHaveLength(1);
+    expect(probe.lastId).toBe(firstId);
+
+    probe.filter(answer(probe) + '\n');
+    probe.start();
+    expect(written).toHaveLength(2);
+    expect(probe.lastId).not.toBe(firstId);
+  });
+
+  it('returns to passthrough after resolution, flushing the remainder once', () => {
+    const { probe } = makeProbe();
+    probe.start();
+    const out = probe.filter(answer(probe) + '\n{"partial');
+    expect(out).toBe('{"partial');
+    expect(probe.filter(':true}\n')).toBe(':true}\n');
+    expect(probe.filter('plain\n')).toBe('plain\n');
+  });
+
+  it('flushes bytes buffered when the probe timed out mid-line', () => {
+    const { probe, onDead } = makeProbe();
+    probe.start();
+    probe.filter('{"half');
+    vi.advanceTimersByTime(PROBE_TIMEOUT_MS);
+    expect(onDead).toHaveBeenCalledTimes(1);
+    expect(probe.filter('-line"}\n')).toBe('{"half-line"}\n');
+  });
+  it('resolves alive and flushes verbatim rather than buffering without bound', () => {
+    const { probe, onAlive, onDead } = makeProbe();
+    probe.start();
+    const huge = 'x'.repeat(1_000_001); // no newline anywhere
+    expect(probe.filter(huge)).toBe(huge);
+    expect(onAlive).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(PROBE_TIMEOUT_MS * 2);
+    expect(onDead).not.toHaveBeenCalled();
+    expect(probe.filter('more\n')).toBe('more\n'); // passthrough again
+  });
+
+  it('handles CRLF: keeps the carriage return, still spots the response', () => {
+    const { probe, onAlive } = makeProbe();
+    probe.start();
+    const request = '{"jsonrpc":"2.0","id":4,"method":"tools/list"}\r\n';
+    const out = probe.filter(answer(probe) + '\r\n' + request);
+    expect(out).toBe(request);
+    expect(onAlive).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards a blank line without taking it for proof of life', () => {
+    const { probe, onAlive, onDead } = makeProbe();
+    probe.start();
+    expect(probe.filter('\n')).toBe('\n');
+    expect(onAlive).not.toHaveBeenCalled();
+    expect(probe.outstanding).toBe(true);
+    vi.advanceTimersByTime(PROBE_TIMEOUT_MS);
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards a response arriving beyond the one-chunk linger bound', () => {
+    // The documented limit of resolving alive on other traffic: the filter stays
+    // engaged for one further chunk, not indefinitely. Two chunks later the
+    // response is ordinary stream content again.
+    const { probe } = makeProbe();
+    probe.start();
+    const late = answer(probe) + '\n';
+    probe.filter('{"jsonrpc":"2.0","id":3,"method":"tools/call"}\n');
+    expect(probe.filter('{"jsonrpc":"2.0","id":4,"method":"tools/call"}\n')).toContain('id":4');
+    expect(probe.filter(late)).toBe(late);
+  });
+
+  it('forwards a response to some other id and counts it as liveness', () => {
+    const { probe, onAlive } = makeProbe();
+    probe.start();
+    const other = '{"jsonrpc":"2.0","id":"not-our-probe","result":{}}\n';
+    expect(probe.filter(other)).toBe(other);
+    expect(onAlive).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the injected timer hooks for both arming and cancelling', () => {
+    const setTimer = vi.fn(() => 'handle');
+    const clearTimer = vi.fn();
+    const onAlive = vi.fn();
+    const probe = new ClientProbe({
+      write: () => {},
+      onAlive,
+      onDead: () => {},
+      timeoutMs: 1234,
+      setTimer,
+      clearTimer,
+    });
+    probe.start();
+    expect(setTimer).toHaveBeenCalledTimes(1);
+    expect(setTimer.mock.calls[0][1]).toBe(1234);
+    probe.filter(answer(probe) + '\n');
+    expect(clearTimer).toHaveBeenCalledWith('handle');
+    expect(onAlive).toHaveBeenCalledTimes(1);
+  });
+
+  describe('multi-byte characters split across chunks', () => {
+    // The shim decodes stdin statefully and forwards what `filter` returns, so
+    // the pair has to be byte-exact even when a read boundary lands inside a
+    // UTF-8 sequence. `Buffer.toString('utf8')` per chunk does not survive this.
+    const pipe = (probe: ClientProbe, chunks: Buffer[]): Buffer => {
+      const decoder = new StringDecoder('utf8');
+      const parts = chunks.map((chunk) => Buffer.from(probe.filter(decoder.write(chunk)), 'utf8'));
+      return Buffer.concat(parts);
+    };
+
+    const payload = Buffer.from('{"text":"é🎯x"}\n', 'utf8');
+    // Land the split inside the four-byte emoji.
+    const cut = payload.indexOf(Buffer.from('🎯', 'utf8')) + 2;
+
+    it('forwards the original bytes when no probe is outstanding', () => {
+      const { probe } = makeProbe();
+      const forwarded = pipe(probe, [payload.subarray(0, cut), payload.subarray(cut)]);
+      expect(forwarded.equals(payload)).toBe(true);
+    });
+
+    it('forwards the original bytes while a probe is outstanding', () => {
+      const { probe, onAlive } = makeProbe();
+      probe.start();
+      const forwarded = pipe(probe, [payload.subarray(0, cut), payload.subarray(cut)]);
+      expect(forwarded.equals(payload)).toBe(true);
+      expect(onAlive).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/daemon/clientProbe.ts
+++ b/src/daemon/clientProbe.ts
@@ -1,0 +1,224 @@
+/**
+ * Liveness probe for the stdio client (issue #126).
+ *
+ * The idle backstop from #80 exists because a SIGKILL'd client whose wrapper
+ * chain holds stdin open never delivers EOF, and the stranded process pins a
+ * daemon session forever. That case is real, so the backstop stays — but it
+ * cannot tell a dead client apart from a live one that simply hasn't asked for
+ * anything in half an hour, and it resolved that ambiguity by exiting. For a
+ * client that treats a stdio server exit as terminal (#123), that costs the
+ * user their tools for the rest of the session.
+ *
+ * So instead of exiting when the idle timer fires, we ask. Server → client
+ * `ping` is part of the MCP protocol and every conformant client answers it. An
+ * answer means keep the session; silence for `PROBE_TIMEOUT_MS` means the client
+ * really is gone and we exit exactly as before. The orphan protection survives:
+ * a stranded shim still dies, one idle window plus one probe window after its
+ * client vanished.
+ *
+ * The id is a string, not a number, because this request is injected into a
+ * stream the shim otherwise only forwards. Clients number their own requests and
+ * the daemon numbers its own; a prefixed string id cannot collide with either.
+ *
+ * `filter` exists because the response to that request has no business reaching
+ * the daemon: the daemon never sent the ping, and a response to a request it did
+ * not make is not part of its session. The SDK we pin today happens to discard
+ * an unknown-id response quietly — it routes it to an `onerror` callback the
+ * daemon leaves unassigned — but that is an unwired hook, not a guarantee, and
+ * the shim should not depend on it to keep a session intact. Filtering is the
+ * single exception to the shim's byte-for-byte pipe, and it is narrow: no
+ * bytes are altered, reordered, or dropped except the one response line the shim
+ * itself solicited, and its newline. Everything else is forwarded verbatim on
+ * line boundaries, and the filter disengages the moment the probe resolves.
+ */
+
+/** How long a live client gets to answer a ping before we call it dead. */
+export const PROBE_TIMEOUT_MS = 10_000;
+
+const PROBE_ID_PREFIX = 'omnifocus-mcp-probe-';
+
+/**
+ * Upper bound on bytes held back while filtering. A single JSON-RPC line this
+ * long is not a real client message, and delaying the client's bytes is worse
+ * than forwarding a probe response we then have to live without — so past this
+ * point we give up filtering rather than buffer. A client producing a megabyte
+ * of unbroken output is self-evidently alive, which is all the probe wanted.
+ */
+const MAX_BUFFERED_BYTES = 1_000_000;
+
+export interface ClientProbeOptions {
+  /** Writes one JSON-RPC line to the client. The newline is the writer's job. */
+  write: (line: string) => void;
+  /** The client answered, or spoke at all. */
+  onAlive: () => void;
+  /**
+   * The client said nothing for `timeoutMs`. Expected to terminate the process;
+   * that is the only caller today. If it returns instead, the probe is simply
+   * resolved dead and any bytes buffered mid-line are delivered, unchanged, on
+   * the next `filter` call.
+   */
+  onDead: () => void;
+  timeoutMs?: number;
+  /** Injectable for tests; defaults to an unref'd setTimeout. */
+  setTimer?: (fn: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+}
+
+interface ProbeJsonRpc {
+  id?: string | number;
+  result?: unknown;
+  error?: unknown;
+}
+
+export class ClientProbe {
+  private readonly write: (line: string) => void;
+  private readonly onAlive: () => void;
+  private readonly onDead: () => void;
+  private readonly timeoutMs: number;
+  private readonly setTimer: (fn: () => void, ms: number) => unknown;
+  private readonly clearTimer: (handle: unknown) => void;
+
+  /** Monotonic within this probe, so no two of its ids ever repeat. */
+  private probeCounter = 0;
+  private probeId: string | null = null;
+  private timer: unknown = null;
+  /** A probe has been written and has not yet been answered or timed out. */
+  private outstandingProbe = false;
+  /** Whether `filter` is inspecting the stream rather than passing it through. */
+  private filtering = false;
+  private lingerChunksLeft = 0;
+  private buffer = '';
+
+  constructor(options: ClientProbeOptions) {
+    this.write = options.write;
+    this.onAlive = options.onAlive;
+    this.onDead = options.onDead;
+    this.timeoutMs = options.timeoutMs ?? PROBE_TIMEOUT_MS;
+    this.setTimer =
+      options.setTimer ??
+      ((fn, ms) => {
+        const handle = setTimeout(fn, ms);
+        // Don't let the probe alone hold the process open; stdin already does.
+        (handle as { unref?: () => void }).unref?.();
+        return handle;
+      });
+    this.clearTimer =
+      options.clearTimer ?? ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
+  }
+
+  /** True while a ping is awaiting an answer. */
+  get outstanding(): boolean {
+    return this.outstandingProbe;
+  }
+
+  /** The id of the most recent ping, for tests and diagnostics. */
+  get lastId(): string | null {
+    return this.probeId;
+  }
+
+  /**
+   * Ping the client. A no-op while a probe is already outstanding, so a repeated
+   * idle trigger cannot stack pings on a client that is merely slow.
+   */
+  start(): void {
+    if (this.outstandingProbe) return;
+    this.probeId = `${PROBE_ID_PREFIX}${++this.probeCounter}`;
+    this.outstandingProbe = true;
+    this.filtering = true;
+    this.lingerChunksLeft = 0;
+    this.write(JSON.stringify({ jsonrpc: '2.0', id: this.probeId, method: 'ping' }));
+    this.timer = this.setTimer(() => {
+      this.timer = null;
+      this.outstandingProbe = false;
+      // Stop filtering; whatever is buffered is flushed by the next `filter`
+      // call, which is only reachable if `onDead` chose not to exit.
+      this.filtering = false;
+      this.lingerChunksLeft = 0;
+      this.onDead();
+    }, this.timeoutMs);
+  }
+
+  /**
+   * Pass client → daemon bytes through, dropping the probe response if it is in
+   * there. Returns exactly what should be forwarded.
+   *
+   * Any complete line proves the client is alive, not just the ping response —
+   * a client that is issuing requests is obviously there. When liveness is
+   * settled that way, the filter stays engaged for one more chunk boundary so a
+   * ping response arriving just behind that traffic is still swallowed rather
+   * than forwarded to a daemon that has no business seeing it. One chunk is
+   * enough in practice (a client writes its ping response in the same or the
+   * next write) and bounds how long any bytes can be held.
+   */
+  filter(chunk: string): string {
+    if (!this.filtering) {
+      // A remainder can only be left here by a probe that timed out mid-line.
+      const held = this.buffer;
+      this.buffer = '';
+      return held + chunk;
+    }
+
+    // This chunk spends the linger allowance granted by earlier traffic.
+    if (!this.outstandingProbe) this.lingerChunksLeft--;
+
+    this.buffer += chunk;
+    let out = '';
+    let idx: number;
+    while (this.filtering && (idx = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, idx);
+      this.buffer = this.buffer.slice(idx + 1);
+      if (this.isProbeResponse(line)) {
+        // Drop the line and its newline — the one exception to the byte pipe.
+        this.resolveAlive();
+        this.filtering = false;
+        break;
+      }
+      out += line + '\n';
+      if (this.outstandingProbe && line.trim() !== '') {
+        this.resolveAlive();
+        this.lingerChunksLeft = 1;
+      }
+    }
+
+    if (this.filtering && !this.outstandingProbe && this.lingerChunksLeft <= 0) {
+      this.filtering = false;
+    }
+    if (this.filtering && this.buffer.length > MAX_BUFFERED_BYTES) {
+      if (this.outstandingProbe) this.resolveAlive();
+      this.filtering = false;
+    }
+    if (!this.filtering) {
+      // Back to passthrough: the partial line goes out unchanged, exactly once.
+      out += this.buffer;
+      this.buffer = '';
+      this.lingerChunksLeft = 0;
+    }
+    return out;
+  }
+
+  /** A response carrying either `result` or `error` answers the ping — a client
+   * replying "method not found" is still a client that is running. */
+  private isProbeResponse(line: string): boolean {
+    const trimmed = line.trim();
+    if (!trimmed) return false;
+    let msg: ProbeJsonRpc;
+    try {
+      msg = JSON.parse(trimmed);
+    } catch {
+      return false;
+    }
+    return (
+      msg.id === this.probeId && (msg.result !== undefined || msg.error !== undefined)
+    );
+  }
+
+  private resolveAlive(): void {
+    if (!this.outstandingProbe) return;
+    this.outstandingProbe = false;
+    if (this.timer !== null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+    this.onAlive();
+  }
+}

--- a/src/daemon/shim.ts
+++ b/src/daemon/shim.ts
@@ -1,12 +1,14 @@
 import { connect, Socket } from 'net';
 import { spawn } from 'child_process';
 import { mkdirSync, openSync } from 'fs';
+import { StringDecoder } from 'string_decoder';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { resolveSocketPath, resolveLockDir, SOCKET_DIR_MODE } from './socketPath.js';
 import { tryAcquireLock } from './lock.js';
 import { resolveIdleTimeoutMinutes, installIdleTimeout } from '../utils/idleTimeout.js';
 import { SessionTracker } from './sessionReplay.js';
+import { ClientProbe } from './clientProbe.js';
 
 /**
  * The client-facing half of the daemon (issue #80).
@@ -14,7 +16,10 @@ import { SessionTracker } from './sessionReplay.js';
  * This is what an MCP client launches. It speaks no protocol of its own: it
  * connects to the shared daemon and splices stdin/stdout onto that socket. MCP
  * over stdio is newline-delimited JSON-RPC with no per-connection framing beyond
- * the newline, so a byte-for-byte pipe is a complete implementation.
+ * the newline, so a byte-for-byte pipe is a complete implementation. The one
+ * exception is the idle probe (#126): the shim writes a `ping` of its own and
+ * swallows the client's answer to it, because the daemon never asked for it. No
+ * other byte is altered — see `clientProbe.ts`.
  *
  * Why a shim at all, rather than pointing clients at the daemon directly? Because
  * every MCP client in existence knows how to launch a command and talk to its
@@ -184,6 +189,8 @@ export async function runShim(options: RunShimOptions = {}): Promise<void> {
     return;
   }
 
+  const idleMinutes = resolveIdleTimeoutMinutes(process.env.OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES);
+
   // Session state that has to survive a daemon restart (#123). Observing only —
   // the pipe below stays byte-for-byte.
   const session = new SessionTracker();
@@ -192,11 +199,39 @@ export async function runShim(options: RunShimOptions = {}): Promise<void> {
   let reconnecting = false;
   let reconnectsLeft = MAX_RECONNECTS;
 
+  // Liveness probe for the idle backstop below (#126). Constructed here so the
+  // stdin handler can filter the answer out before anything else sees it.
+  const probe = new ClientProbe({
+    // Writing to stdout is safe here even though the daemon relay writes to it
+    // too: the daemon only speaks in response to a client request, and the idle
+    // timer fires only after a full window in which the client said nothing, so
+    // there is no relayed line in flight to interleave with.
+    write: (line: string) => process.stdout.write(line + '\n'),
+    // Quiet on purpose: the bytes that answered the ping already reset the idle
+    // timer, so there is nothing left to do.
+    onAlive: () => {},
+    onDead: () => {
+      console.error(
+        `[omnifocus-mcp] no client traffic for ${idleMinutes}m and no answer to a ping; closing daemon session (issue #80).`
+      );
+      exit();
+    },
+  });
+
+  // Decode statefully. A chunk can end mid-character — a pipe read boundary has
+  // nothing to do with UTF-8 sequence boundaries — and `chunk.toString('utf8')`
+  // turns that tail into U+FFFD, which the next chunk cannot undo. That was
+  // harmless while the decoded copy was only observed and the Buffer itself was
+  // forwarded, but the probe filter forwards the decoded string, so the decoder
+  // has to hold the partial sequence until the rest of it arrives (#126).
+  const stdinDecoder = new StringDecoder('utf8');
+
   // Nothing has touched stdin until now, so it is still paused and no client
   // bytes have been dropped while we were connecting.
   process.stdin.on('data', (chunk: Buffer) => {
-    session.observeOutbound(chunk.toString('utf8'));
-    active.write(chunk);
+    const forwarded = probe.filter(stdinDecoder.write(chunk));
+    session.observeOutbound(forwarded);
+    if (forwarded) active.write(forwarded);
   });
 
   const attachSocket = (sock: Socket): void => {
@@ -285,11 +320,15 @@ export async function runShim(options: RunShimOptions = {}): Promise<void> {
   // Same orphan backstop as the standalone server: if the client is SIGKILLed
   // and the wrapper chain holds stdin open, no EOF ever arrives. A stranded shim
   // is far cheaper than a stranded server, but it still pins a daemon session.
-  const idleMinutes = resolveIdleTimeoutMinutes(process.env.OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES);
+  //
+  // Silence is not proof of death, though, and exiting on it cost live sessions
+  // their tools: a client that treats a stdio exit as terminal (#123) never
+  // comes back, and a long-lived agent session going 30 minutes without an
+  // OmniFocus call is ordinary (#126). So the timer now pings the client instead
+  // of exiting, and only a ping that goes unanswered ends the session. A
+  // stranded shim still dies, one idle window plus one probe window later.
   installIdleTimeout(process.stdin, idleMinutes, () => {
-    console.error(
-      `[omnifocus-mcp] no client traffic for ${idleMinutes}m; closing daemon session (issue #80).`
-    );
-    exit();
+    if (clientClosed) return; // the close/EOF paths above already handle it
+    probe.start();
   });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { resolveIdleTimeoutMinutes, installIdleTimeout } from './utils/idleTimeout.js';
+import { PROBE_TIMEOUT_MS } from './daemon/clientProbe.js';
 import { createOmniFocusServer } from './buildServer.js';
 
 // Tool/resource registration lives in buildServer.ts so the daemon can build a
@@ -37,17 +38,42 @@ process.on('SIGINT', shutdown);
 // Idle-timeout backstop (issue #80). The stdin-EOF and signal handlers above
 // catch the clean-disconnect case; when the wrapper chain holds stdin open after
 // a SIGKILL'd client, they don't fire and the server lingers as an orphan. If no
-// client traffic arrives within the idle window, exit. Every JSON-RPC request
-// reaches us as stdin data (the SDK's stdio transport also listens on 'data', so
-// our listener is additive), so an actively-used server keeps resetting the timer
-// and never times out. Configure with OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES
-// (default 30; set 0 to disable). See src/utils/idleTimeout.ts.
+// client traffic arrives within the idle window, ask the client whether it is
+// still there. Every JSON-RPC request reaches us as stdin data (the SDK's stdio
+// transport also listens on 'data', so our listener is additive), so an
+// actively-used server keeps resetting the timer and never reaches this.
+//
+// Silence alone is not proof of death, and exiting on it disconnects clients
+// that are alive and merely quiet — terminally, for clients that treat a stdio
+// exit as unrecoverable (#123, #126). So we ping first and exit only if nobody
+// answers. The shim does the same thing over its socket; here the SDK server is
+// in-process, so `Server.ping()` is all it takes. Configure the window with
+// OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES (default 30; set 0 to disable).
+// See src/utils/idleTimeout.ts and src/daemon/clientProbe.ts.
 const idleTimeoutMinutes = resolveIdleTimeoutMinutes(
   process.env.OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES
 );
 installIdleTimeout(process.stdin, idleTimeoutMinutes, () => {
-  console.error(
-    `[omnifocus-mcp] no client traffic for ${idleTimeoutMinutes}m; exiting to avoid orphaned-process accumulation (issue #80).`
+  const giveUp = (): void => {
+    console.error(
+      `[omnifocus-mcp] no client traffic for ${idleTimeoutMinutes}m and no answer to a ping; exiting to avoid orphaned-process accumulation (issue #80).`
+    );
+    process.exit(0);
+  };
+  // A ping the client answers means it is alive; its answer is stdin data, which
+  // has already re-armed the idle timer, so there is nothing more to do. Either
+  // rejection or silence means it is gone. The timer is cleared on the success
+  // path so a live server doesn't hold a pending handle for every idle window.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('ping timed out')), PROBE_TIMEOUT_MS);
+    timer.unref();
+  });
+  Promise.race([server.server.ping(), timedOut]).then(
+    () => clearTimeout(timer),
+    () => {
+      clearTimeout(timer);
+      giveUp();
+    }
   );
-  process.exit(0);
 });


### PR DESCRIPTION
Fixes #126.

#86 added the idle backstop and noted the risk in its own description: the window "could in principle reap a live-but-silent session that goes 30 min between OmniFocus calls (rare for agent workloads)." For a long-lived Claude Code session it is the normal case, and #123 established that a stdio exit is terminal for that client: the session shows the server as failed until someone manually reconnects. Both the shim and the standalone server have the backstop, so both paths hit it.

## Change

When the idle timer fires, send the client a JSON-RPC `ping` instead of exiting. Answer within 10 s → alive, session kept. No answer → exit exactly as before. Any other client traffic during the window also proves liveness. The SIGKILL-orphan protection from #86 survives unchanged; a stranded shim still dies one idle window plus one probe window after its client vanishes. Defaults and `OMNIFOCUS_MCP_IDLE_TIMEOUT_MINUTES` semantics are untouched.

- `src/daemon/clientProbe.ts` (new): emits the ping with a string id (`omnifocus-mcp-probe-<n>`, so it can never collide with the client's or daemon's numeric ids) and, only while a probe is outstanding, filters the one response line out of the client→daemon stream so the daemon never sees a response to a request it did not send. Every other byte is forwarded unchanged, by line boundary; a partial line is held for at most one chunk or the probe window, never a complete line.
- `src/daemon/shim.ts`: wires the probe in. Stdin is now decoded through one stateful `StringDecoder`, which also fixes a latent issue in the #123 replay path: an `initialize` line spanning a chunk boundary with non-ASCII text would previously have been recorded with U+FFFD baked in.
- `src/server.ts`: the standalone path uses the in-process SDK `Server.ping()` raced against the same window.
- README: env-var row and one sentence under "Shared daemon".

## Testing

`npx tsc --noEmit` clean; `npm test` 29 files / 545 tests (19 new in `clientProbe.test.ts`: passthrough, ping shape, result and error responses, split responses, timeout, liveness by other traffic, re-probe ids, CRLF, lone newline, the linger bound, foreign-id responses, the buffer cap, injected timers, multi-byte UTF-8 split across chunks with and without a probe outstanding).

Smoke-tested the built shim and the standalone server against an isolated socket with a 3 s window: a client that answers is re-pinged every window and stays attached indefinitely; a client that never answers is exited at window + 10 s with the new log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
