### PR TITLE
Fix perspective rule engine referencing nonexistent OmniJS properties

### DIFF
--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -105,13 +105,18 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       (task.repetitionRule !== null) === value;
     var evaluateActionIsUntagged = (task, value) =>
       (task.tags.length === 0) === value;
+    // Tag.effectivelyDropped/effectivelyActive/effectivelyOnHold do not exist on
+    // the OmniJS Tag class (verified against app.getTypeScriptDeclarations() and
+    // by probing a live tag — all three read back as undefined). Every branch
+    // here silently evaluated to a fixed wrong value: "remaining" was always
+    // true (!undefined), the rest were always false. Tag.Status has exactly
+    // three real members: Active, Dropped, OnHold.
     var evaluateActionHasTagWithStatus = (task, value) => {
       return task.tags.some((tag) => {
-        // Map OmniFocus tag status values
-        if (value === "remaining") return !tag.effectivelyDropped;
-        if (value === "active") return tag.effectivelyActive;
-        if (value === "onHold") return tag.effectivelyOnHold;
-        if (value === "dropped") return tag.effectivelyDropped;
+        if (value === "remaining") return tag.status !== Tag.Status.Dropped;
+        if (value === "active") return tag.status === Tag.Status.Active;
+        if (value === "onHold") return tag.status === Tag.Status.OnHold;
+        if (value === "dropped") return tag.status === Tag.Status.Dropped;
         return false;
       });
     };
@@ -119,24 +124,72 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       (!task.children || task.children.length === 0) === value;
     var evaluateActionHasNoProject = (task, value) =>
       (task.containingProject === null) === value;
+    // Project.Status has no `SingleActions` member (only Active/Done/Dropped/
+    // OnHold), so this always compared against `undefined` and never matched.
+    // Being in a single actions list is its own boolean property.
     var evaluateActionIsInSingleActionsList = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
-      return (project.status === Project.Status.SingleActions) === value;
+      return Boolean(project.containsSingletonActions) === value;
     };
+    // Project.effectivelyCompleted/effectivelyDropped do not exist (same class
+    // of bug as the tag statuses above); "remaining" was always true, "completed"
+    // and "dropped" were always false. "stalled" and "pending" mapped to
+    // Project.Status.Stalled/.Pending, which also don't exist — Project.Status
+    // has only Active/Done/Dropped/OnHold, so both always evaluated false.
+    //
+    // OmniFocus's own glossary confirms "Stalled" and "Pending" are legacy names
+    // for compound conditions, not literal statuses:
+    //   Stalled -> "Has an active project which has no remaining actions"
+    //   Pending -> "Has an active project which has a future defer date"
+    // (https://support.omnigroup.com/documentation/omnifocus/universal/4.8.11/en/glossary/#stalled,
+    //  .../#pending — unchanged since 4.3.3.)
+    //
+    // The glossary's "no remaining actions" reading is self-contradictory once you
+    // account for how this rule is actually used: every real perspective pairs
+    // {actionHasProjectWithStatus: "stalled"} with {actionAvailability: "remaining"}
+    // at the TASK level (AND'd together). A task can't be "remaining" while its own
+    // project has zero remaining tasks — it would be one. Verified live: that literal
+    // reading matched 25 active projects, almost all placeholder projects with zero
+    // tasks; the classic GTD reading below ("has work left, but none of it is
+    // currently actionable") matched 3 real in-progress projects and is what makes
+    // the paired rule non-vacuous.
     var evaluateActionHasProjectWithStatus = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
       if (value === "remaining") {
-        return !project.effectivelyCompleted && !project.effectivelyDropped;
+        return !project.completed && project.status !== Project.Status.Dropped;
       }
