### PR TITLE
Exclude container-dropped projects, folders, and tags from listings

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -595,6 +595,30 @@ describe('formatProjects - status guard (#106)', () => {
   });
 });
 
+describe('generateQueryScript - container-dropped projects', () => {
+  const { generateQueryScript } = primitives;
+
+  it('rejects projects whose containing folder is dropped or under a dropped folder', () => {
+    const script = generateQueryScript({ entity: 'projects', filters: {} });
+    // Set seeded by walking DOWN from every folder whose OWN status is Dropped.
+    expect(script).toContain('Folder.Status.Dropped');
+    expect(script).toContain('collectDescendantFolderIds(flattenedFolders');
+    expect(script).toMatch(/_droppedFolderIds\.has\(\s*project\.parentFolder\.id\.primaryKey\s*\)/);
+    expect(script).toContain('isInDroppedFolder(item)');
+  });
+
+  it('does NOT rely on an upward folder.parentFolder walk (unreliable when flattened)', () => {
+    const script = generateQueryScript({ entity: 'projects', filters: {} });
+    expect(script).not.toContain('isAncestorFolderDropped');
+    expect(script).not.toMatch(/folder\s*=\s*folder\.parentFolder/);
+  });
+
+  it('applies the same exclusion to a folders query', () => {
+    const script = generateQueryScript({ entity: 'folders', filters: {} });
+    expect(script).toMatch(/_droppedFolderIds\.has\(item\.id\.primaryKey\)/);
+  });
+});
+
 describe('formatQueryResults - no argument echo (#106)', () => {
   it('opens with a bare count line, not a markdown header', () => {
     const output = formatQueryResults([{ name: 'Task', id: 't1' }], 'tasks');

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -236,15 +236,28 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
         }
       }
 
-      // Check if any ancestor folder is dropped.
-      // OmniJS doesn't expose effectivelyDropped on projects, so we walk up manually.
-      function isAncestorFolderDropped(project) {
-        var folder = project.parentFolder;
-        while (folder) {
-          if (folder.status === Folder.Status.Dropped) return true;
-          folder = folder.parentFolder;
+      // Set of every folder ID that is dropped, or nested anywhere under a
+      // dropped folder. Two OmniJS quirks make the obvious upward walk wrong:
+      //   1. folder.status is the folder's OWN status — a folder that is
+      //      "dropped with container" still reports Active.
+      //   2. folder.parentFolder is unreliable on the flattened collection, so
+      //      walking up from a project stops at its own folder and never sees a
+      //      dropped grandparent.
+      // Walking DOWN from each dropped folder via .folders (the reliable pattern
+      // collectDescendantFolderIds already uses for folder scoping) avoids both.
+      const _droppedFolderIds = new Set();
+      for (var _dfi = 0; _dfi < flattenedFolders.length; _dfi++) {
+        if (flattenedFolders[_dfi].status === Folder.Status.Dropped) {
+          collectDescendantFolderIds(flattenedFolders[_dfi], _droppedFolderIds);
         }
-        return false;
+      }
+
+      // A project whose own status is still Active is nonetheless effectively
+      // dropped when its containing folder is dropped or sits under one.
+      function isInDroppedFolder(project) {
+        return project.parentFolder
+          ? _droppedFolderIds.has(project.parentFolder.id.primaryKey)
+          : false;
       }
 
       // Get the appropriate collection based on entity type
@@ -293,7 +306,11 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
           } else if (entityType === "projects") {
             if (item.status === Project.Status.Done ||
                 item.status === Project.Status.Dropped ||
-                isAncestorFolderDropped(item)) {
+                isInDroppedFolder(item)) {
+              return false;
+            }
+          } else if (entityType === "folders") {
+            if (_droppedFolderIds.has(item.id.primaryKey)) {
               return false;
             }
           }

--- a/src/utils/omnifocusScripts/listTags.js
+++ b/src/utils/omnifocusScripts/listTags.js
@@ -14,6 +14,15 @@
         const tagId = tag.id.primaryKey;
         const parentTagID = tag.parent ? tag.parent.id.primaryKey : null;
 
+        // `tag.active` is the tag's OWN flag: a tag nested under a dropped or
+        // on-hold parent still reports active:true, so it leaks into the default
+        // (non-dropped) listing. `tag.effectiveActive` folds in ancestor status
+        // the way OmniFocus does in the sidebar. Fall back to `tag.active` only
+        // if the effective flag is somehow unavailable.
+        const effectiveActive = typeof tag.effectiveActive === "boolean"
+          ? tag.effectiveActive
+          : tag.active;
+
         // Count remaining (non-completed, non-dropped) tasks for this tag
         let taskCount = 0;
         try {
@@ -35,7 +44,7 @@
           name: tag.name,
           parentTagID: parentTagID,
           parentName: parentTagID ? (parentNameMap[parentTagID] || null) : null,
-          active: tag.active,
+          active: effectiveActive,
           allowsNextAction: tag.allowsNextAction,
           taskCount: taskCount
         });


### PR DESCRIPTION
Two instances of the same bug: the MCP reads an item's **own** status flag and ignores status inherited from a dropped/on-hold container.

## 1. Container-dropped projects & folders (`query_omnifocus`)

A project inside a folder dropped **with container** keeps coming back as `Active`, matches an explicit `status: ["Active"]` filter, and shows up under `reviewDue: true`.

Root cause: `isAncestorFolderDropped()` walked **up** the folder chain, which fails on two OmniJS quirks — `folder.status` reports the folder's *own* status (a dropped-with-container folder still reads `Active`), and `folder.parentFolder` is unreliable on the flattened collection so the walk never reached a dropped grandparent.

Fix: walk **down** from every folder whose own status is `Dropped` (via `.folders`, the same traversal `collectDescendantFolderIds` already uses), and treat a project as dropped when its containing folder is in that set. Same exclusion applied to the `folders` entity. `includeCompleted: true` still surfaces everything.

## 2. Container-dropped tags (`list_tags`)

`list_tags` read `tag.active`, a tag's **own** flag. A tag nested under a dropped or on-hold parent still reports `active: true`, so the default listing includes the whole subtree of archived tag groups.

Fix: read `tag.effectiveActive` instead (folds in ancestor status like the OmniFocus sidebar), falling back to `tag.active` only if unavailable.

## Verification (live database)

| | before | after |
|---|---|---|
| active projects | 26 | 21 |
| default folder list | 28 | 6 |
| `list_tags` default | 75 | 23 |

`includeCompleted` / `includeDropped` still return the full set. `npx vitest run` passes, plus 3 new tests for the project/folder case.

## Note (not addressed here)

`generateFilterConditions` has no `folders` branch, so every filter on `entity: "folders"` (`status`, date filters) is silently a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)