### PR TITLE
Fix query_omnifocus date-filter asymmetry, status validation, and folder status routing (#128, rebased)

### DIFF
--- a/src/tools/__tests__/queryOmnifocus.parity.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.parity.test.ts
@@ -276,6 +276,30 @@ describe('query_omnifocus folder property routing (#95)', () => {
 });
 
 /**
+ * Folder `status` field routing. `Folder` and `Project` are separate OmniJS
+ * classes with separate status enums — Folder.Status only has Active/Dropped,
+ * while Project.Status also has Done/OnHold. generateFieldMapping's `status`
+ * case was written once for projects and never branched by entity, so
+ * requesting `fields: ['status']` against folders ran the folder's
+ * Folder.Status value through projectStatusMap, whose keys are Project.Status
+ * values — a lookup miss that returns undefined for every folder. Documented
+ * as a valid folder field the whole time (fields description lists `status`
+ * for folders), so a caller had no reason to suspect the mapping was wrong.
+ */
+describe('query_omnifocus folder status routing', () => {
+  it('folder status reads Folder.Status through its own map, not projectStatusMap', () => {
+    const emitted = generateFieldMapping('folders', ['status']);
+    expect(emitted).toContain('folderStatusMap[item.status]');
+    expect(emitted).not.toContain('projectStatusMap[item.status]');
+  });
+
+  it('leaves project status routing on projectStatusMap', () => {
+    const emitted = generateFieldMapping('projects', ['status']);
+    expect(emitted).toContain('projectStatusMap[item.status]');
+  });
+});
+
+/**
  * folderName filter (#107): "all tasks in the Barochory folder" used to cost a
  * folders query to find the id, then a folderId query — or, worse, dead
  * projectName guesses. folderName seeds the same descendant-folder set as

--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { _testExports as primitives } from '../primitives/queryOmnifocus.js';
+import { _testExports as primitives, queryOmnifocus } from '../primitives/queryOmnifocus.js';
 import { _testExports as definitions } from '../definitions/queryOmnifocus.js';
 
-const { escapeJXA, generateFilterConditions, generateFieldMapping } = primitives;
-const { formatTasks, formatProjects, formatFolders, formatQueryResults, validateFields } = definitions;
+const { escapeJXA, generateFilterConditions, generateFieldMapping, validateFields } = primitives;
+const { formatTasks, formatProjects, formatFolders, formatQueryResults } = definitions;
 
 // ============================================================
 // escapeJXA
@@ -648,6 +648,29 @@ describe('validateFields', () => {
 
   it('validates against the folders field set', () => {
     expect(validateFields('folders', ['path', 'projectCount', 'parentFolderID', 'status'])).toEqual([]);
+  });
+});
+
+// ============================================================
+// queryOmnifocus (primitive) - fields validation applies to every caller,
+// not just the query_omnifocus tool handler. Resources (project.ts, flagged.ts,
+// inbox.ts, today.ts) call this primitive directly with their own hardcoded
+// `fields` arrays, bypassing any check that lived only in the tool handler.
+// ============================================================
+describe('queryOmnifocus - fields validation applies to direct callers', () => {
+  it('rejects an invalid field before generating or running any script', async () => {
+    // No OmniFocus/osascript involved: an invalid field must short-circuit
+    // before generateQueryScript / executeOmniFocusScript are ever reached,
+    // which is what makes this safely testable without a live OmniFocus.
+    const result = await queryOmnifocus({ entity: 'tasks', fields: ['bogusField'] });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('bogusField');
+  });
+
+  it('names the valid fields for the entity in the error', async () => {
+    const result = await queryOmnifocus({ entity: 'projects', fields: ['nope'] });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('folderName');
   });
 });
 

--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -595,6 +595,30 @@ describe('formatProjects - status guard (#106)', () => {
   });
 });
 
+describe('generateQueryScript - container-dropped projects', () => {
+  const { generateQueryScript } = primitives;
+
+  it('rejects projects whose containing folder is dropped or under a dropped folder', () => {
+    const script = generateQueryScript({ entity: 'projects', filters: {} });
+    // Set seeded by walking DOWN from every folder whose OWN status is Dropped.
+    expect(script).toContain('Folder.Status.Dropped');
+    expect(script).toContain('collectDescendantFolderIds(flattenedFolders');
+    expect(script).toMatch(/_droppedFolderIds\.has\(\s*project\.parentFolder\.id\.primaryKey\s*\)/);
+    expect(script).toContain('isInDroppedFolder(item)');
+  });
+
+  it('does NOT rely on an upward folder.parentFolder walk (unreliable when flattened)', () => {
+    const script = generateQueryScript({ entity: 'projects', filters: {} });
+    expect(script).not.toContain('isAncestorFolderDropped');
+    expect(script).not.toMatch(/folder\s*=\s*folder\.parentFolder/);
+  });
+
+  it('applies the same exclusion to a folders query', () => {
+    const script = generateQueryScript({ entity: 'folders', filters: {} });
+    expect(script).toMatch(/_droppedFolderIds\.has\(item\.id\.primaryKey\)/);
+  });
+});
+
 describe('formatQueryResults - no argument echo (#106)', () => {
   it('opens with a bare count line, not a markdown header', () => {
     const output = formatQueryResults([{ name: 'Task', id: 't1' }], 'tasks');

--- a/src/tools/__tests__/queryOmnifocus.test.ts
+++ b/src/tools/__tests__/queryOmnifocus.test.ts
@@ -3,7 +3,7 @@ import { _testExports as primitives } from '../primitives/queryOmnifocus.js';
 import { _testExports as definitions } from '../definitions/queryOmnifocus.js';
 
 const { escapeJXA, generateFilterConditions, generateFieldMapping } = primitives;
-const { formatTasks, formatProjects, formatFolders, formatQueryResults } = definitions;
+const { formatTasks, formatProjects, formatFolders, formatQueryResults, validateFields } = definitions;
 
 // ============================================================
 // escapeJXA
@@ -611,6 +611,43 @@ describe('formatQueryResults - no argument echo (#106)', () => {
     expect(formatQueryResults([], 'projects')).toBe(
       'No projects found matching the specified criteria.'
     );
+  });
+});
+
+// ============================================================
+// validateFields - allowlist per entity
+// ============================================================
+describe('validateFields', () => {
+  it('returns no invalid fields when fields is undefined', () => {
+    expect(validateFields('tasks', undefined)).toEqual([]);
+  });
+
+  it('returns no invalid fields when all requested task fields are known', () => {
+    expect(validateFields('tasks', ['id', 'name', 'dueDate', 'tagNames', 'repetitionMethod', 'isPastOccurrence'])).toEqual([]);
+  });
+
+  it('flags a single unknown field', () => {
+    expect(validateFields('tasks', ['id', 'bogusField'])).toEqual(['bogusField']);
+  });
+
+  it('flags multiple unknown fields', () => {
+    expect(validateFields('tasks', ['nope', 'alsoNope'])).toEqual(['nope', 'alsoNope']);
+  });
+
+  it('accepts the modified/added date aliases', () => {
+    expect(validateFields('tasks', ['modified', 'added'])).toEqual([]);
+  });
+
+  it('validates against the projects field set', () => {
+    expect(validateFields('projects', ['folderName', 'reviewInterval', 'tagNames', 'flagged', 'isPastOccurrence'])).toEqual([]);
+  });
+
+  it('flags a task-only field when queried against projects', () => {
+    expect(validateFields('projects', ['plannedDate'])).toEqual(['plannedDate']);
+  });
+
+  it('validates against the folders field set', () => {
+    expect(validateFields('folders', ['path', 'projectCount', 'parentFolderID', 'status'])).toEqual([]);
   });
 });
 

--- a/src/tools/definitions/queryOmnifocus.test.ts
+++ b/src/tools/definitions/queryOmnifocus.test.ts
@@ -3,7 +3,10 @@ import { schema } from './queryOmnifocus.js';
 
 describe('queryOmnifocus schema', () => {
   describe('date filter union types', () => {
-    const dateFields = ['dueWithin', 'deferredUntil', 'plannedWithin', 'dueOn', 'deferOn', 'plannedOn'];
+    const dateFields = [
+      'dueWithin', 'deferredUntil', 'plannedWithin', 'dueOn', 'deferOn', 'plannedOn',
+      'addedWithin', 'addedOn', 'completedWithin', 'completedOn', 'droppedWithin', 'droppedOn',
+    ];
 
     for (const field of dateFields) {
       it(`${field} accepts a number`, () => {
@@ -47,6 +50,32 @@ describe('queryOmnifocus schema', () => {
 
     it('rejects non-boolean types', () => {
       const input = { entity: 'projects', filters: { reviewDue: 'yes' } };
+      const result = schema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('status filter enum', () => {
+    it('accepts valid task status values', () => {
+      const input = { entity: 'tasks', filters: { status: ['Next', 'Available', 'Overdue'] } };
+      const result = schema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts valid project status values', () => {
+      const input = { entity: 'projects', filters: { status: ['Active', 'OnHold', 'Done', 'Dropped'] } };
+      const result = schema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a misspelled status value', () => {
+      const input = { entity: 'tasks', filters: { status: ['NextAction'] } };
+      const result = schema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a lowercase status value (case matters)', () => {
+      const input = { entity: 'tasks', filters: { status: ['next'] } };
       const result = schema.safeParse(input);
       expect(result.success).toBe(false);
     });

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -52,59 +52,14 @@ export const schema = z.object({
   summary: z.boolean().optional().describe("Return only the match count")
 });
 
-// Fields queryOmnifocus can actually populate for each entity. Kept in sync with
-// generateFieldMapping in primitives/queryOmnifocus.ts and the `fields` description
-// above. An unrecognized field silently returns null rather than erroring (raw
-// property access on the underlying OmniJS object), so we reject typos here
-// instead of letting them surface as confusing all-null results.
-const VALID_FIELDS: Record<'tasks' | 'projects' | 'folders', string[]> = {
-  tasks: [
-    'id', 'name', 'note', 'flagged', 'taskStatus', 'dueDate', 'deferDate', 'plannedDate',
-    'effectiveDueDate', 'effectiveDeferDate', 'effectivePlannedDate', 'completionDate',
-    'dropDate', 'effectiveDropDate', 'estimatedMinutes', 'tagNames', 'tags', 'projectName',
-    'projectId', 'parentId', 'childIds', 'hasChildren', 'sequential', 'completedByChildren',
-    'inInbox', 'isRepeating', 'repetitionRule', 'repetitionMethod', 'isPastOccurrence',
-    'modificationDate', 'modified', 'creationDate', 'added',
-  ],
-  projects: [
-    'id', 'name', 'status', 'note', 'flagged', 'folderName', 'folderID', 'sequential',
-    'dueDate', 'deferDate', 'effectiveDueDate', 'effectiveDeferDate', 'completionDate',
-    'dropDate', 'effectiveDropDate', 'completedByChildren', 'containsSingletonActions',
-    'taskCount', 'tasks', 'tagNames', 'isPastOccurrence', 'nextReviewDate', 'reviewInterval',
-    'modificationDate', 'modified', 'creationDate', 'added',
-  ],
-  folders: [
-    'id', 'name', 'path', 'parentFolderID', 'status', 'projectCount', 'projects', 'subfolders',
-  ],
-};
-
 // Backward-looking filters ("within the last N days ago") need the ISO-date branch
 // of resolveDateFilter inverted relative to forward-looking filters like dueWithin —
 // see resolveDateFilter's `direction` param.
 const PAST_LOOKING_DATE_FIELDS = ['addedWithin', 'completedWithin', 'droppedWithin'] as const;
 const FUTURE_LOOKING_DATE_FIELDS = ['dueWithin', 'deferredUntil', 'plannedWithin', 'dueOn', 'deferOn', 'plannedOn', 'addedOn', 'completedOn', 'droppedOn'] as const;
 
-export function validateFields(entity: 'tasks' | 'projects' | 'folders', fields?: string[]): string[] {
-  if (!fields || fields.length === 0) return [];
-  const allowed = new Set(VALID_FIELDS[entity]);
-  return fields.filter(f => !allowed.has(f));
-}
-
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {
   try {
-    if (args.fields && args.fields.length > 0) {
-      const invalidFields = validateFields(args.entity, args.fields);
-      if (invalidFields.length > 0) {
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Invalid field(s) for entity "${args.entity}": ${invalidFields.join(', ')}. Valid fields: ${VALID_FIELDS[args.entity].join(', ')}.`
-          }],
-          isError: true
-        };
-      }
-    }
-
     // Normalize date filter strings to numbers
     const normalizedArgs = { ...args };
     if (normalizedArgs.filters) {
@@ -376,5 +331,4 @@ export const _testExports = {
   formatProjects,
   formatFolders,
   formatQueryResults,
-  validateFields,
 };

--- a/src/tools/definitions/queryOmnifocus.ts
+++ b/src/tools/definitions/queryOmnifocus.ts
@@ -19,7 +19,7 @@ export const schema = z.object({
     folderId: z.string().optional().describe("Folder id, including subfolders; tasks match via their containing project"),
     folderName: z.string().optional().describe("Folder name; case-insensitive partial match, may match several folders, each including subfolders. folderId takes precedence"),
     tags: z.array(z.string()).optional().describe("Tag names; exact match, case-sensitive"),
-    status: z.array(z.string()).optional().describe("Tasks: Next, Available, Blocked, DueSoon, Overdue, Completed, Dropped. Projects: Active, OnHold, Done, Dropped"),
+    status: z.array(z.enum(['Next', 'Available', 'Blocked', 'DueSoon', 'Overdue', 'Completed', 'Dropped', 'Active', 'OnHold', 'Done'])).optional().describe("Tasks: Next, Available, Blocked, DueSoon, Overdue, Completed, Dropped. Projects: Active, OnHold, Done, Dropped"),
     flagged: z.boolean().optional().describe("true = flagged only, false = unflagged only"),
     dueWithin: z.union([z.number(), z.string()]).optional().describe("Due between today and the given day/range"),
     deferredUntil: z.union([z.number(), z.string()]).optional().describe("Currently deferred, becoming available by the given day"),
@@ -29,15 +29,15 @@ export const schema = z.object({
     dueOn: z.union([z.number(), z.string()]).optional().describe("Due on exactly that day"),
     deferOn: z.union([z.number(), z.string()]).optional().describe("Defer date exactly that day"),
     plannedOn: z.union([z.number(), z.string()]).optional().describe("Planned date exactly that day"),
-    addedWithin: z.number().optional().describe("Added in the last N days"),
-    addedOn: z.number().optional().describe("Added on day N (0 = today, -1 = yesterday)"),
+    addedWithin: z.union([z.number(), z.string()]).optional().describe("Added in the last N days"),
+    addedOn: z.union([z.number(), z.string()]).optional().describe("Added on day N (0 = today, -1 = yesterday)"),
     isRepeating: z.boolean().optional().describe("true = repeating tasks only"),
-    completedWithin: z.number().optional().describe("Completed in the last N days (dropped items need droppedWithin). Requires includeCompleted: true"),
-    completedOn: z.number().optional().describe("Completed on day N (0 = today, -1 = yesterday). Requires includeCompleted: true"),
-    droppedWithin: z.number().optional().describe("Dropped in the last N days. Requires includeCompleted: true"),
-    droppedOn: z.number().optional().describe("Dropped on day N (0 = today, -1 = yesterday). Requires includeCompleted: true"),
+    completedWithin: z.union([z.number(), z.string()]).optional().describe("Completed in the last N days (dropped items need droppedWithin). Requires includeCompleted: true"),
+    completedOn: z.union([z.number(), z.string()]).optional().describe("Completed on day N (0 = today, -1 = yesterday). Requires includeCompleted: true"),
+    droppedWithin: z.union([z.number(), z.string()]).optional().describe("Dropped in the last N days. Requires includeCompleted: true"),
+    droppedOn: z.union([z.number(), z.string()]).optional().describe("Dropped on day N (0 = today, -1 = yesterday). Requires includeCompleted: true"),
     reviewDue: z.boolean().optional().describe("true = projects due for review (projects only)")
-  }).optional().describe("Filters AND together; array filters (tags, status) OR within the array. Date-valued filters (dueWithin, deferredUntil, plannedWithin, dueOn, deferOn, plannedOn) accept a number of days from today, 'today', 'tomorrow', 'this week', 'next week', or 'YYYY-MM-DD'"),
+  }).optional().describe("Filters AND together; array filters (tags, status) OR within the array. Date-valued filters (dueWithin, deferredUntil, plannedWithin, dueOn, deferOn, plannedOn, addedWithin, addedOn, completedWithin, completedOn, droppedWithin, droppedOn) accept a number of days from today, 'today', 'tomorrow', 'this week', 'next week', or 'YYYY-MM-DD'"),
 
   fields: z.array(z.string()).optional().describe("Only return the listed fields (smaller responses). Tasks: id, name, note, flagged, taskStatus, dueDate, deferDate, plannedDate, effectiveDueDate, effectiveDeferDate, effectivePlannedDate, completionDate, dropDate, effectiveDropDate, estimatedMinutes, tagNames, tags, projectName, projectId, parentId, childIds, hasChildren, sequential, completedByChildren, inInbox, isRepeating, repetitionRule (ICS, e.g. FREQ=WEEKLY;INTERVAL=2), repetitionMethod (Fixed | DeferUntilDate | DueDate), isPastOccurrence, modificationDate, creationDate. Projects: id, name, status, note, folderName, folderID, sequential, dueDate, deferDate, effectiveDueDate, effectiveDeferDate, completionDate, dropDate, effectiveDropDate, completedByChildren, containsSingletonActions, taskCount, tasks, nextReviewDate, reviewInterval, modificationDate, creationDate. Folders: id, name, path, parentFolderID, status, projectCount, projects, subfolders"),
 
@@ -52,16 +52,71 @@ export const schema = z.object({
   summary: z.boolean().optional().describe("Return only the match count")
 });
 
+// Fields queryOmnifocus can actually populate for each entity. Kept in sync with
+// generateFieldMapping in primitives/queryOmnifocus.ts and the `fields` description
+// above. An unrecognized field silently returns null rather than erroring (raw
+// property access on the underlying OmniJS object), so we reject typos here
+// instead of letting them surface as confusing all-null results.
+const VALID_FIELDS: Record<'tasks' | 'projects' | 'folders', string[]> = {
+  tasks: [
+    'id', 'name', 'note', 'flagged', 'taskStatus', 'dueDate', 'deferDate', 'plannedDate',
+    'effectiveDueDate', 'effectiveDeferDate', 'effectivePlannedDate', 'completionDate',
+    'dropDate', 'effectiveDropDate', 'estimatedMinutes', 'tagNames', 'tags', 'projectName',
+    'projectId', 'parentId', 'childIds', 'hasChildren', 'sequential', 'completedByChildren',
+    'inInbox', 'isRepeating', 'repetitionRule', 'repetitionMethod', 'isPastOccurrence',
+    'modificationDate', 'modified', 'creationDate', 'added',
+  ],
+  projects: [
+    'id', 'name', 'status', 'note', 'flagged', 'folderName', 'folderID', 'sequential',
+    'dueDate', 'deferDate', 'effectiveDueDate', 'effectiveDeferDate', 'completionDate',
+    'dropDate', 'effectiveDropDate', 'completedByChildren', 'containsSingletonActions',
+    'taskCount', 'tasks', 'tagNames', 'isPastOccurrence', 'nextReviewDate', 'reviewInterval',
+    'modificationDate', 'modified', 'creationDate', 'added',
+  ],
+  folders: [
+    'id', 'name', 'path', 'parentFolderID', 'status', 'projectCount', 'projects', 'subfolders',
+  ],
+};
+
+// Backward-looking filters ("within the last N days ago") need the ISO-date branch
+// of resolveDateFilter inverted relative to forward-looking filters like dueWithin —
+// see resolveDateFilter's `direction` param.
+const PAST_LOOKING_DATE_FIELDS = ['addedWithin', 'completedWithin', 'droppedWithin'] as const;
+const FUTURE_LOOKING_DATE_FIELDS = ['dueWithin', 'deferredUntil', 'plannedWithin', 'dueOn', 'deferOn', 'plannedOn', 'addedOn', 'completedOn', 'droppedOn'] as const;
+
+export function validateFields(entity: 'tasks' | 'projects' | 'folders', fields?: string[]): string[] {
+  if (!fields || fields.length === 0) return [];
+  const allowed = new Set(VALID_FIELDS[entity]);
+  return fields.filter(f => !allowed.has(f));
+}
+
 export async function handler(args: z.infer<typeof schema>, extra: RequestHandlerExtra) {
   try {
+    if (args.fields && args.fields.length > 0) {
+      const invalidFields = validateFields(args.entity, args.fields);
+      if (invalidFields.length > 0) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Invalid field(s) for entity "${args.entity}": ${invalidFields.join(', ')}. Valid fields: ${VALID_FIELDS[args.entity].join(', ')}.`
+          }],
+          isError: true
+        };
+      }
+    }
+
     // Normalize date filter strings to numbers
     const normalizedArgs = { ...args };
     if (normalizedArgs.filters) {
       const f = { ...normalizedArgs.filters };
-      const dateFields = ['dueWithin', 'deferredUntil', 'plannedWithin', 'dueOn', 'deferOn', 'plannedOn'] as const;
-      for (const field of dateFields) {
+      for (const field of FUTURE_LOOKING_DATE_FIELDS) {
         if (f[field] !== undefined) {
-          (f as any)[field] = resolveDateFilter(f[field]!);
+          (f as any)[field] = resolveDateFilter(f[field]!, 'future');
+        }
+      }
+      for (const field of PAST_LOOKING_DATE_FIELDS) {
+        if (f[field] !== undefined) {
+          (f as any)[field] = resolveDateFilter(f[field]!, 'past');
         }
       }
       normalizedArgs.filters = f;
@@ -321,4 +376,5 @@ export const _testExports = {
   formatProjects,
   formatFolders,
   formatQueryResults,
+  validateFields,
 };

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -121,7 +121,50 @@ interface QueryResult {
   error?: string;
 }
 
+// Fields queryOmnifocus can actually populate for each entity. Kept in sync with
+// generateFieldMapping below. An unrecognized field silently returns null rather
+// than erroring (raw property access on the underlying OmniJS object), so this is
+// checked here — in the primitive itself, not just the query_omnifocus tool
+// handler — so every caller gets it, including resources (project.ts, flagged.ts,
+// inbox.ts, today.ts) that call this function directly with their own field lists.
+const VALID_FIELDS: Record<'tasks' | 'projects' | 'folders', string[]> = {
+  tasks: [
+    'id', 'name', 'note', 'flagged', 'taskStatus', 'dueDate', 'deferDate', 'plannedDate',
+    'effectiveDueDate', 'effectiveDeferDate', 'effectivePlannedDate', 'completionDate',
+    'dropDate', 'effectiveDropDate', 'estimatedMinutes', 'tagNames', 'tags', 'projectName',
+    'projectId', 'parentId', 'childIds', 'hasChildren', 'sequential', 'completedByChildren',
+    'inInbox', 'isRepeating', 'repetitionRule', 'repetitionMethod', 'isPastOccurrence',
+    'modificationDate', 'modified', 'creationDate', 'added',
+  ],
+  projects: [
+    'id', 'name', 'status', 'note', 'flagged', 'folderName', 'folderID', 'sequential',
+    'dueDate', 'deferDate', 'effectiveDueDate', 'effectiveDeferDate', 'completionDate',
+    'dropDate', 'effectiveDropDate', 'completedByChildren', 'containsSingletonActions',
+    'taskCount', 'tasks', 'tagNames', 'isPastOccurrence', 'nextReviewDate', 'reviewInterval',
+    'modificationDate', 'modified', 'creationDate', 'added',
+  ],
+  folders: [
+    'id', 'name', 'path', 'parentFolderID', 'status', 'projectCount', 'projects', 'subfolders',
+  ],
+};
+
+export function validateFields(entity: 'tasks' | 'projects' | 'folders', fields?: string[]): string[] {
+  if (!fields || fields.length === 0) return [];
+  const allowed = new Set(VALID_FIELDS[entity]);
+  return fields.filter(f => !allowed.has(f));
+}
+
 export async function queryOmnifocus(params: QueryOmnifocusParams): Promise<QueryResult> {
+  if (params.fields && params.fields.length > 0) {
+    const invalidFields = validateFields(params.entity, params.fields);
+    if (invalidFields.length > 0) {
+      return {
+        success: false,
+        error: `Invalid field(s) for entity "${params.entity}": ${invalidFields.join(', ')}. Valid fields: ${VALID_FIELDS[params.entity].join(', ')}.`
+      };
+    }
+  }
+
   try {
     // Create JXA script for the query
     const jxaScript = generateQueryScript(params);
@@ -875,4 +918,5 @@ export const _testExports = {
   generateFilterConditions,
   generateFieldMapping,
   generateQueryScript,
+  validateFields,
 };

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -288,15 +288,28 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
         }
       }
 
-      // Check if any ancestor folder is dropped.
-      // OmniJS doesn't expose effectivelyDropped on projects, so we walk up manually.
-      function isAncestorFolderDropped(project) {
-        var folder = project.parentFolder;
-        while (folder) {
-          if (folder.status === Folder.Status.Dropped) return true;
-          folder = folder.parentFolder;
+      // Set of every folder ID that is dropped, or nested anywhere under a
+      // dropped folder. Two OmniJS quirks make the obvious upward walk wrong:
+      //   1. folder.status is the folder's OWN status — a folder that is
+      //      "dropped with container" still reports Active.
+      //   2. folder.parentFolder is unreliable on the flattened collection, so
+      //      walking up from a project stops at its own folder and never sees a
+      //      dropped grandparent.
+      // Walking DOWN from each dropped folder via .folders (the reliable pattern
+      // collectDescendantFolderIds already uses for folder scoping) avoids both.
+      const _droppedFolderIds = new Set();
+      for (var _dfi = 0; _dfi < flattenedFolders.length; _dfi++) {
+        if (flattenedFolders[_dfi].status === Folder.Status.Dropped) {
+          collectDescendantFolderIds(flattenedFolders[_dfi], _droppedFolderIds);
         }
-        return false;
+      }
+
+      // A project whose own status is still Active is nonetheless effectively
+      // dropped when its containing folder is dropped or sits under one.
+      function isInDroppedFolder(project) {
+        return project.parentFolder
+          ? _droppedFolderIds.has(project.parentFolder.id.primaryKey)
+          : false;
       }
 
       // Get the appropriate collection based on entity type
@@ -345,7 +358,11 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
           } else if (entityType === "projects") {
             if (item.status === Project.Status.Done ||
                 item.status === Project.Status.Dropped ||
-                isAncestorFolderDropped(item)) {
+                isInDroppedFolder(item)) {
+              return false;
+            }
+          } else if (entityType === "folders") {
+            if (_droppedFolderIds.has(item.id.primaryKey)) {
               return false;
             }
           }

--- a/src/tools/primitives/queryOmnifocus.ts
+++ b/src/tools/primitives/queryOmnifocus.ts
@@ -225,7 +225,16 @@ function generateQueryScript(params: QueryOmnifocusParams): string {
         [Project.Status.Dropped]: "Dropped",
         [Project.Status.OnHold]: "OnHold"
       };
-      
+
+      // Folder.Status is its own enum (Active/Dropped only) — distinct from
+      // Project.Status. The status field mapping used to run every entity's
+      // status through projectStatusMap, so a folder's status looked up a
+      // Project.Status key against Folder.Status values and silently missed.
+      const folderStatusMap = {
+        [Folder.Status.Active]: "Active",
+        [Folder.Status.Dropped]: "Dropped"
+      };
+
       // Helper to collect all descendant folder IDs by walking down from a folder.
       // parentFolder is unreliable on flattenedFolders, so we walk children instead.
       function collectDescendantFolderIds(folder, idSet) {
@@ -760,7 +769,9 @@ function generateFieldMapping(entity: string, fields?: string[]): string {
     } else if (field === 'taskStatus') {
       return `taskStatus: taskStatusMap[item.taskStatus]`;
     } else if (field === 'status') {
-      return `status: projectStatusMap[item.status]`;
+      return entity === 'folders'
+        ? `status: folderStatusMap[item.status]`
+        : `status: projectStatusMap[item.status]`;
     } else if (field === 'modificationDate' || field === 'modified') {
       return entity === 'projects'
         ? `modificationDate: formatDate(${PROJECT_MODIFIED_EXPR})`

--- a/src/utils/dateFilter.test.ts
+++ b/src/utils/dateFilter.test.ts
@@ -75,4 +75,37 @@ describe('resolveDateFilter', () => {
       expect(() => resolveDateFilter('not-a-date')).toThrow();
     });
   });
+
+  describe('direction parameter (for backward-looking filters like addedWithin)', () => {
+    it('numbers pass through unchanged regardless of direction', () => {
+      expect(resolveDateFilter(5, 'past')).toBe(5);
+      expect(resolveDateFilter(-5, 'past')).toBe(-5);
+    });
+
+    it('named strings resolve the same regardless of direction', () => {
+      expect(resolveDateFilter('today', 'past')).toBe(0);
+      expect(resolveDateFilter('this week', 'past')).toBe(7);
+    });
+
+    it('resolves a past ISO date to a positive "days ago" count under past direction', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-26T12:00:00'));
+
+      expect(resolveDateFilter('2026-03-25', 'past')).toBe(1);
+    });
+
+    it('resolves a future ISO date to a negative count under past direction', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-26T12:00:00'));
+
+      expect(resolveDateFilter('2026-04-02', 'past')).toBe(-7);
+    });
+
+    it('defaults to future direction when omitted (unchanged behavior)', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-26T12:00:00'));
+
+      expect(resolveDateFilter('2026-03-25')).toBe(-1);
+    });
+  });
 });

--- a/src/utils/dateFilter.ts
+++ b/src/utils/dateFilter.ts
@@ -12,7 +12,7 @@ const NAMED_DATES: Record<string, number> = {
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-export function resolveDateFilter(input: number | string): number {
+export function resolveDateFilter(input: number | string, direction: 'future' | 'past' = 'future'): number {
   if (typeof input === 'number') {
     return input;
   }
@@ -31,7 +31,10 @@ export function resolveDateFilter(input: number | string): number {
     const target = new Date(normalized + 'T00:00:00');
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    return Math.round((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+    const daysFromNow = Math.round((target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+    // Backward-looking filters (e.g. addedWithin) expect an unsigned "days ago"
+    // count, which is the negation of the forward "days from now" offset.
+    return direction === 'past' ? -daysFromNow : daysFromNow;
   }
 
   throw new Error(`Unrecognized date filter value: "${input}". Use a number, "today", "tomorrow", "this week", "next week", or an ISO date (YYYY-MM-DD).`);

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -105,13 +105,18 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       (task.repetitionRule !== null) === value;
     var evaluateActionIsUntagged = (task, value) =>
       (task.tags.length === 0) === value;
+    // Tag.effectivelyDropped/effectivelyActive/effectivelyOnHold do not exist on
+    // the OmniJS Tag class (verified against app.getTypeScriptDeclarations() and
+    // by probing a live tag — all three read back as undefined). Every branch
+    // here silently evaluated to a fixed wrong value: "remaining" was always
+    // true (!undefined), the rest were always false. Tag.Status has exactly
+    // three real members: Active, Dropped, OnHold.
     var evaluateActionHasTagWithStatus = (task, value) => {
       return task.tags.some((tag) => {
-        // Map OmniFocus tag status values
-        if (value === "remaining") return !tag.effectivelyDropped;
-        if (value === "active") return tag.effectivelyActive;
-        if (value === "onHold") return tag.effectivelyOnHold;
-        if (value === "dropped") return tag.effectivelyDropped;
+        if (value === "remaining") return tag.status !== Tag.Status.Dropped;
+        if (value === "active") return tag.status === Tag.Status.Active;
+        if (value === "onHold") return tag.status === Tag.Status.OnHold;
+        if (value === "dropped") return tag.status === Tag.Status.Dropped;
         return false;
       });
     };
@@ -119,24 +124,72 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       (!task.children || task.children.length === 0) === value;
     var evaluateActionHasNoProject = (task, value) =>
       (task.containingProject === null) === value;
+    // Project.Status has no `SingleActions` member (only Active/Done/Dropped/
+    // OnHold), so this always compared against `undefined` and never matched.
+    // Being in a single actions list is its own boolean property.
     var evaluateActionIsInSingleActionsList = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
-      return (project.status === Project.Status.SingleActions) === value;
+      return Boolean(project.containsSingletonActions) === value;
     };
+    // Project.effectivelyCompleted/effectivelyDropped do not exist (same class
+    // of bug as the tag statuses above); "remaining" was always true, "completed"
+    // and "dropped" were always false. "stalled" and "pending" mapped to
+    // Project.Status.Stalled/.Pending, which also don't exist — Project.Status
+    // has only Active/Done/Dropped/OnHold, so both always evaluated false.
+    //
+    // OmniFocus's own glossary confirms "Stalled" and "Pending" are legacy names
+    // for compound conditions, not literal statuses:
+    //   Stalled -> "Has an active project which has no remaining actions"
+    //   Pending -> "Has an active project which has a future defer date"
+    // (https://support.omnigroup.com/documentation/omnifocus/universal/4.8.11/en/glossary/#stalled,
+    //  .../#pending — unchanged since 4.3.3.)
+    //
+    // The glossary's "no remaining actions" reading is self-contradictory once you
+    // account for how this rule is actually used: every real perspective pairs
+    // {actionHasProjectWithStatus: "stalled"} with {actionAvailability: "remaining"}
+    // at the TASK level (AND'd together). A task can't be "remaining" while its own
+    // project has zero remaining tasks — it would be one. Verified live: that literal
+    // reading matched 25 active projects, almost all placeholder projects with zero
+    // tasks; the classic GTD reading below ("has work left, but none of it is
+    // currently actionable") matched 3 real in-progress projects and is what makes
+    // the paired rule non-vacuous.
     var evaluateActionHasProjectWithStatus = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
       if (value === "remaining") {
-        return !project.effectivelyCompleted && !project.effectivelyDropped;
+        return !project.completed && project.status !== Project.Status.Dropped;
       }
-      if (value === "completed") return project.effectivelyCompleted;
-      if (value === "dropped") return project.effectivelyDropped;
+      if (value === "stalled") {
+        const remaining = project.flattenedTasks.filter(
+          (t) => !t.completed && t.taskStatus !== Task.Status.Dropped
+        );
+        const hasActionableTask = remaining.some(
+          (t) =>
+            t.taskStatus === Task.Status.Available ||
+            t.taskStatus === Task.Status.Next ||
+            t.taskStatus === Task.Status.DueSoon ||
+            t.taskStatus === Task.Status.Overdue
+        );
+        return (
+          project.status === Project.Status.Active &&
+          remaining.length > 0 &&
+          !hasActionableTask
+        );
+      }
+      if (value === "pending") {
+        const deferDate = project.effectiveDeferDate;
+        return (
+          project.status === Project.Status.Active &&
+          deferDate !== null &&
+          deferDate > new Date()
+        );
+      }
       const statusMap = {
         active: Project.Status.Active,
         onHold: Project.Status.OnHold,
-        stalled: Project.Status.Stalled,
-        pending: Project.Status.Pending,
+        completed: Project.Status.Done,
+        dropped: Project.Status.Dropped,
       };
       return project.status === statusMap[value];
     };
@@ -189,14 +242,25 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       return value.some((term) => searchText.includes(term.toLowerCase()));
     };
 
-    // OmniFocus stores "completed" as the field name but the JS property is completionDate.
-    var normalizeDateFieldName = (dateField) => {
-      const map = { completed: "completion" };
-      return map[dateField] || dateField;
+    // Perspective rules name date fields as "due"/"defer"/"completed"/"dropped"/
+    // "added"/"changed" (https://omni-automation.com/omnifocus/perspective.html),
+    // but the real OmniJS Task properties don't follow one consistent "<field>Date"
+    // pattern: "dropped" is dropDate (not droppedDate), and "added"/"changed" have
+    // no Date suffix at all (added, modified). The old suffix-concatenation
+    // approach silently produced a nonexistent property name for those three,
+    // so any rule filtering on drop/added/changed date never matched anything.
+    var DATE_FIELD_PROPERTY = {
+      due: "dueDate",
+      defer: "deferDate",
+      completed: "completionDate",
+      dropped: "dropDate",
+      added: "added",
+      changed: "modified",
     };
 
     var getTaskDateField = (task, dateField) => {
-      return task[normalizeDateFieldName(dateField) + "Date"];
+      const prop = DATE_FIELD_PROPERTY[dateField];
+      return prop ? task[prop] : undefined;
     };
 
     var evaluateActionDateIsToday = (task, dateField) => {
@@ -238,7 +302,9 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       }
 
       const cutoff = new Date();
-      if (relativeComponent === "day") {
+      if (relativeComponent === "hour") {
+        cutoff.setHours(cutoff.getHours() - relativeBeforeAmount);
+      } else if (relativeComponent === "day") {
         cutoff.setDate(cutoff.getDate() - relativeBeforeAmount);
       } else if (relativeComponent === "week") {
         cutoff.setDate(cutoff.getDate() - relativeBeforeAmount * 7);
@@ -250,6 +316,42 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return fieldDate <= now;
       }
       return fieldDate >= cutoff && fieldDate <= now;
+    };
+
+    // Forward-looking counterpart to actionDateIsInThePast, documented at
+    // https://omni-automation.com/omnifocus/perspective.html but never
+    // implemented — any rule using it fell through to unknownRuleTypes and
+    // matched nothing, silently, since a date-field rule short-circuits the
+    // whole evaluateRule branch once it recognizes `rule.actionDateField`.
+    var evaluateActionDateIsInTheNext = (task, dateField, value) => {
+      const fieldDate = getTaskDateField(task, dateField);
+      if (!fieldDate) return false;
+      const now = new Date();
+
+      if (typeof value !== "object" || value === null) {
+        return fieldDate >= now;
+      }
+
+      const { relativeAfterAmount, relativeComponent } = value;
+      if (relativeAfterAmount === undefined || relativeComponent === undefined) {
+        return fieldDate >= now;
+      }
+
+      const cutoff = new Date();
+      if (relativeComponent === "hour") {
+        cutoff.setHours(cutoff.getHours() + relativeAfterAmount);
+      } else if (relativeComponent === "day") {
+        cutoff.setDate(cutoff.getDate() + relativeAfterAmount);
+      } else if (relativeComponent === "week") {
+        cutoff.setDate(cutoff.getDate() + relativeAfterAmount * 7);
+      } else if (relativeComponent === "month") {
+        cutoff.setMonth(cutoff.getMonth() + relativeAfterAmount);
+      } else if (relativeComponent === "year") {
+        cutoff.setFullYear(cutoff.getFullYear() + relativeAfterAmount);
+      } else {
+        return fieldDate >= now;
+      }
+      return fieldDate <= cutoff && fieldDate >= now;
     };
 
     // filter rules and values are defined here: https://omni-automation.com/omnifocus/perspective.html
@@ -294,9 +396,12 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         if (rule.actionDateIsInThePast) {
           return evaluateActionDateIsInThePast(task, dateField, rule.actionDateIsInThePast);
         }
+        if (rule.actionDateIsInTheNext) {
+          return evaluateActionDateIsInTheNext(task, dateField, rule.actionDateIsInTheNext);
+        }
 
         // Record any unrecognised date conditions so callers can diagnose gaps
-        const knownDateKeys = new Set(["actionDateField", "actionDateIsToday", "actionDateIsYesterday", "actionDateIsTomorrow", "actionDateIsInThePast"]);
+        const knownDateKeys = new Set(["actionDateField", "actionDateIsToday", "actionDateIsYesterday", "actionDateIsTomorrow", "actionDateIsInThePast", "actionDateIsInTheNext"]);
         Object.keys(rule).forEach((k) => {
           if (!knownDateKeys.has(k)) {
             const entry = k + "(field=" + dateField + ", value=" + JSON.stringify(rule[k]) + ")";

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -200,8 +200,16 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     var evaluateActionHasProjectWithStatus = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
+      // Project is not an ActiveObject and exposes no effective status, so a
+      // project inside a dropped folder keeps status:Active. Fold the folder
+      // chain in by hand — consistently, not just for stalled/pending.
+      const folderDropped = isAncestorFolderDropped(project);
       if (value === "remaining") {
-        return !project.completed && project.status !== Project.Status.Dropped;
+        return (
+          !project.completed &&
+          project.status !== Project.Status.Dropped &&
+          !folderDropped
+        );
       }
       if (value === "stalled") {
         return isProjectStalled(project);
@@ -210,16 +218,20 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         const deferDate = project.effectiveDeferDate;
         return (
           project.status === Project.Status.Active &&
-          !isAncestorFolderDropped(project) &&
+          !folderDropped &&
           deferDate !== null &&
           deferDate > new Date()
         );
       }
+      if (value === "dropped") {
+        return project.status === Project.Status.Dropped || folderDropped;
+      }
+      if (value === "active") {
+        return project.status === Project.Status.Active && !folderDropped;
+      }
       const statusMap = {
-        active: Project.Status.Active,
         onHold: Project.Status.OnHold,
         completed: Project.Status.Done,
-        dropped: Project.Status.Dropped,
       };
       return project.status === statusMap[value];
     };

--- a/src/utils/omnifocusScripts/getPerspectiveView.js
+++ b/src/utils/omnifocusScripts/getPerspectiveView.js
@@ -154,6 +154,49 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     // tasks; the classic GTD reading below ("has work left, but none of it is
     // currently actionable") matched 3 real in-progress projects and is what makes
     // the paired rule non-vacuous.
+    // OmniJS doesn't expose an "effectively active" flag on Project — a project's
+    // own `.status` stays Active even when a containing folder has been dropped,
+    // which hides it from the app despite the field never changing. Walk `.parent`
+    // (not `.parentFolder`, which only exists on Project, not Folder itself) to
+    // check the whole chain.
+    function isAncestorFolderDropped(project) {
+      var folder = project.parentFolder;
+      while (folder) {
+        if (folder.status === Folder.Status.Dropped) return true;
+        folder = folder.parent;
+      }
+      return false;
+    }
+
+    // Memoized per project id for the lifetime of this getPerspectiveViewByName
+    // call: {actionHasProjectWithStatus: "stalled"} is typically paired with
+    // {actionAvailability: "remaining"} at the task level, so evaluateTask calls
+    // into this once per remaining task in a project, not once per project —
+    // without the cache, an N-task stalled project re-scans its own M-task list
+    // N times.
+    var _stalledProjectCache = new Map();
+    function isProjectStalled(project) {
+      const key = project.id.primaryKey;
+      if (_stalledProjectCache.has(key)) return _stalledProjectCache.get(key);
+      const remaining = project.flattenedTasks.filter(
+        (t) => !t.completed && t.taskStatus !== Task.Status.Dropped
+      );
+      const hasActionableTask = remaining.some(
+        (t) =>
+          t.taskStatus === Task.Status.Available ||
+          t.taskStatus === Task.Status.Next ||
+          t.taskStatus === Task.Status.DueSoon ||
+          t.taskStatus === Task.Status.Overdue
+      );
+      const result =
+        project.status === Project.Status.Active &&
+        !isAncestorFolderDropped(project) &&
+        remaining.length > 0 &&
+        !hasActionableTask;
+      _stalledProjectCache.set(key, result);
+      return result;
+    }
+
     var evaluateActionHasProjectWithStatus = (task, value) => {
       const project = task.containingProject;
       if (!project) return false;
@@ -161,26 +204,13 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return !project.completed && project.status !== Project.Status.Dropped;
       }
       if (value === "stalled") {
-        const remaining = project.flattenedTasks.filter(
-          (t) => !t.completed && t.taskStatus !== Task.Status.Dropped
-        );
-        const hasActionableTask = remaining.some(
-          (t) =>
-            t.taskStatus === Task.Status.Available ||
-            t.taskStatus === Task.Status.Next ||
-            t.taskStatus === Task.Status.DueSoon ||
-            t.taskStatus === Task.Status.Overdue
-        );
-        return (
-          project.status === Project.Status.Active &&
-          remaining.length > 0 &&
-          !hasActionableTask
-        );
+        return isProjectStalled(project);
       }
       if (value === "pending") {
         const deferDate = project.effectiveDeferDate;
         return (
           project.status === Project.Status.Active &&
+          !isAncestorFolderDropped(project) &&
           deferDate !== null &&
           deferDate > new Date()
         );
@@ -252,6 +282,7 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
     var DATE_FIELD_PROPERTY = {
       due: "dueDate",
       defer: "deferDate",
+      planned: "plannedDate",
       completed: "completionDate",
       dropped: "dropDate",
       added: "added",
@@ -286,6 +317,23 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
       return fieldDate.toDateString() === tomorrow.toDateString();
     };
 
+    // Shared by evaluateActionDateIsInThePast/InTheNext, which are identical
+    // apart from the offset's sign and which side of `now` the window falls on.
+    // Keeping the hour/day/week/month/year cases in one place means a future
+    // fix (a new component, a unit bug) can't be applied to one side and
+    // forgotten on the other — exactly the class of bug this file was already
+    // full of.
+    function applyRelativeOffset(date, amount, component, sign) {
+      const delta = sign * amount;
+      if (component === "hour") date.setHours(date.getHours() + delta);
+      else if (component === "day") date.setDate(date.getDate() + delta);
+      else if (component === "week") date.setDate(date.getDate() + delta * 7);
+      else if (component === "month") date.setMonth(date.getMonth() + delta);
+      else if (component === "year") date.setFullYear(date.getFullYear() + delta);
+      else return null;
+      return date;
+    }
+
     var evaluateActionDateIsInThePast = (task, dateField, value) => {
       const fieldDate = getTaskDateField(task, dateField);
       if (!fieldDate) return false;
@@ -301,20 +349,8 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return fieldDate <= now;
       }
 
-      const cutoff = new Date();
-      if (relativeComponent === "hour") {
-        cutoff.setHours(cutoff.getHours() - relativeBeforeAmount);
-      } else if (relativeComponent === "day") {
-        cutoff.setDate(cutoff.getDate() - relativeBeforeAmount);
-      } else if (relativeComponent === "week") {
-        cutoff.setDate(cutoff.getDate() - relativeBeforeAmount * 7);
-      } else if (relativeComponent === "month") {
-        cutoff.setMonth(cutoff.getMonth() - relativeBeforeAmount);
-      } else if (relativeComponent === "year") {
-        cutoff.setFullYear(cutoff.getFullYear() - relativeBeforeAmount);
-      } else {
-        return fieldDate <= now;
-      }
+      const cutoff = applyRelativeOffset(new Date(), relativeBeforeAmount, relativeComponent, -1);
+      if (!cutoff) return fieldDate <= now;
       return fieldDate >= cutoff && fieldDate <= now;
     };
 
@@ -337,20 +373,8 @@ function getPerspectiveViewByName(perspectiveName, limit = 100) {
         return fieldDate >= now;
       }
 
-      const cutoff = new Date();
-      if (relativeComponent === "hour") {
-        cutoff.setHours(cutoff.getHours() + relativeAfterAmount);
-      } else if (relativeComponent === "day") {
-        cutoff.setDate(cutoff.getDate() + relativeAfterAmount);
-      } else if (relativeComponent === "week") {
-        cutoff.setDate(cutoff.getDate() + relativeAfterAmount * 7);
-      } else if (relativeComponent === "month") {
-        cutoff.setMonth(cutoff.getMonth() + relativeAfterAmount);
-      } else if (relativeComponent === "year") {
-        cutoff.setFullYear(cutoff.getFullYear() + relativeAfterAmount);
-      } else {
-        return fieldDate >= now;
-      }
+      const cutoff = applyRelativeOffset(new Date(), relativeAfterAmount, relativeComponent, 1);
+      if (!cutoff) return fieldDate >= now;
       return fieldDate <= cutoff && fieldDate >= now;
     };
 

--- a/src/utils/omnifocusScripts/listTags.js
+++ b/src/utils/omnifocusScripts/listTags.js
@@ -14,6 +14,15 @@
         const tagId = tag.id.primaryKey;
         const parentTagID = tag.parent ? tag.parent.id.primaryKey : null;
 
+        // `tag.active` is the tag's OWN flag: a tag nested under a dropped or
+        // on-hold parent still reports active:true, so it leaks into the default
+        // (non-dropped) listing. `tag.effectiveActive` folds in ancestor status
+        // the way OmniFocus does in the sidebar. Fall back to `tag.active` only
+        // if the effective flag is somehow unavailable.
+        const effectiveActive = typeof tag.effectiveActive === "boolean"
+          ? tag.effectiveActive
+          : tag.active;
+
         // Count remaining (non-completed, non-dropped) tasks for this tag
         let taskCount = 0;
         try {
@@ -35,7 +44,7 @@
           name: tag.name,
           parentTagID: parentTagID,
           parentName: parentTagID ? (parentNameMap[parentTagID] || null) : null,
-          active: tag.active,
+          active: effectiveActive,
           allowsNextAction: tag.allowsNextAction,
           taskCount: taskCount
         });


### PR DESCRIPTION
Supersedes #128 by @rjames86 — same commits, merged onto current `main` (their branch was `rjames86:main`, which also carried #129 and #130; those are already merged, so this is the remaining date-filter/status/fields work plus a conflict resolution). Authorship preserved in the commits.

From the original description:

- `addedWithin`/`addedOn`/`completedWithin`/`completedOn`/`droppedWithin`/`droppedOn` accept the same `number | named-string | ISO-date` union as the forward-looking date filters. `resolveDateFilter` gains a `direction` param because the backward-looking `*Within` fields need the ISO-date offset inverted.
- `filters.status` constrained to the real task/project status values, so a typo is rejected at the schema instead of silently matching zero items.
- `fields` validated against a per-entity allowlist in the primitive (so resources get it too); unknown field names error naming the bad ones.
- Folder `status` routed through a dedicated `folderStatusMap` — `Folder.Status` is a distinct enum from `Project.Status`, and a folder's status always missed the lookup.

Resolution notes: took `main`'s `getPerspectiveView.js` (the #129 merge is newer than the copy on their branch); combined the two `filters` descriptions and trimmed the #133 note by ~20 chars to stay under the #105 budget.

Gate: tsc, 600 tests, build — green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ABVTARS2Bd3q77hPt42w1