-      if (value === "completed") return project.effectivelyCompleted;
-      if (value === "dropped") return project.effectivelyDropped;
+      if (value === "stalled") {
+        const remaining = project.flattenedTasks.filter(
+          (t) => !t.completed && t.taskStatus !== Task.Status.Dropped
+        );
+        const hasActionableTask = remaining.some(
+          (t) =>
+            t.taskStatus === Task.Status.Available ||
+            t.taskStatus === Task.Status.Next ||
+            t.taskStatus === Task.Status.DueSoon ||
+            t.taskStatus === Task.Status.Overdue
+        );
+        return (
+          project.status === Project.Status.Active &&
+          remaining.length > 0 &&
+          !hasActionableTask
+        );
+      }
+      if (value === "pending") {
+        const deferDate = project.effectiveDeferDate;
+        return (
+          project.status === Project.Status.Active &&
+          deferDate !== null &&
+          deferDate > new Date()
+        );
+      }
       const statusMap = {
         active: Project.Status.Active,
         onHold: Project.Status.OnHold,
-        stalled: Project.Status.Stalled,
-        pending: Project.Status.Pending,
+        completed: Project.Status.Done,
+        dropped: Project.Status.Dropped,
       };
       return project.status === statusMap[value];
     };
@@ -189,14 +242,25 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       return value.some((term) => searchText.includes(term.toLowerCase()));
     };
 
-    // OmniFocus stores "completed" as the field name but the JS property is completionDate.
-    var normalizeDateFieldName = (dateField) => {
-      const map = { completed: "completion" };
-      return map[dateField] || dateField;
+    // Perspective rules name date fields as "due"/"defer"/"completed"/"dropped"/
+    // "added"/"changed" (https://omni-automation.com/omnifocus/perspective.html),
+    // but the real OmniJS Task properties don't follow one consistent "<field>Date"
+    // pattern: "dropped" is dropDate (not droppedDate), and "added"/"changed" have
+    // no Date suffix at all (added, modified). The old suffix-concatenation
+    // approach silently produced a nonexistent property name for those three,
+    // so any rule filtering on drop/added/changed date never matched anything.
+    var DATE_FIELD_PROPERTY = {
+      due: "dueDate",
+      defer: "deferDate",
+      completed: "completionDate",
+      dropped: "dropDate",
+      added: "added",
+      changed: "modified",
     };
 
     var getTaskDateField = (task, dateField) => {
-      return task[normalizeDateFieldName(dateField) + "Date"];
+      const prop = DATE_FIELD_PROPERTY[dateField];
+      return prop ? task[prop] : undefined;
     };
 
     var evaluateActionDateIsToday = (task, dateField) => {
@@ -238,7 +302,9 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       }
 
       const cutoff = new Date();
-      if (relativeComponent === "day") {
+      if (relativeComponent === "hour") {
+        cutoff.setHours(cutoff.getHours() - relativeBeforeAmount);
+      } else if (relativeComponent === "day") {
         cutoff.setDate(cutoff.getDate() - relativeBeforeAmount);
       } else if (relativeComponent === "week") {
         cutoff.setDate(cutoff.getDate() - relativeBeforeAmount * 7);
@@ -250,6 +316,42 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return fieldDate <= now;
       }
       return fieldDate >= cutoff && fieldDate <= now;
+    };
+
+    // Forward-looking counterpart to actionDateIsInThePast, documented at
+    // https://omni-automation.com/omnifocus/perspective.html but never
+    // implemented — any rule using it fell through to unknownRuleTypes and
+    // matched nothing, silently, since a date-field rule short-circuits the
+    // whole evaluateRule branch once it recognizes `rule.actionDateField`.
+    var evaluateActionDateIsInTheNext = (task, dateField, value) => {
+      const fieldDate = getTaskDateField(task, dateField);
+      if (!fieldDate) return false;
+      const now = new Date();
+
+      if (typeof value !== "object" || value === null) {
+        return fieldDate >= now;
+      }
+
+      const { relativeAfterAmount, relativeComponent } = value;
+      if (relativeAfterAmount === undefined || relativeComponent === undefined) {
+        return fieldDate >= now;
+      }
+
+      const cutoff = new Date();
+      if (relativeComponent === "hour") {
+        cutoff.setHours(cutoff.getHours() + relativeAfterAmount);
+      } else if (relativeComponent === "day") {
+        cutoff.setDate(cutoff.getDate() + relativeAfterAmount);
+      } else if (relativeComponent === "week") {
+        cutoff.setDate(cutoff.getDate() + relativeAfterAmount * 7);
+      } else if (relativeComponent === "month") {
+        cutoff.setMonth(cutoff.getMonth() + relativeAfterAmount);
+      } else if (relativeComponent === "year") {
+        cutoff.setFullYear(cutoff.getFullYear() + relativeAfterAmount);
+      } else {
+        return fieldDate >= now;
+      }
+      return fieldDate <= cutoff && fieldDate >= now;
     };
 
     // filter rules and values are defined here: https://omni-automation.com/omnifocus/perspective.html
@@ -294,9 +396,12 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         if (rule.actionDateIsInThePast) {
           return evaluateActionDateIsInThePast(task, dateField, rule.actionDateIsInThePast);
         }
+        if (rule.actionDateIsInTheNext) {
+          return evaluateActionDateIsInTheNext(task, dateField, rule.actionDateIsInTheNext);
+        }
 
         // Record any unrecognised date conditions so callers can diagnose gaps
-        const knownDateKeys = new Set(["actionDateField", "actionDateIsToday", "actionDateIsYesterday", "actionDateIsTomorrow", "actionDateIsInThePast"]);
+        const knownDateKeys = new Set(["actionDateField", "actionDateIsToday", "actionDateIsYesterday", "actionDateIsTomorrow", "actionDateIsInThePast", "actionDateIsInTheNext"]);
         Object.keys(rule).forEach((k) => {
           if (!knownDateKeys.has(k)) {
             const entry = k + "(field=" + dateField + ", value=" + JSON.stringify(rule[k]) + ")";

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -50,20 +50,27 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
 
     var evaluateActionAvailability = (task, value) => {
       let result;
+      // task.completed is unreliable for repeating tasks: a completed occurrence
+      // reads back completed:false while task.taskStatus is Completed (the next
+      // occurrence hasn't been generated yet). taskStatus is the source of truth
+      // for whether an action is finished — keying "remaining"/"completed"/
+      // "available" off task.completed let every past occurrence of a repeating
+      // task slip through "Availability: Available" and flood perspectives.
+      const isFinished =
+        task.taskStatus === Task.Status.Completed ||
+        task.taskStatus === Task.Status.Dropped;
       if (value === "remaining") {
-        result = !task.completed && task.taskStatus !== Task.Status.Dropped;
+        result = !isFinished;
       } else if (value === "completed") {
-        result = task.completed;
+        result = task.taskStatus === Task.Status.Completed;
       } else if (value === "dropped") {
         result = task.taskStatus === Task.Status.Dropped;
       } else if (value === "available") {
         // "available" is defined here: https://support.omnigroup.com/documentation/omnifocus/universal/4.3.3/en/glossary/#view-options
-        const isActive =
-          !task.completed && task.taskStatus !== Task.Status.Dropped;
         const isAvailable =
           task.taskStatus !== Task.Status.Blocked &&
           (!task.deferDate || task.deferDate <= new Date());
-        result = isActive && isAvailable;
+        result = !isFinished && isAvailable;
       } else if (value === "firstAvailable") {
         // "firstAvailable" specifically means the Available status
         result = task.taskStatus === Task.Status.Available;

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -112,18 +112,31 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       (task.repetitionRule !== null) === value;
     var evaluateActionIsUntagged = (task, value) =>
       (task.tags.length === 0) === value;
-    // Tag.effectivelyDropped/effectivelyActive/effectivelyOnHold do not exist on
-    // the OmniJS Tag class (verified against app.getTypeScriptDeclarations() and
-    // by probing a live tag — all three read back as undefined). Every branch
-    // here silently evaluated to a fixed wrong value: "remaining" was always
-    // true (!undefined), the rest were always false. Tag.Status has exactly
-    // three real members: Active, Dropped, OnHold.
+    // The adverb-form names Tag.effectivelyDropped/effectivelyActive/
+    // effectivelyOnHold do NOT exist (verified against
+    // app.getTypeScriptDeclarations() — zero matches — and by probing a live
+    // tag; all read back as undefined). The adjective-form `effectiveActive`
+    // DOES exist (inherited from ActiveObject) but is the wrong tool here: for a
+    // Tag it only tracks "not dropped" — a live probe shows an on-hold tag
+    // reads effectiveActive:true. The perspective editor treats Active and
+    // On Hold as distinct rule values (that's why "remaining" — meaning "not
+    // dropped" — is a separate value), so we need the real Tag.Status, folded
+    // up the parent chain. `tag.parent` and `tag.status` are both real
+    // properties; Tag.Status members are Active, Dropped, OnHold.
+    var tagAncestryHasStatus = (tag, status) => {
+      for (var t = tag; t; t = t.parent) {
+        if (t.status === status) return true;
+      }
+      return false;
+    };
     var evaluateActionHasTagWithStatus = (task, value) => {
       return task.tags.some((tag) => {
-        if (value === "remaining") return tag.status !== Tag.Status.Dropped;
-        if (value === "active") return tag.status === Tag.Status.Active;
-        if (value === "onHold") return tag.status === Tag.Status.OnHold;
-        if (value === "dropped") return tag.status === Tag.Status.Dropped;
+        const droppedInChain = tagAncestryHasStatus(tag, Tag.Status.Dropped);
+        if (value === "dropped") return droppedInChain;
+        if (value === "remaining") return !droppedInChain;
+        const onHoldInChain = tagAncestryHasStatus(tag, Tag.Status.OnHold);
+        if (value === "onHold") return !droppedInChain && onHoldInChain;
+        if (value === "active") return !droppedInChain && !onHoldInChain;
         return false;
       });
     };

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -154,6 +154,49 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     // tasks; the classic GTD reading below ("has work left, but none of it is
     // currently actionable") matched 3 real in-progress projects and is what makes
     // the paired rule non-vacuous.
+    // OmniJS doesn't expose an "effectively active" flag on Project — a project's
+    // own `.status` stays Active even when a containing folder has been dropped,
+    // which hides it from the app despite the field never changing. Walk `.parent`
+    // (not `.parentFolder`, which only exists on Project, not Folder itself) to
+    // check the whole chain.
+    function isAncestorFolderDropped(project) {
+      var folder = project.parentFolder;
+      while (folder) {
+        if (folder.status === Folder.Status.Dropped) return true;
+        folder = folder.parent;
+      }
+      return false;
+    }
+
+    // Memoized per project id for the lifetime of this getPerspectiveViewByName
+    // call: {actionHasProjectWithStatus: "stalled"} is typically paired with
+    // {actionAvailability: "remaining"} at the task level, so evaluateTask calls
+    // into this once per remaining task in a project, not once per project —
+    // without the cache, an N-task stalled project re-scans its own M-task list
+    // N times.
+    var _stalledProjectCache = new Map();
+    function isProjectStalled(project) {
+      const key = project.id.primaryKey;
+      if (_stalledProjectCache.has(key)) return _stalledProjectCache.get(key);
+      const remaining = project.flattenedTasks.filter(
+        (t) => !t.completed && t.taskStatus !== Task.Status.Dropped
+      );
+      const hasActionableTask = remaining.some(
+        (t) =>
+          t.taskStatus === Task.Status.Available ||
+          t.taskStatus === Task.Status.Next ||
+          t.taskStatus === Task.Status.DueSoon ||
+          t.taskStatus === Task.Status.Overdue
+      );
+      const result =
+        project.status === Project.Status.Active &&
+        !isAncestorFolderDropped(project) &&
+        remaining.length > 0 &&
+        !hasActionableTask;
+      _stalledProjectCache.set(key, result);
+      return result;
+    }
+
     var evaluateActionHasProjectWithStatus = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
@@ -161,26 +204,13 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return !project.completed && project.status !== Project.Status.Dropped;
       }
       if (value === "stalled") {
-        const remaining = project.flattenedTasks.filter(
-          (t) => !t.completed && t.taskStatus !== Task.Status.Dropped
-        );
-        const hasActionableTask = remaining.some(
-          (t) =>
-            t.taskStatus === Task.Status.Available ||
-            t.taskStatus === Task.Status.Next ||
-            t.taskStatus === Task.Status.DueSoon ||
-            t.taskStatus === Task.Status.Overdue
-        );
-        return (
-          project.status === Project.Status.Active &&
-          remaining.length > 0 &&
-          !hasActionableTask
-        );
+        return isProjectStalled(project);
       }
       if (value === "pending") {
         const deferDate = project.effectiveDeferDate;
         return (
           project.status === Project.Status.Active &&
+          !isAncestorFolderDropped(project) &&
           deferDate !== null &&
           deferDate > new Date()
         );
@@ -252,6 +282,7 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     var DATE_FIELD_PROPERTY = {
       due: "dueDate",
       defer: "deferDate",
+      planned: "plannedDate",
       completed: "completionDate",
       dropped: "dropDate",
       added: "added",
@@ -286,6 +317,23 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       return fieldDate.toDateString() === tomorrow.toDateString();
     };
 
+    // Shared by evaluateActionDateIsInThePast/InTheNext, which are identical
+    // apart from the offset's sign and which side of `now` the window falls on.
+    // Keeping the hour/day/week/month/year cases in one place means a future
+    // fix (a new component, a unit bug) can't be applied to one side and
+    // forgotten on the other — exactly the class of bug this file was already
+    // full of.
+    function applyRelativeOffset(date, amount, component, sign) {
+      const delta = sign * amount;
+      if (component === "hour") date.setHours(date.getHours() + delta);
+      else if (component === "day") date.setDate(date.getDate() + delta);
+      else if (component === "week") date.setDate(date.getDate() + delta * 7);
+      else if (component === "month") date.setMonth(date.getMonth() + delta);
+      else if (component === "year") date.setFullYear(date.getFullYear() + delta);
+      else return null;
+      return date;
+    }
+
     var evaluateActionDateIsInThePast = (task, dateField, value) => {
       const fieldDate = getTaskDateField(task, dateField);
       if (!fieldDate) return false;
@@ -301,20 +349,8 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return fieldDate <= now;
       }
 
-      const cutoff = new Date();
-      if (relativeComponent === "hour") {
-        cutoff.setHours(cutoff.getHours() - relativeBeforeAmount);
-      } else if (relativeComponent === "day") {
-        cutoff.setDate(cutoff.getDate() - relativeBeforeAmount);
-      } else if (relativeComponent === "week") {
-        cutoff.setDate(cutoff.getDate() - relativeBeforeAmount * 7);
-      } else if (relativeComponent === "month") {
-        cutoff.setMonth(cutoff.getMonth() - relativeBeforeAmount);
-      } else if (relativeComponent === "year") {
-        cutoff.setFullYear(cutoff.getFullYear() - relativeBeforeAmount);
-      } else {
-        return fieldDate <= now;
-      }
+      const cutoff = applyRelativeOffset(new Date(), relativeBeforeAmount, relativeComponent, -1);
+      if (!cutoff) return fieldDate <= now;
       return fieldDate >= cutoff && fieldDate <= now;
     };
 
@@ -337,20 +373,8 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return fieldDate >= now;
       }
 
-      const cutoff = new Date();
-      if (relativeComponent === "hour") {
-        cutoff.setHours(cutoff.getHours() + relativeAfterAmount);
-      } else if (relativeComponent === "day") {
-        cutoff.setDate(cutoff.getDate() + relativeAfterAmount);
-      } else if (relativeComponent === "week") {
-        cutoff.setDate(cutoff.getDate() + relativeAfterAmount * 7);
-      } else if (relativeComponent === "month") {
-        cutoff.setMonth(cutoff.getMonth() + relativeAfterAmount);
-      } else if (relativeComponent === "year") {
-        cutoff.setFullYear(cutoff.getFullYear() + relativeAfterAmount);
-      } else {
-        return fieldDate >= now;
-      }
+      const cutoff = applyRelativeOffset(new Date(), relativeAfterAmount, relativeComponent, 1);
+      if (!cutoff) return fieldDate >= now;
       return fieldDate <= cutoff && fieldDate >= now;
     };
 

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -220,8 +220,16 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     var evaluateActionHasProjectWithStatus = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
+      // Project is not an ActiveObject and exposes no effective status, so a
+      // project inside a dropped folder keeps status:Active. Fold the folder
+      // chain in by hand — consistently, not just for stalled/pending.
+      const folderDropped = isAncestorFolderDropped(project);
       if (value === "remaining") {
-        return !project.completed && project.status !== Project.Status.Dropped;
+        return (
+          !project.completed &&
+          project.status !== Project.Status.Dropped &&
+          !folderDropped
+        );
       }
       if (value === "stalled") {
         return isProjectStalled(project);
@@ -230,16 +238,20 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         const deferDate = project.effectiveDeferDate;
         return (
           project.status === Project.Status.Active &&
-          !isAncestorFolderDropped(project) &&
+          !folderDropped &&
           deferDate !== null &&
           deferDate > new Date()
         );
       }
+      if (value === "dropped") {
+        return project.status === Project.Status.Dropped || folderDropped;
+      }
+      if (value === "active") {
+        return project.status === Project.Status.Active && !folderDropped;
+      }
       const statusMap = {
-        active: Project.Status.Active,
         onHold: Project.Status.OnHold,
         completed: Project.Status.Done,
-        dropped: Project.Status.Dropped,
       };
       return project.status === statusMap[value];
     };


### PR DESCRIPTION
## Summary

Several evaluators in the custom-perspective rule engine (from PR #13) call OmniJS properties that never existed — verified against `app.getTypeScriptDeclarations()` and confirmed by live probing against a real database, not a version-drift issue.

- **`evaluateActionHasTagWithStatus`** used `tag.effectivelyDropped`/`effectivelyActive`/`effectivelyOnHold`, none of which exist on `Tag`. `"remaining"` always evaluated `true`, the rest always `false`. Fixed to compare the real `tag.status` against `Tag.Status`.
- **`evaluateActionHasProjectWithStatus`** used `project.effectivelyCompleted`/`effectivelyDropped` (same failure mode), and mapped `"stalled"`/`"pending"` to `Project.Status.Stalled`/`.Pending`, which don't exist (the real enum only has `Active`/`Done`/`Dropped`/`OnHold`). Replaced with `project.completed`/`project.status` for `remaining`/`completed`/`dropped`, and computed conditions for `stalled`/`pending` per OmniGroup's glossary (unchanged from 4.3.3 through 4.8.11):
  - `stalled` = active project with remaining tasks, none currently actionable
  - `pending` = active project with a future `effectiveDeferDate`

  The literal "has no remaining actions at all" glossary wording was tried first but produces a self-contradictory rule once paired with the `{actionAvailability: "remaining"}` condition every real perspective ANDs it with — a task can't be "remaining" while its own project has zero remaining tasks (it would be one). Verified live: that reading matched 25 mostly-empty placeholder projects, while the reading above matches the 3 real in-progress projects the paired rule implies.
- **`evaluateActionIsInSingleActionsList`** compared `project.status` to `Project.Status.SingleActions`, which also doesn't exist. Replaced with the real `project.containsSingletonActions` boolean.
- **`getTaskDateField`** assumed every perspective date field name plus `"Date"` is a real property. True for `due`/`defer`/`completed`, false for `dropped` (`dropDate`, not `droppedDate`) and `added`/`changed` (`added`/`modified`, no suffix at all) — those three silently matched nothing. Replaced the suffix concatenation with an explicit field→property map.
- Added the documented but unimplemented `actionDateIsInTheNext` rule and `"hour"` `relativeComponent`, both listed at [omni-automation.com/omnifocus/perspective.html](https://omni-automation.com/omnifocus/perspective.html) but previously missing (silently falling through to a non-match recorded only in `debug.unknownRuleTypes`).

None of this stems from an OmniFocus version change — every one of these predates any OmniFocus update this server has tracked. They were present in PR #13's very first commit and untouched by its later bugfix pass (#101/7ae7258).

## Test plan

- [x] `npm run build` (tsc clean)
- [x] `npx vitest run` — 28 files, 565 tests passing (no test coverage existed for this file previously — it's a plain JXA script with no unit-test harness, so verification here is live-empirical)
- [x] Live-verified against a real OmniFocus 4.9 database: all 13 custom perspectives on the account return correct, non-empty (where expected) results with no `unknownRuleTypes`, including "Stalled" which was previously always empty and now correctly surfaces 3 real stalled projects, cross-checked against an independent live query for the same condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)